### PR TITLE
Add sceKernelGetProcessId

### DIFF
--- a/include/psp2/kernel/processmgr.h
+++ b/include/psp2/kernel/processmgr.h
@@ -84,6 +84,13 @@ SceUInt32 sceKernelGetProcessTimeLow(void);
 */
 SceUInt64 sceKernelGetProcessTimeWide(void);
 
+/***
+ * Get the process ID of the current process.
+ *
+ * @return process ID of the current process
+*/
+SceUID sceKernelGetProcessId(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Adds sceKernelGetProcessId, which is already used in newlib.