### PR TITLE
Added a centralized header file.

### DIFF
--- a/include/psp2/common_dialog.h
+++ b/include/psp2/common_dialog.h
@@ -12,6 +12,7 @@
 #ifndef _PSP2_COMMON_API_H_
 #define _PSP2_COMMON_API_H_
 
+#include <string.h>
 #include <psp2/system_param.h>
 #include <psp2/gxm.h>
 #include <psp2/types.h>

--- a/include/vitasdk.h
+++ b/include/vitasdk.h
@@ -1,0 +1,63 @@
+/**
+ * \file
+ * \brief Header file which includes all the others
+ *
+ * Copyright (C) 2016 vitasdk
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+ 
+#ifndef _VITASDK_H_
+#define _VITASDK_H_
+
+#include <psp2/types.h>
+#include <psp2/appmgr.h>
+#include <psp2/apputil.h>
+#include <psp2/atrac.h>
+#include <psp2/audiodec.h>
+#include <psp2/audioenc.h>
+#include <psp2/audioin.h>
+#include <psp2/audioout.h>
+#include <psp2/camera.h>
+#include <psp2/common_dialog.h>
+#include <psp2/ctrl.h>
+#include <psp2/display.h>
+#include <psp2/gxm.h>
+#include <psp2/gxt.h>
+#include <psp2/ime_dialog.h>
+#include <psp2/libssl.h>
+#include <psp2/message_dialog.h>
+#include <psp2/moduleinfo.h>
+#include <psp2/motion.h>
+#include <psp2/pgf.h>
+#include <psp2/photoexport.h>
+#include <psp2/power.h>
+#include <psp2/pss.h>
+#include <psp2/rtc.h>
+#include <psp2/screenshot.h>
+#include <psp2/sqlite.h>
+#include <psp2/sysmodule.h>
+#include <psp2/system_param.h>
+#include <psp2/touch.h>
+
+#include <psp2/io/devctl.h>
+#include <psp2/io/dirent.h>
+#include <psp2/io/fcntl.h>
+#include <psp2/io/stat.h>
+
+#include <psp2/kernel/clib.h>
+#include <psp2/kernel/error.h>
+#include <psp2/kernel/loadcore.h>
+#include <psp2/kernel/modulemgr.h>
+#include <psp2/kernel/processmgr.h>
+#include <psp2/kernel/rng.h>
+#include <psp2/kernel/sysmem.h>
+#include <psp2/kernel/threadmgr.h>
+
+#include <psp2/net/http.h>
+#include <psp2/net/net.h>
+#include <psp2/net/netctl.h>
+
+#endif


### PR DESCRIPTION
This adds a centralized header file like 3ds.h for ctrulib and pspsdk.h for pspsdk.
Also adds a missing header in common_dialog causing memset not getting detected by the compiler.