### PR TITLE
Remove duplicate ScePhotoExport library from db.json

### DIFF
--- a/db.json
+++ b/db.json
@@ -5141,19 +5141,5 @@
             }
         },
         "nid": 227
-    },
-	"ScePhotoExport": {
-		"modules": {
-			"ScePhotoExport": {
-				"functions": {
-					"scePhotoExportFromData": 1884365601,
-					"scePhotoExportFromFile": 2231214021
-				},
-				"kernel": false,
-				"nid": 2031512537,
-				"variables": {}
-			}
-		},
-		"nid": 228
-	}
+    }
 }


### PR DESCRIPTION
The nids present were already included in the first library (#145)