### PR TITLE
Changed pixelformat global name to reflect its behaviour.

### DIFF
--- a/include/psp2/display.h
+++ b/include/psp2/display.h
@@ -31,7 +31,7 @@ enum {
 	SCE_DISPLAY_ERROR_NO_PIXEL_DATA		= 0x80290008
 };
 
-#define SCE_DISPLAY_PIXELFORMAT_A8B8G8R8 0x00000000U
+#define SCE_DISPLAY_PIXELFORMAT_U8U8U8U8 0x00000000U
 
 enum {
 	/** Buffer change effective immediately */


### PR DESCRIPTION
Trying to write a screenshot tool i found that framebuffer is not always set at ABGR encoding, same screenshot code for example produced these three screenshots:
http://rinnegatamante.it/site/PCSB00830_94_16721.bmp
https://pbs.twimg.com/media/CrbxanyXEAEY_Km.jpg:large
https://pbs.twimg.com/media/Cri1FVMXYCAeV7P.jpg:large