### PR TITLE
add sceAppMgrGetAppParam

### DIFF
--- a/include/psp2/appmgr.h
+++ b/include/psp2/appmgr.h
@@ -83,6 +83,9 @@ int _sceAppMgrGetAppState(SceAppMgrAppState *appState, uint32_t len, uint32_t ve
 
 int sceAppMgrReceiveSystemEvent(SceAppMgrSystemEvent *systemEvent);
 
+//! Copies app param to an array
+int sceAppMgrGetAppParam(char *param);
+
 //! Obtains the BGM port, even when it is not in front
 int sceAppMgrAcquireBgmPort(void);
 

--- a/include/psp2/appmgr.h
+++ b/include/psp2/appmgr.h
@@ -84,6 +84,7 @@ int _sceAppMgrGetAppState(SceAppMgrAppState *appState, uint32_t len, uint32_t ve
 int sceAppMgrReceiveSystemEvent(SceAppMgrSystemEvent *systemEvent);
 
 //! Copies app param to an array
+//! App param example: type=LAUNCH_APP_BY_URI&uri=psgm:play?titleid=NPXS10031
 int sceAppMgrGetAppParam(char *param);
 
 //! Obtains the BGM port, even when it is not in front

--- a/include/psp2/appmgr.h
+++ b/include/psp2/appmgr.h
@@ -85,6 +85,7 @@ int sceAppMgrReceiveSystemEvent(SceAppMgrSystemEvent *systemEvent);
 
 //! Copies app param to an array
 //! App param example: type=LAUNCH_APP_BY_URI&uri=psgm:play?titleid=NPXS10031
+//! Returns 0 for success
 int sceAppMgrGetAppParam(char *param);
 
 //! Obtains the BGM port, even when it is not in front


### PR DESCRIPTION
This function copies the app parameters to an array through which you can grab custom arguments from, kind of a substitute for argv

It returns something like this if you use it from a custom uri:

type=LAUNCH_APP_BY_URI&uri=test:test?test