### PR TITLE
Fixed number of arguments in two functions

### DIFF
--- a/include/psp2/appmgr.h
+++ b/include/psp2/appmgr.h
@@ -75,7 +75,8 @@ typedef struct SceAppMgrLaunchAppOptParam SceAppMgrLaunchAppOptParam; // Missing
 int sceAppMgrDestroyAppByName(char *name);
 
 //! name: The Title ID of the application
-int _sceAppMgrDestroyAppByName(char *name, char temp[3]);
+//! temp: A 12bytes temporary work buffer (content important)
+int _sceAppMgrDestroyAppByName(const char *name, char temp[3]);
 
 int _sceAppMgrGetAppState(SceAppMgrAppState *appState, uint32_t len, uint32_t version);
 
@@ -107,7 +108,8 @@ int sceAppMgrLoadExec(const char *appPath, char * const argv[],
 int sceAppMgrLaunchAppByUri(int flags, char *uri);
 
 //! name: The Title ID of the application
-int sceAppMgrLaunchAppByName2(char *name, char *param, SceAppMgrLaunchAppOptParam *optParam);
+//! param: The parameter passed to the application which can be retrieved with sceAppMgrGetAppParam
+int sceAppMgrLaunchAppByName2(const char *name, const char *param, SceAppMgrLaunchAppOptParam *optParam);
 
 //! id: 100 (photo0), 101 (friends), 102 (messages), 103 (near), 105 (music), 108 (calendar)
 int sceAppMgrAppDataMount(int id, char *mount_point);

--- a/include/psp2/appmgr.h
+++ b/include/psp2/appmgr.h
@@ -74,10 +74,6 @@ typedef struct SceAppMgrLaunchAppOptParam SceAppMgrLaunchAppOptParam; // Missing
 //! name: The Title ID of the application
 int sceAppMgrDestroyAppByName(char *name);
 
-//! name: The Title ID of the application
-//! temp: A 12bytes temporary work buffer (content important)
-int _sceAppMgrDestroyAppByName(const char *name, char temp[3]);
-
 int _sceAppMgrGetAppState(SceAppMgrAppState *appState, uint32_t len, uint32_t version);
 
 /**

--- a/include/psp2/appmgr.h
+++ b/include/psp2/appmgr.h
@@ -67,11 +67,15 @@ typedef struct SceAppMgrSystemEvent {
 
 typedef struct SceAppMgrAppState SceAppMgrAppState; // Missing struct
 typedef struct SceAppMgrExecOptParam SceAppMgrExecOptParam; // Missing struct
+typedef struct SceAppMgrLaunchAppOptParam SceAppMgrLaunchAppOptParam; // Missing struct
 
 #define SCE_APPMGR_MAX_APP_NAME_LENGTH	(31)
 
 //! name: The Title ID of the application
-int _sceAppMgrDestroyAppByName(char *name);
+int sceAppMgrDestroyAppByName(char *name);
+
+//! name: The Title ID of the application
+int _sceAppMgrDestroyAppByName(char *name, char temp[3]);
 
 int _sceAppMgrGetAppState(SceAppMgrAppState *appState, uint32_t len, uint32_t version);
 
@@ -103,7 +107,7 @@ int sceAppMgrLoadExec(const char *appPath, char * const argv[],
 int sceAppMgrLaunchAppByUri(int flags, char *uri);
 
 //! name: The Title ID of the application
-int sceAppMgrLaunchAppByName2(char *name);
+int sceAppMgrLaunchAppByName2(char *name, char *param, SceAppMgrLaunchAppOptParam *optParam);
 
 //! id: 100 (photo0), 101 (friends), 102 (messages), 103 (near), 105 (music), 108 (calendar)
 int sceAppMgrAppDataMount(int id, char *mount_point);


### PR DESCRIPTION
The number of arguments in the functions commited by @himanshugoel2797 were wrong.

@himanshugoel2797, reverse enginering the api properly instead of just guessing them.
