### PR TITLE
Use enum tag in return types gxt.h.

### DIFF
--- a/include/psp2/gxt.h
+++ b/include/psp2/gxt.h
@@ -58,7 +58,7 @@ typedef struct SceGxtTextureInfo {
  * @retval	SCE_OK
  * @retval	SCE_GXT_ERROR_INVALID_VALUE Magic or version invalid
  */
-SceGxtErrorCode sceGxtCheckData(const void *gxt);
+enum SceGxtErrorCode sceGxtCheckData(const void *gxt);
 
 /**
  * Gets the start address of the texture data.
@@ -105,10 +105,10 @@ uint32_t sceGxtGetTextureCount(const void *gxt);
  * @retval	SCE_GXT_ERROR_INVALID_VALUE
  * @retval	SCE_GXT_ERROR_INVALID_POINTER
  */
-SceGxtErrorCode sceGxtSetPalette(SceGxmTexture *texture,
-				const void *gxt,
-				const void *textureData,
-				uint32_t paletteIndex);
+enum SceGxtErrorCode sceGxtSetPalette(SceGxmTexture *texture,
+				     const void *gxt,
+				     const void *textureData,
+				     uint32_t paletteIndex);
 
 #ifdef __cplusplus
 }

--- a/include/psp2/gxt.h
+++ b/include/psp2/gxt.h
@@ -22,12 +22,12 @@ extern "C" {
 #include <psp2/gxm.h>
 
 /** GXT error codes */
-enum SceGxtErrorCode {
+typedef enum SceGxtErrorCode {
 	SCE_OK = 0,
 	SCE_GXT_ERROR_INVALID_ALIGNMENT,
 	SCE_GXT_ERROR_INVALID_VALUE,
 	SCE_GXT_ERROR_INVALID_POINTER
-};
+} SceGxtErrorCode;
 
 /** Header for a GXT file */
 typedef struct SceGxtHeader {
@@ -58,7 +58,7 @@ typedef struct SceGxtTextureInfo {
  * @retval	SCE_OK
  * @retval	SCE_GXT_ERROR_INVALID_VALUE Magic or version invalid
  */
-enum SceGxtErrorCode sceGxtCheckData(const void *gxt);
+SceGxtErrorCode sceGxtCheckData(const void *gxt);
 
 /**
  * Gets the start address of the texture data.
@@ -105,10 +105,10 @@ uint32_t sceGxtGetTextureCount(const void *gxt);
  * @retval	SCE_GXT_ERROR_INVALID_VALUE
  * @retval	SCE_GXT_ERROR_INVALID_POINTER
  */
-enum SceGxtErrorCode sceGxtSetPalette(SceGxmTexture *texture,
-				     const void *gxt,
-				     const void *textureData,
-				     uint32_t paletteIndex);
+SceGxtErrorCode sceGxtSetPalette(SceGxmTexture *texture,
+				const void *gxt,
+				const void *textureData,
+				uint32_t paletteIndex);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When using rust bindgen to generate Rust bindings over the psp2 headers, clang encounters a compile error in using an enum as a type without the `enum` tag. Evidently this is a semantic error; you are _supposed_ to use `enum` tags, but gcc allows not using it without warning.