### PR TITLE
remove unnecessary libgcc symbols from SceSysclibForDriver

### DIFF
--- a/db.json
+++ b/db.json
@@ -1744,8 +1744,6 @@
                 "nid": 2128892817,
                 "variables": {},
                 "functions": {
-                    "__aeabi_uidiv": 2852065797,
-                    "__aeabi_uidivmod": 2758588382,
                     "memcpy": 1086882582,
                     "memset": 179945308,
                     "strchr": 944125785,


### PR DESCRIPTION
Using SceSysclibForDriver will clash with the toolchain on these symbols.