### PR TITLE
Renamed SCE_CTRL_ALL to SCE_CTRL_INTERCEPTED

### DIFF
--- a/include/psp2/ctrl.h
+++ b/include/psp2/ctrl.h
@@ -33,23 +33,23 @@ enum {
 /** Enumeration for the digital controller buttons.
  * L1/R1/L3/R3 only can bind using sceCtrlReadBufferPositiveExt2 */
 enum {
-	SCE_CTRL_SELECT     = 0x000001,	//!< Select button.
-	SCE_CTRL_L3         = 0x000002,	//!< L3 button.
-	SCE_CTRL_R3         = 0x000004,	//!< R3 button.
-	SCE_CTRL_START      = 0x000008,	//!< Start button.
-	SCE_CTRL_UP         = 0x000010,	//!< Up D-Pad button.
-	SCE_CTRL_RIGHT      = 0x000020,	//!< Right D-Pad button.
-	SCE_CTRL_DOWN       = 0x000040,	//!< Down D-Pad button.
-	SCE_CTRL_LEFT       = 0x000080,	//!< Left D-Pad button.
-	SCE_CTRL_LTRIGGER   = 0x000100,	//!< Left trigger.
-	SCE_CTRL_RTRIGGER   = 0x000200,	//!< Right trigger.
-	SCE_CTRL_L1         = 0x000400,	//!< L1 button.
-	SCE_CTRL_R1         = 0x000800,	//!< R1 button.
-	SCE_CTRL_TRIANGLE   = 0x001000,	//!< Triangle button.
-	SCE_CTRL_CIRCLE     = 0x002000,	//!< Circle button.
-	SCE_CTRL_CROSS      = 0x004000,	//!< Cross button.
-	SCE_CTRL_SQUARE     = 0x008000,	//!< Square button.
-	SCE_CTRL_ANY        = 0x010000	//!< Any input intercepted.
+	SCE_CTRL_SELECT      = 0x000001,	//!< Select button.
+	SCE_CTRL_L3          = 0x000002,	//!< L3 button.
+	SCE_CTRL_R3          = 0x000004,	//!< R3 button.
+	SCE_CTRL_START       = 0x000008,	//!< Start button.
+	SCE_CTRL_UP          = 0x000010,	//!< Up D-Pad button.
+	SCE_CTRL_RIGHT       = 0x000020,	//!< Right D-Pad button.
+	SCE_CTRL_DOWN        = 0x000040,	//!< Down D-Pad button.
+	SCE_CTRL_LEFT        = 0x000080,	//!< Left D-Pad button.
+	SCE_CTRL_LTRIGGER    = 0x000100,	//!< Left trigger.
+	SCE_CTRL_RTRIGGER    = 0x000200,	//!< Right trigger.
+	SCE_CTRL_L1          = 0x000400,	//!< L1 button.
+	SCE_CTRL_R1          = 0x000800,	//!< R1 button.
+	SCE_CTRL_TRIANGLE    = 0x001000,	//!< Triangle button.
+	SCE_CTRL_CIRCLE      = 0x002000,	//!< Circle button.
+	SCE_CTRL_CROSS       = 0x004000,	//!< Cross button.
+	SCE_CTRL_SQUARE      = 0x008000,	//!< Square button.
+	SCE_CTRL_INTERCEPTED = 0x010000	        //!< Input not available because intercepted by another application
 };
 
 /** Enumeration for the controller types. */


### PR DESCRIPTION
The old wording was incorrect, if we wanted a macro for masking all buttons, it should be a OR'ing of the above button macros, and it would give 0xffff.