### PR TITLE
Rename ksceKernelMemPool* functions

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -1644,10 +1644,10 @@ modules:
           ksceKernelGetMemBlockBase: 0xA841EDDA
           ksceKernelFindMemBlockByAddr: 0x8A1742F6
           ksceKernelRemapBlock: 0xDFE2C8CB
-          ksceKernelMemPoolCreate: 0x9328E0E8
-          ksceKernelMemPoolDestroy: 0xD6437637
-          ksceKernelMemPoolAlloc: 0x7B4CB60A
-          ksceKernelMemPoolFree: 0x3EBCE343
+          ksceKernelCreateHeap: 0x9328E0E8
+          ksceKernelDeleteHeap: 0xD6437637
+          ksceKernelAllocHeapMemory: 0x7B4CB60A
+          ksceKernelFreeHeapMemory: 0x3EBCE343
           ksceKernelMapUserBlock: 0x7D4F8B5F
           ksceKernelSwitchVmaForPid: 0x6F2ACDAE
           ksceKernelRoMemcpyKernelToUserForPid: 0x571D2739

--- a/include/psp2kern/kernel/sysmem.h
+++ b/include/psp2kern/kernel/sysmem.h
@@ -64,7 +64,7 @@ typedef struct SceKernelAllocMemBlockKernelOpt {
   SceUInt32 field_54;
 } SceKernelAllocMemBlockKernelOpt;
 
-typedef struct SceKernelMemPoolCreateOpt {
+typedef struct SceKernelHeapCreateOpt {
   SceSize size;
   SceUInt32 uselock;
   SceUInt32 field_8;
@@ -72,7 +72,7 @@ typedef struct SceKernelMemPoolCreateOpt {
   SceUInt32 field_10;
   SceUInt32 field_14;
   SceUInt32 field_18;
-} SceKernelMemPoolCreateOpt;
+} SceKernelHeapCreateOpt;
 
 typedef struct SceCreateUidObjOpt {
   SceUInt32 flags;
@@ -122,10 +122,10 @@ int ksceKernelFreeMemBlock(SceUID uid);
 */
 int ksceKernelGetMemBlockBase(SceUID uid, void **basep);
 
-SceUID ksceKernelMemPoolCreate(const char *name, SceSize size, SceKernelMemPoolCreateOpt *opt);
-int ksceKernelMemPoolDestroy(SceUID pool);
-void *ksceKernelMemPoolAlloc(SceUID pool, SceSize size);
-void ksceKernelMemPoolFree(SceUID pool, void *ptr);
+SceUID ksceKernelCreateHeap(const char *name, SceSize size, SceKernelHeapCreateOpt *opt);
+int ksceKernelDeleteHeap(SceUID uid);
+void *ksceKernelAllocHeapMemory(SceUID uid, SceSize size);
+void ksceKernelFreeHeapMemory(SceUID uid, void *ptr);
 
 int ksceKernelMemcpyUserToKernelForPid(SceUID pid, void *dst, uintptr_t src, size_t len);
 int ksceKernelMemcpyUserToKernel(void *dst, uintptr_t src, size_t len);


### PR DESCRIPTION
Since SceUsbAudio exposes the real name of `ksceKernelMemPoolCreate` which is actually `sceKernelCreateHeap`.