### PR TITLE
Change vitasdk download method

### DIFF
--- a/.travis.d/download_sdk.sh
+++ b/.travis.d/download_sdk.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+cd $TRAVIS_BUILD_DIR
+curl -sL https://github.com/vitasdk/autobuilds/releases | grep linux | grep tar.bz2 | head -n 1 | cut -d '"' -f 2 | xargs -I PATH curl -L https://github.comPATH | tar xj

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
     - set -e
     - cd $TRAVIS_BUILD_DIR
     - python $TRAVIS_BUILD_DIR/.travis.d/definition_check.py
-    - curl https://api.github.com/repos/vitasdk/autobuilds/releases | grep browser_download_url | grep linux | head -n 1 | cut -d '"' -f 4 | xargs curl -L | tar xj
+    - bash $TRAVIS_BUILD_DIR/.travis.d/download_sdk.sh
     - export VITASDK=$PWD/vitasdk
     - export PATH=$VITASDK/bin:$PATH
     - cd $VITASDK/arm-vita-eabi/include


### PR DESCRIPTION
API call have rate limit.
this patch will parse repo release page instead handle API result.