### PR TITLE
change SceDebugForDriver printf naming and add definition

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -1901,7 +1901,7 @@ modules:
         kernel: true
         nid: 0x88758561
         functions:
-          printf: 0x391B74B7
+          ksceDebugPrintf: 0x391B74B7
       SceDebugForKernel:
         kernel: true
         nid: 0x88C17370

--- a/db.yml
+++ b/db.yml
@@ -1902,6 +1902,7 @@ modules:
         nid: 0x88758561
         functions:
           ksceDebugPrintf: 0x391B74B7
+          ksceDebugPrintf2: 0x02B04343
       SceDebugForKernel:
         kernel: true
         nid: 0x88C17370

--- a/include/psp2kern/kernel/sysmem.h
+++ b/include/psp2kern/kernel/sysmem.h
@@ -203,6 +203,8 @@ int ksceKernelGetPaddr(void *addr, uintptr_t *paddr);
 
 int ksceSysrootIsManufacturingMode(void);
 
+int ksceDebugPrintf(const char *fmt, ...);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/psp2kern/kernel/sysmem.h
+++ b/include/psp2kern/kernel/sysmem.h
@@ -205,6 +205,8 @@ int ksceSysrootIsManufacturingMode(void);
 
 int ksceDebugPrintf(const char *fmt, ...);
 
+int ksceDebugPrintf2(int unk0, int unk1, const char *fmt, ...);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
I think the function name may be wrong, as it may be difficult, sometime, to redefine printf..
This, at least, allow kernel debug print from [psp2shell](https://github.com/Cpasjuste/psp2shell). 