### PR TITLE
Download last built toolchain

### DIFF
--- a/.travis.d/download_sdk.sh
+++ b/.travis.d/download_sdk.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 set -e
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 cd $TRAVIS_BUILD_DIR
-curl -sL https://github.com/vitasdk/autobuilds/releases | grep linux | grep tar.bz2 | head -n 1 | cut -d '"' -f 2 | xargs -I PATH curl -L https://github.comPATH | tar xj
+curl -sL $(python $DIR/last_built_toolchain.py) | tar xj

--- a/.travis.d/last_built_toolchain.py
+++ b/.travis.d/last_built_toolchain.py
@@ -1,6 +1,6 @@
 import re
 import json
-import urllib
+import urllib2
 
 TRAVIS_REPO_ID = '10768510'
 GITHUB_REPO = 'vitasdk/autobuilds'
@@ -11,6 +11,7 @@ GITHUB_REL = GITHUB + '/' + GITHUB_REPO + '/releases'
 GITHUB_TAG = GITHUB_REL + '/tag'
 TAG_FORMAT = '%(branch)s-%(os)s-v%(build)s'
 REGEX = re.compile('href="([^"]*)"')
+HEADERS = dict(Accept='application/vnd.travis-ci.2+json')
 
 def find_sdk(page):
     for line in page.split('\n'):
@@ -21,12 +22,14 @@ def find_sdk(page):
             continue
         return m.group(1)
 
-build_info = json.load(urllib.urlopen(TRAVIS_API))
-number = build_info['last_build_number']
+req = urllib2.Request(TRAVIS_API, headers=HEADERS)
+build_info = json.load(urllib2.urlopen(req))
+number = build_info['repo']['last_build_number']
 # just check last 10 build
 for x in range(10):
     tag = (TAG_FORMAT % dict(branch='master', os='linux', build=int(number) - x))
-    path = find_sdk(urllib.urlopen(GITHUB_TAG + '/' + tag).read())
+    req = urllib2.Request(GITHUB_TAG + '/' + tag)
+    path = find_sdk(urllib2.urlopen(req).read())
     if not path:
         continue
     print GITHUB + path

--- a/.travis.d/last_built_toolchain.py
+++ b/.travis.d/last_built_toolchain.py
@@ -1,0 +1,35 @@
+import re
+import json
+import urllib
+
+TRAVIS_REPO_ID = '10768510'
+GITHUB_REPO = 'vitasdk/autobuilds'
+
+TRAVIS_API = 'https://api.travis-ci.org/repos/' + TRAVIS_REPO_ID
+GITHUB = 'https://github.com'
+GITHUB_REL = GITHUB + '/' + GITHUB_REPO + '/releases'
+GITHUB_TAG = GITHUB_REL + '/tag'
+TAG_FORMAT = '%(branch)s-%(os)s-v%(build)s'
+REGEX = re.compile('href="([^"]*)"')
+
+def find_sdk(page):
+    for line in page.split('\n'):
+        if 'linux' not in line or 'tar.bz2' not in line:
+            continue
+        m = REGEX.search(line)
+        if not m:
+            continue
+        return m.group(1)
+
+build_info = json.load(urllib.urlopen(TRAVIS_API))
+number = build_info['last_build_number']
+# just check last 10 build
+for x in range(10):
+    tag = (TAG_FORMAT % dict(branch='master', os='linux', build=int(number) - x))
+    path = find_sdk(urllib.urlopen(GITHUB_TAG + '/' + tag).read())
+    if not path:
+        continue
+    print GITHUB + path
+    raise SystemExit(0)
+
+raise SystemExit(1)


### PR DESCRIPTION
If hang travis build, we cannot find linux package from first page of github release
This patch check release with travis build number

But this patch is just quick and dirty fixing, and travis also can have API limit.