### PR TITLE
Refactor sceIo headers.

### DIFF
--- a/include/psp2/io/devctl.h
+++ b/include/psp2/io/devctl.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_IO_DEVCTRL_H_
-#define _PSP2_IO_DEVCTRL_H_
+#ifndef _PSP2_IO_DEVCTL_H_
+#define _PSP2_IO_DEVCTL_H_
 
 #include <psp2/types.h>
 
@@ -61,5 +61,5 @@ int sceIoIoctlAsync(SceUID fd, unsigned int cmd, void *indata, int inlen, void *
 }
 #endif
 
-#endif /* _PSP2_IO_DEVCTRL_H_ */
+#endif /* _PSP2_IO_DEVCTL_H_ */
 

--- a/include/psp2/io/dirent.h
+++ b/include/psp2/io/dirent.h
@@ -19,7 +19,7 @@ typedef struct SceIoDirent {
 	SceIoStat d_stat; //!< File status
 	char d_name[256]; //!< File name
 	void *d_private;  //!< Device-specific data
-	int dummy;        //!< Unknown
+	int dummy;        //!< Dummy data
 } SceIoDirent;
 
 /**

--- a/include/psp2/io/dirent.h
+++ b/include/psp2/io/dirent.h
@@ -16,13 +16,10 @@ extern "C" {
 
 /** Describes a single directory entry */
 typedef struct SceIoDirent {
-	/** File status. */
-	SceIoStat	d_stat;
-	/** File name. */
-	char	d_name[256];
-	/** Device-specific data. */
-	void	*d_private;
-	int	dummy;
+	SceIoStat d_stat; //!< File status
+	char d_name[256]; //!< File name
+	void *d_private;  //!< Device-specific data
+	int dummy;        //!< Unknown
 } SceIoDirent;
 
 /**
@@ -43,8 +40,8 @@ SceUID sceIoDopen(const char *dirname);
 /**
   * Reads an entry from an opened file descriptor.
   *
-  * @param fd - Already opened file descriptor (using sceIoDopen)
-  * @param dir - Pointer to an io_dirent_t structure to hold the file information
+  * @param fd - Already opened file descriptor (using ::sceIoDopen)
+  * @param dir - Pointer to a ::SceIoDirent structure to hold the file information
   *
   * @return Read status
   * -   0 - No more directory entries left
@@ -56,7 +53,7 @@ int sceIoDread(SceUID fd, SceIoDirent *dir);
 /**
   * Close an opened directory file descriptor
   *
-  * @param fd - Already opened file descriptor (using sceIoDopen)
+  * @param fd - Already opened file descriptor (using ::sceIoDopen)
   * @return < 0 on error
   */
 int sceIoDclose(SceUID fd);

--- a/include/psp2/io/fcntl.h
+++ b/include/psp2/io/fcntl.h
@@ -32,6 +32,7 @@ typedef enum SceIoMode {
 	SCE_O_NOBUF     = 0x4000,                         //!< Number device buffer
 	SCE_O_NOWAIT    = 0x8000                          //!< Asynchronous I/O
 	SCE_O_FDEXCL    = 0x01000000,                     //!< Exclusive access
+	SCE_O_PWLOCK    = 0x02000000,                     //!< Power control lock
 	SCE_O_FGAMEDATA = 0x40000000                      //!< Gamedata access
 } SceIoMode;
 

--- a/include/psp2/io/fcntl.h
+++ b/include/psp2/io/fcntl.h
@@ -44,7 +44,7 @@ typedef enum SceIoSeekMode {
 typedef enum SceIoDevType {
 	SCE_DEV_TYPE_NULL     = 0x00, //!< Dummy device
 	SCE_DEV_TYPE_CHAR     = 0x01, //!< Character device
-	SCE_DEV_TYPE_BLOCK    = 0X04, //!< Block device
+	SCE_DEV_TYPE_BLOCK    = 0x04, //!< Block device
 	SCE_DEV_TYPE_FS       = 0x10, //!< File system device
 	SCE_DEV_TYPE_ALIAS    = 0x20, //!< Alias name
 	SCE_DEV_TYPE_MOUNTPT  = 0x40  //!< Mount point

--- a/include/psp2/io/fcntl.h
+++ b/include/psp2/io/fcntl.h
@@ -15,24 +15,40 @@ extern "C" {
 
 /* Note: Not all of these sceIoOpen() flags are not compatible with the
    open() flags found in sys/unistd.h. */
-enum {
-	SCE_O_RDONLY   = 0x0001,
-	SCE_O_WRONLY   = 0x0002,
-	SCE_O_RDWR     = (SCE_O_RDONLY | SCE_O_WRONLY),
-	SCE_O_NBLOCK   = 0x0004,
-	SCE_O_DIROPEN  = 0x0008,  // Internal use for dopen
-	SCE_O_APPEND   = 0x0100,
-	SCE_O_CREAT    = 0x0200,
-	SCE_O_TRUNC    = 0x0400,
-	SCE_O_EXCL     = 0x0800,
-	SCE_O_NOWAIT   = 0x8000
-};
+typedef enum SceIoMode {
+	SCE_O_RDONLY    = 0x0001,                         //!< Read-only
+	SCE_O_WRONLY    = 0x0002,                         //!< Write-only
+	SCE_O_RDWR      = (SCE_O_RDONLY | SCE_O_WRONLY),  //!< Read/Write
+	SCE_O_NBLOCK    = 0x0004,                         //!< Non blocking
+	SCE_O_DIROPEN   = 0x0008,                         //!< Internal use for ::sceIoDopen
+	SCE_O_RDLOCK    = 0x0010,                         //!< Read locked (non-shared)
+	SCE_O_WRLOCK    = 0x0020,                         //!< Write locked (non-shared)
+	SCE_O_APPEND    = 0x0100,                         //!< Append
+	SCE_O_CREAT     = 0x0200,                         //!< Create
+	SCE_O_TRUNC     = 0x0400,                         //!< Truncate
+	SCE_O_EXCL      = 0x0800,                         //!< Exclusive create
+	SCE_O_SCAN      = 0x1000,                         //!< Scan type
+	SCE_O_RCOM      = 0x2000,                         //!< Remote command entry
+	SCE_O_NOBUF     = 0x4000,                         //!< Number device buffer
+	SCE_O_NOWAIT    = 0x8000                          //!< Asynchronous I/O
+	SCE_O_FDEXCL    = 0x01000000,                     //!< Exclusive access
+	SCE_O_FGAMEDATA = 0x40000000                      //!< Gamedata access
+} SceIoMode;
 
-enum {
-	SCE_SEEK_SET,
-	SCE_SEEK_CUR,
-	SCE_SEEK_END
-};
+typedef enum SceIoSeekMode {
+	SCE_SEEK_SET,   //!< Starts from the begin of the file
+	SCE_SEEK_CUR,   //!< Starts from current position
+	SCE_SEEK_END    //!< Starts from the end of the file
+} SceIoSeekMode;
+
+typedef enum SceIoDevType {
+	SCE_DEV_TYPE_NULL     = 0x00, //!< Dummy device
+	SCE_DEV_TYPE_CHAR     = 0x01, //!< Character device
+	SCE_DEV_TYPE_BLOCK    = 0X04, //!< Block device
+	SCE_DEV_TYPE_FS       = 0x10, //!< File system device
+	SCE_DEV_TYPE_ALIAS    = 0x20, //!< Alias name
+	SCE_DEV_TYPE_MOUNTPT  = 0x40  //!< Mount point
+} SceIoDevType;
 
 /**
  * Open or create a file for reading or writing
@@ -52,7 +68,7 @@ enum {
  *
  * @param file - Pointer to a string holding the name of the file to open
  * @param flags - Libc styled flags that are or'ed together
- * @param mode - File access mode.
+ * @param mode - File access mode (One or more ::SceIoMode).
  * @return A non-negative integer is a valid fd, anything else an error
  */
 SceUID sceIoOpen(const char *file, int flags, SceMode mode);
@@ -62,7 +78,7 @@ SceUID sceIoOpen(const char *file, int flags, SceMode mode);
  *
  * @param file - Pointer to a string holding the name of the file to open
  * @param flags - Libc styled flags that are or'ed together
- * @param mode - File access mode.
+ * @param mode - File access mode (One or more ::SceIoMode).
  * @return A non-negative integer is a valid fd, anything else an error
  */
 SceUID sceIoOpenAsync(const char *file, int flags, SceMode mode);
@@ -151,13 +167,12 @@ int sceIoWriteAsync(SceUID fd, const void *data, SceSize size);
  *
  * @par Example:
  * @code
- * pos = sceIoLseek(fd, -10, SEEK_END);
+ * pos = sceIoLseek(fd, -10, SCE_SEEK_END);
  * @endcode
  *
  * @param fd - Opened file descriptor with which to seek
  * @param offset - Relative offset from the start position given by whence
- * @param whence - Set to SEEK_SET to seek from the start of the file, SEEK_CUR
- * seek from the current position and SEEK_END to seek from the end.
+ * @param whence - One of ::SceIoSeekMode.
  *
  * @return The position in the file after the seek.
  */
@@ -168,8 +183,7 @@ SceOff sceIoLseek(SceUID fd, SceOff offset, int whence);
  *
  * @param fd - Opened file descriptor with which to seek
  * @param offset - Relative offset from the start position given by whence
- * @param whence - Set to SEEK_SET to seek from the start of the file, SEEK_CUR
- * seek from the current position and SEEK_END to seek from the end.
+ * @param whence - One of ::SceIoSeekMode.
  *
  * @return < 0 on error. Actual value should be passed returned by the ::sceIoWaitAsync call.
  */
@@ -180,13 +194,12 @@ int sceIoLseekAsync(SceUID fd, SceOff offset, int whence);
  *
  * @par Example:
  * @code
- * pos = sceIoLseek32(fd, -10, SEEK_END);
+ * pos = sceIoLseek32(fd, -10, SCE_SEEK_END);
  * @endcode
  *
  * @param fd - Opened file descriptor with which to seek
  * @param offset - Relative offset from the start position given by whence
- * @param whence - Set to SEEK_SET to seek from the start of the file, SEEK_CUR
- * seek from the current position and SEEK_END to seek from the end.
+ * @param whence - One of ::SceIoSeekMode.
  *
  * @return The position in the file after the seek.
  */
@@ -197,8 +210,7 @@ int sceIoLseek32(SceUID fd, int offset, int whence);
  *
  * @param fd - Opened file descriptor with which to seek
  * @param offset - Relative offset from the start position given by whence
- * @param whence - Set to SEEK_SET to seek from the start of the file, SEEK_CUR
- * seek from the current position and SEEK_END to seek from the end.
+ * @param whence - One of ::SceIoSeekMode.
  *
  * @return < 0 on error.
  */
@@ -293,7 +305,7 @@ int sceIoCancel(SceUID fd);
   *
   * @param fd - The opened file descriptor.
   *
-  * @return < 0 on error. Otherwise the device type?
+  * @return < 0 on error, otherwise one of ::SceIoDevType.
   */
 int sceIoGetDevType(SceUID fd);
 

--- a/include/psp2/io/fcntl.h
+++ b/include/psp2/io/fcntl.h
@@ -30,7 +30,7 @@ typedef enum SceIoMode {
 	SCE_O_SCAN      = 0x1000,                         //!< Scan type
 	SCE_O_RCOM      = 0x2000,                         //!< Remote command entry
 	SCE_O_NOBUF     = 0x4000,                         //!< Number device buffer
-	SCE_O_NOWAIT    = 0x8000                          //!< Asynchronous I/O
+	SCE_O_NOWAIT    = 0x8000,                         //!< Asynchronous I/O
 	SCE_O_FDEXCL    = 0x01000000,                     //!< Exclusive access
 	SCE_O_PWLOCK    = 0x02000000,                     //!< Power control lock
 	SCE_O_FGAMEDATA = 0x40000000                      //!< Gamedata access

--- a/include/psp2/io/stat.h
+++ b/include/psp2/io/stat.h
@@ -15,29 +15,29 @@ extern "C" {
 
 /** Access modes for st_mode in ::SceIoStat. */
 typedef enum SceIoAccessMode {
-	SCE_S_IFMT		= 0xF000,  //!< Format bits mask
-	SCE_S_IFLNK		= 0x4000,  //!< Symbolic link
+	SCE_S_IXUSR		= 0x0001,  //!< User execute permission
+	SCE_S_IWUSR		= 0x0002,  //!< User write permission
+	SCE_S_IRUSR		= 0x0004,  //!< User read permission
+	SCE_S_IRWXU		= 0x0007,  //!< User access rights mask
+	
+	SCE_S_IXGRP		= 0x0008,  //!< Group execute permission
+	SCE_S_IWGRP		= 0x0010,  //!< Group write permission
+	SCE_S_IRGRP		= 0x0020,  //!< Group read permission
+	SCE_S_IRWXG		= 0x0038,  //!< Group access rights mask
+	
+	SCE_S_IXOTH		= 0x0040,  //!< Others execute permission
+	SCE_S_IWOTH		= 0x0080,  //!< Others write permission
+	SCE_S_IROTH		= 0x0100,  //!< Others read permission
+	SCE_S_IRWXO		= 0x01C0,  //!< Others access rights mask
+	
+	SCE_S_ISVTX		= 0x0200,  //!< Sticky
+	SCE_S_ISGID		= 0x0400,  //!< Set GID
+	SCE_S_ISUID		= 0x0800,  //!< Set UID
+	
 	SCE_S_IFDIR		= 0x1000,  //!< Directory
 	SCE_S_IFREG		= 0x2000,  //!< Regular file
-
-	SCE_S_ISUID		= 0x0800,  //!< Set UID
-	SCE_S_ISGID		= 0x0400,  //!< Set GID
-	SCE_S_ISVTX		= 0x0200,  //!< Sticky
-
-	SCE_S_IRWXO		= 0x01C0,  //!< Others access rights mask
-	SCE_S_IROTH		= 0x0100,  //!< Others read permission
-	SCE_S_IWOTH		= 0x0080,  //!< Others write permission
-	SCE_S_IXOTH		= 0x0040,  //!< Others execute permission
-
-	SCE_S_IRWXG		= 0x0038,  //!< Group access rights mask
-	SCE_S_IRGRP		= 0x0020,  //!< Group read permission
-	SCE_S_IWGRP		= 0x0010,  //!< Group write permission
-	SCE_S_IXGRP		= 0x0008,  //!< Group execute permission
-
-	SCE_S_IRWXU		= 0x0007,  //!< User access rights mask
-	SCE_S_IRUSR		= 0x0004,  //!< User read permission
-	SCE_S_IWUSR		= 0x0002,  //!< User write permission
-	SCE_S_IXUSR		= 0x0001,  //!< User execute permission
+	SCE_S_IFLNK		= 0x4000,  //!< Symbolic link
+	SCE_S_IFMT		= 0xF000,  //!< Format bits mask
 } SceIoAccessMode;
 
 // File mode checking macros
@@ -47,13 +47,13 @@ typedef enum SceIoAccessMode {
 
 /** File modes, used for the st_attr parameter in ::SceIoStat. */
 typedef enum SceIoFileMode {
-	SCE_SO_IFMT             = 0x0038,               //!< Format mask
+	SCE_SO_IXOTH            = 0x0001,               //!< Hidden execute permission
+	SCE_SO_IWOTH            = 0x0002,               //!< Hidden write permission
+	SCE_SO_IROTH            = 0x0004,               //!< Hidden read permission
 	SCE_SO_IFLNK            = 0x0008,               //!< Symbolic link
 	SCE_SO_IFDIR            = 0x0010,               //!< Directory
 	SCE_SO_IFREG            = 0x0020,               //!< Regular file
-	SCE_SO_IROTH            = 0x0004,               //!< Hidden read permission
-	SCE_SO_IWOTH            = 0x0002,               //!< Hidden write permission
-	SCE_SO_IXOTH            = 0x0001,               //!< Hidden execute permission
+	SCE_SO_IFMT             = 0x0038,               //!< Format mask	
 } SceIoFileMode;
 
 // File mode checking macros

--- a/include/psp2/io/stat.h
+++ b/include/psp2/io/stat.h
@@ -13,75 +13,48 @@
 extern "C" {
 #endif
 
-/** Access modes for st_mode in SceIoStat (confirm?). */
-enum {
-	/** Format bits mask */
-	SCE_S_IFMT		= 0xF000,
-	/** Symbolic link */
-	SCE_S_IFLNK		= 0x4000,
-	/** Directory */
-	SCE_S_IFDIR		= 0x1000,
-	/** Regular file */
-	SCE_S_IFREG		= 0x2000,
+/** Access modes for st_mode in ::SceIoStat. */
+typedef enum SceIoAccessMode {
+	SCE_S_IFMT		= 0xF000,  //!< Format bits mask
+	SCE_S_IFLNK		= 0x4000,  //!< Symbolic link
+	SCE_S_IFDIR		= 0x1000,  //!< Directory
+	SCE_S_IFREG		= 0x2000,  //!< Regular file
 
-	/** Set UID */
-	SCE_S_ISUID		= 0x0800,
-	/** Set GID */
-	SCE_S_ISGID		= 0x0400,
-	/** Sticky */
-	SCE_S_ISVTX		= 0x0200,
+	SCE_S_ISUID		= 0x0800,  //!< Set UID
+	SCE_S_ISGID		= 0x0400,  //!< Set GID
+	SCE_S_ISVTX		= 0x0200,  //!< Sticky
 
-	/** Others access rights mask */
-	SCE_S_IRWXO		= 0x01C0,
-	/** Others read permission */
-	SCE_S_IROTH		= 0x0100,
-	/** Others write permission */
-	SCE_S_IWOTH		= 0x0080,
-	/** Others execute permission */
-	SCE_S_IXOTH		= 0x0040,
+	SCE_S_IRWXO		= 0x01C0,  //!< Others access rights mask
+	SCE_S_IROTH		= 0x0100,  //!< Others read permission
+	SCE_S_IWOTH		= 0x0080,  //!< Others write permission
+	SCE_S_IXOTH		= 0x0040,  //!< Others execute permission
 
-	/** Group access rights mask */
-	SCE_S_IRWXG		= 0x0038,
-	/** Group read permission */
-	SCE_S_IRGRP		= 0x0020,
-	/** Group write permission */
-	SCE_S_IWGRP		= 0x0010,
-	/** Group execute permission */
-	SCE_S_IXGRP		= 0x0008,
+	SCE_S_IRWXG		= 0x0038,  //!< Group access rights mask
+	SCE_S_IRGRP		= 0x0020,  //!< Group read permission
+	SCE_S_IWGRP		= 0x0010,  //!< Group write permission
+	SCE_S_IXGRP		= 0x0008,  //!< Group execute permission
 
-	/** User access rights mask */
-	SCE_S_IRWXU		= 0x0007,
-	/** User read permission */
-	SCE_S_IRUSR		= 0x0004,
-	/** User write permission */
-	SCE_S_IWUSR		= 0x0002,
-	/** User execute permission */
-	SCE_S_IXUSR		= 0x0001,
-};
+	SCE_S_IRWXU		= 0x0007,  //!< User access rights mask
+	SCE_S_IRUSR		= 0x0004,  //!< User read permission
+	SCE_S_IWUSR		= 0x0002,  //!< User write permission
+	SCE_S_IXUSR		= 0x0001,  //!< User execute permission
+} SceIoAccessMode;
 
 // File mode checking macros
 #define SCE_S_ISLNK(m)	(((m) & SCE_S_IFMT) == SCE_S_IFLNK)
 #define SCE_S_ISREG(m)	(((m) & SCE_S_IFMT) == SCE_S_IFREG)
 #define SCE_S_ISDIR(m)	(((m) & SCE_S_IFMT) == SCE_S_IFDIR)
 
-/** File modes, used for the st_attr parameter in SceIoStat (confirm?). */
-enum {
-	/** Format mask */
-	SCE_SO_IFMT             = 0x0038,               // Format mask
-	/** Symlink */
-	SCE_SO_IFLNK            = 0x0008,               // Symbolic link
-	/** Directory */
-	SCE_SO_IFDIR            = 0x0010,               // Directory
-	/** Regular file */
-	SCE_SO_IFREG            = 0x0020,               // Regular file
-
-	/** Hidden read permission */
-	SCE_SO_IROTH            = 0x0004,               // read
-	/** Hidden write permission */
-	SCE_SO_IWOTH            = 0x0002,               // write
-	/** Hidden execute permission */
-	SCE_SO_IXOTH            = 0x0001,               // execute
-};
+/** File modes, used for the st_attr parameter in ::SceIoStat. */
+typedef enum SceIoFileMode {
+	SCE_SO_IFMT             = 0x0038,               //!< Format mask
+	SCE_SO_IFLNK            = 0x0008,               //!< Symbolic link
+	SCE_SO_IFDIR            = 0x0010,               //!< Directory
+	SCE_SO_IFREG            = 0x0020,               //!< Regular file
+	SCE_SO_IROTH            = 0x0004,               //!< Hidden read permission
+	SCE_SO_IWOTH            = 0x0002,               //!< Hidden write permission
+	SCE_SO_IXOTH            = 0x0001,               //!< Hidden execute permission
+} SceIoFileMode;
 
 // File mode checking macros
 #define SCE_SO_ISLNK(m)	(((m) & SCE_SO_IFMT) == SCE_SO_IFLNK)
@@ -90,25 +63,20 @@ enum {
 
 /** Structure to hold the status information about a file */
 typedef struct SceIoStat {
-	SceMode	st_mode;
-	unsigned int	st_attr;
-	/** Size of the file in bytes. */
-	SceOff	st_size;
-	/** Creation time. */
-	SceDateTime	st_ctime;
-	/** Access time. */
-	SceDateTime	st_atime;
-	/** Modification time. */
-	SceDateTime	st_mtime;
-	/** Device-specific data. */
-	unsigned int	st_private[6];
+	SceMode st_mode;             //!< One or more ::SceIoAccessMode
+	unsigned int st_attr;        //!< One or more ::SceIoFileMode
+	SceOff st_size;              //!< Size of the file in bytes
+	SceDateTime st_ctime;        //!< Creation time
+	SceDateTime st_atime;        //!< Last access time
+	SceDateTime st_mtime;        //!< Last modification time
+	unsigned int st_private[6];  //!< Device-specific data
 } SceIoStat;
 
 /**
  * Make a directory file
  *
- * @param dir
- * @param mode - Access mode.
+ * @param dir - The path to the directory
+ * @param mode - Access mode (One or more ::SceIoAccessMode).
  * @return Returns the value 0 if it's successful, otherwise -1
  */
 int sceIoMkdir(const char *dir, SceMode mode);
@@ -125,7 +93,7 @@ int sceIoRmdir(const char *path);
   * Get the status of a file.
   *
   * @param file - The path to the file.
-  * @param stat - A pointer to an io_stat_t structure.
+  * @param stat - A pointer to a ::SceIoStat structure.
   *
   * @return < 0 on error.
   */
@@ -135,7 +103,7 @@ int sceIoGetstat(const char *file, SceIoStat *stat);
   * Get the status of a file descriptor.
   *
   * @param fd - The file descriptor.
-  * @param stat - A pointer to an io_stat_t structure.
+  * @param stat - A pointer to a ::SceIoStat structure.
   *
   * @return < 0 on error.
   */
@@ -145,7 +113,7 @@ int sceIoGetstatByFd(SceUID fd, SceIoStat *stat);
   * Change the status of a file.
   *
   * @param file - The path to the file.
-  * @param stat - A pointer to an io_stat_t structure.
+  * @param stat - A pointer to a ::SceIoStat structure.
   * @param bits - Bitmask defining which bits to change.
   *
   * @return < 0 on error.

--- a/include/psp2kern/io/devctl.h
+++ b/include/psp2kern/io/devctl.h
@@ -4,10 +4,10 @@
  */
 
 
-#ifndef _PSP2_IO_DEVCTRL_H_
-#define _PSP2_IO_DEVCTRL_H_
+#ifndef _PSP2_IO_DEVCTL_H_
+#define _PSP2_IO_DEVCTL_H_
 
-#include <psp2/types.h>
+#include <psp2kern/types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,5 +35,5 @@ int ksceIoDevctl(const char *dev, unsigned int cmd, void *indata, int inlen, voi
 }
 #endif
 
-#endif /* _PSP2_IO_DEVCTRL_H_ */
+#endif /* _PSP2_IO_DEVCTL_H_ */
 

--- a/include/psp2kern/io/dirent.h
+++ b/include/psp2kern/io/dirent.h
@@ -7,7 +7,7 @@
 #ifndef _PSP2_IO_DRENT_H_
 #define _PSP2_IO_DRENT_H_
 
-#include <psp2/types.h>
+#include <psp2kern/types.h>
 #include <psp2kern/io/stat.h>
 
 #ifdef __cplusplus
@@ -16,13 +16,10 @@ extern "C" {
 
 /** Describes a single directory entry */
 typedef struct SceIoDirent {
-	/** File status. */
-	SceIoStat	d_stat;
-	/** File name. */
-	char	d_name[256];
-	/** Device-specific data. */
-	void	*d_private;
-	int	dummy;
+	SceIoStat d_stat; //!< File status
+	char d_name[256]; //!< File name
+	void *d_private;  //!< Device-specific data
+	int dummy;        //!< Dummy data
 } SceIoDirent;
 
 /**
@@ -43,8 +40,8 @@ SceUID ksceIoDopen(const char *dirname);
 /**
   * Reads an entry from an opened file descriptor.
   *
-  * @param fd - Already opened file descriptor (using ksceIoDopen)
-  * @param dir - Pointer to an io_dirent_t structure to hold the file information
+  * @param fd - Already opened file descriptor (using ::ksceIoDopen)
+  * @param dir - Pointer to an ::SceIoDirent structure to hold the file information
   *
   * @return Read status
   * -   0 - No more directory entries left
@@ -56,7 +53,7 @@ int ksceIoDread(SceUID fd, SceIoDirent *dir);
 /**
   * Close an opened directory file descriptor
   *
-  * @param fd - Already opened file descriptor (using ksceIoDopen)
+  * @param fd - Already opened file descriptor (using ::ksceIoDopen)
   * @return < 0 on error
   */
 int ksceIoDclose(SceUID fd);

--- a/include/psp2kern/io/fcntl.h
+++ b/include/psp2kern/io/fcntl.h
@@ -32,6 +32,7 @@ typedef enum SceIoMode {
 	SCE_O_NOBUF     = 0x4000,                         //!< Number device buffer
 	SCE_O_NOWAIT    = 0x8000                          //!< Asynchronous I/O
 	SCE_O_FDEXCL    = 0x01000000,                     //!< Exclusive access
+	SCE_O_PWLOCK    = 0x02000000,                     //!< Power control lock
 	SCE_O_FGAMEDATA = 0x40000000                      //!< Gamedata access
 } SceIoMode;
 

--- a/include/psp2kern/io/fcntl.h
+++ b/include/psp2kern/io/fcntl.h
@@ -44,7 +44,7 @@ typedef enum SceIoSeekMode {
 typedef enum SceIoDevType {
 	SCE_DEV_TYPE_NULL     = 0x00, //!< Dummy device
 	SCE_DEV_TYPE_CHAR     = 0x01, //!< Character device
-	SCE_DEV_TYPE_BLOCK    = 0X04, //!< Block device
+	SCE_DEV_TYPE_BLOCK    = 0x04, //!< Block device
 	SCE_DEV_TYPE_FS       = 0x10, //!< File system device
 	SCE_DEV_TYPE_ALIAS    = 0x20, //!< Alias name
 	SCE_DEV_TYPE_MOUNTPT  = 0x40  //!< Mount point

--- a/include/psp2kern/io/fcntl.h
+++ b/include/psp2kern/io/fcntl.h
@@ -7,7 +7,7 @@
 #ifndef _PSP2_IO_FCNTL_H_
 #define _PSP2_IO_FCNTL_H_
 
-#include <psp2/types.h>
+#include <psp2kern/types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -15,24 +15,40 @@ extern "C" {
 
 /* Note: Not all of these ksceIoOpen() flags are not compatible with the
    open() flags found in sys/unistd.h. */
-enum {
-	SCE_O_RDONLY   = 0x0001,
-	SCE_O_WRONLY   = 0x0002,
-	SCE_O_RDWR     = (SCE_O_RDONLY | SCE_O_WRONLY),
-	SCE_O_NBLOCK   = 0x0004,
-	SCE_O_DIROPEN  = 0x0008,  // Internal use for dopen
-	SCE_O_APPEND   = 0x0100,
-	SCE_O_CREAT    = 0x0200,
-	SCE_O_TRUNC    = 0x0400,
-	SCE_O_EXCL     = 0x0800,
-	SCE_O_NOWAIT   = 0x8000
-};
+typedef enum SceIoMode {
+	SCE_O_RDONLY    = 0x0001,                         //!< Read-only
+	SCE_O_WRONLY    = 0x0002,                         //!< Write-only
+	SCE_O_RDWR      = (SCE_O_RDONLY | SCE_O_WRONLY),  //!< Read/Write
+	SCE_O_NBLOCK    = 0x0004,                         //!< Non blocking
+	SCE_O_DIROPEN   = 0x0008,                         //!< Internal use for ::ksceIoDopen
+	SCE_O_RDLOCK    = 0x0010,                         //!< Read locked (non-shared)
+	SCE_O_WRLOCK    = 0x0020,                         //!< Write locked (non-shared)
+	SCE_O_APPEND    = 0x0100,                         //!< Append
+	SCE_O_CREAT     = 0x0200,                         //!< Create
+	SCE_O_TRUNC     = 0x0400,                         //!< Truncate
+	SCE_O_EXCL      = 0x0800,                         //!< Exclusive create
+	SCE_O_SCAN      = 0x1000,                         //!< Scan type
+	SCE_O_RCOM      = 0x2000,                         //!< Remote command entry
+	SCE_O_NOBUF     = 0x4000,                         //!< Number device buffer
+	SCE_O_NOWAIT    = 0x8000                          //!< Asynchronous I/O
+	SCE_O_FDEXCL    = 0x01000000,                     //!< Exclusive access
+	SCE_O_FGAMEDATA = 0x40000000                      //!< Gamedata access
+} SceIoMode;
 
-enum {
-	SCE_SEEK_SET,
-	SCE_SEEK_CUR,
-	SCE_SEEK_END
-};
+typedef enum SceIoSeekMode {
+	SCE_SEEK_SET,   //!< Starts from the begin of the file
+	SCE_SEEK_CUR,   //!< Starts from current position
+	SCE_SEEK_END    //!< Starts from the end of the file
+} SceIoSeekMode;
+
+typedef enum SceIoDevType {
+	SCE_DEV_TYPE_NULL     = 0x00, //!< Dummy device
+	SCE_DEV_TYPE_CHAR     = 0x01, //!< Character device
+	SCE_DEV_TYPE_BLOCK    = 0X04, //!< Block device
+	SCE_DEV_TYPE_FS       = 0x10, //!< File system device
+	SCE_DEV_TYPE_ALIAS    = 0x20, //!< Alias name
+	SCE_DEV_TYPE_MOUNTPT  = 0x40  //!< Mount point
+} SceIoDevType;
 
 /**
  * Open or create a file for reading or writing
@@ -52,7 +68,7 @@ enum {
  *
  * @param file - Pointer to a string holding the name of the file to open
  * @param flags - Libc styled flags that are or'ed together
- * @param mode - File access mode.
+ * @param mode - File access mode (One or more ::SceIoMode).
  * @return A non-negative integer is a valid fd, anything else an error
  */
 SceUID ksceIoOpen(const char *file, int flags, SceMode mode);
@@ -62,7 +78,7 @@ SceUID ksceIoOpen(const char *file, int flags, SceMode mode);
  *
  * @param file - Pointer to a string holding the name of the file to open
  * @param flags - Libc styled flags that are or'ed together
- * @param mode - File access mode.
+ * @param mode - File access mode (One or more ::SceIoMode).
  * @return A non-negative integer is a valid fd, anything else an error
  */
 SceUID ksceIoOpenAsync(const char *file, int flags, SceMode mode);
@@ -151,13 +167,12 @@ int ksceIoWriteAsync(SceUID fd, const void *data, SceSize size);
  *
  * @par Example:
  * @code
- * pos = ksceIoLseek(fd, -10, SEEK_END);
+ * pos = ksceIoLseek(fd, -10, SCE_SEEK_END);
  * @endcode
  *
  * @param fd - Opened file descriptor with which to seek
  * @param offset - Relative offset from the start position given by whence
- * @param whence - Set to SEEK_SET to seek from the start of the file, SEEK_CUR
- * seek from the current position and SEEK_END to seek from the end.
+ * @param whence - One of ::SceIoSeekMode.
  *
  * @return The position in the file after the seek.
  */
@@ -168,8 +183,7 @@ SceOff ksceIoLseek(SceUID fd, SceOff offset, int whence);
  *
  * @param fd - Opened file descriptor with which to seek
  * @param offset - Relative offset from the start position given by whence
- * @param whence - Set to SEEK_SET to seek from the start of the file, SEEK_CUR
- * seek from the current position and SEEK_END to seek from the end.
+ * @param whence - One of ::SceIoSeekMode.
  *
  * @return < 0 on error. Actual value should be passed returned by the ::ksceIoWaitAsync call.
  */
@@ -180,13 +194,12 @@ int ksceIoLseekAsync(SceUID fd, SceOff offset, int whence);
  *
  * @par Example:
  * @code
- * pos = ksceIoLseek32(fd, -10, SEEK_END);
+ * pos = ksceIoLseek32(fd, -10, SCE_SEEK_END);
  * @endcode
  *
  * @param fd - Opened file descriptor with which to seek
  * @param offset - Relative offset from the start position given by whence
- * @param whence - Set to SEEK_SET to seek from the start of the file, SEEK_CUR
- * seek from the current position and SEEK_END to seek from the end.
+ * @param whence - One of ::SceIoSeekMode.
  *
  * @return The position in the file after the seek.
  */
@@ -197,8 +210,7 @@ int ksceIoLseek32(SceUID fd, int offset, int whence);
  *
  * @param fd - Opened file descriptor with which to seek
  * @param offset - Relative offset from the start position given by whence
- * @param whence - Set to SEEK_SET to seek from the start of the file, SEEK_CUR
- * seek from the current position and SEEK_END to seek from the end.
+ * @param whence - One of ::SceIoSeekMode.
  *
  * @return < 0 on error.
  */
@@ -293,7 +305,7 @@ int ksceIoCancel(SceUID fd);
   *
   * @param fd - The opened file descriptor.
   *
-  * @return < 0 on error. Otherwise the device type?
+  * @return < 0 on error, otherwise one of ::SceIoDevType.
   */
 int ksceIoGetDevType(SceUID fd);
 

--- a/include/psp2kern/io/fcntl.h
+++ b/include/psp2kern/io/fcntl.h
@@ -30,7 +30,7 @@ typedef enum SceIoMode {
 	SCE_O_SCAN      = 0x1000,                         //!< Scan type
 	SCE_O_RCOM      = 0x2000,                         //!< Remote command entry
 	SCE_O_NOBUF     = 0x4000,                         //!< Number device buffer
-	SCE_O_NOWAIT    = 0x8000                          //!< Asynchronous I/O
+	SCE_O_NOWAIT    = 0x8000,                         //!< Asynchronous I/O
 	SCE_O_FDEXCL    = 0x01000000,                     //!< Exclusive access
 	SCE_O_PWLOCK    = 0x02000000,                     //!< Power control lock
 	SCE_O_FGAMEDATA = 0x40000000                      //!< Gamedata access

--- a/include/psp2kern/io/stat.h
+++ b/include/psp2kern/io/stat.h
@@ -15,29 +15,29 @@ extern "C" {
 
 /** Access modes for st_mode in ::SceIoStat. */
 typedef enum SceIoAccessMode {
-	SCE_S_IFMT		= 0xF000,  //!< Format bits mask
-	SCE_S_IFLNK		= 0x4000,  //!< Symbolic link
+	SCE_S_IXUSR		= 0x0001,  //!< User execute permission
+	SCE_S_IWUSR		= 0x0002,  //!< User write permission
+	SCE_S_IRUSR		= 0x0004,  //!< User read permission
+	SCE_S_IRWXU		= 0x0007,  //!< User access rights mask
+	
+	SCE_S_IXGRP		= 0x0008,  //!< Group execute permission
+	SCE_S_IWGRP		= 0x0010,  //!< Group write permission
+	SCE_S_IRGRP		= 0x0020,  //!< Group read permission
+	SCE_S_IRWXG		= 0x0038,  //!< Group access rights mask
+	
+	SCE_S_IXOTH		= 0x0040,  //!< Others execute permission
+	SCE_S_IWOTH		= 0x0080,  //!< Others write permission
+	SCE_S_IROTH		= 0x0100,  //!< Others read permission
+	SCE_S_IRWXO		= 0x01C0,  //!< Others access rights mask
+	
+	SCE_S_ISVTX		= 0x0200,  //!< Sticky
+	SCE_S_ISGID		= 0x0400,  //!< Set GID
+	SCE_S_ISUID		= 0x0800,  //!< Set UID
+	
 	SCE_S_IFDIR		= 0x1000,  //!< Directory
 	SCE_S_IFREG		= 0x2000,  //!< Regular file
-
-	SCE_S_ISUID		= 0x0800,  //!< Set UID
-	SCE_S_ISGID		= 0x0400,  //!< Set GID
-	SCE_S_ISVTX		= 0x0200,  //!< Sticky
-
-	SCE_S_IRWXO		= 0x01C0,  //!< Others access rights mask
-	SCE_S_IROTH		= 0x0100,  //!< Others read permission
-	SCE_S_IWOTH		= 0x0080,  //!< Others write permission
-	SCE_S_IXOTH		= 0x0040,  //!< Others execute permission
-
-	SCE_S_IRWXG		= 0x0038,  //!< Group access rights mask
-	SCE_S_IRGRP		= 0x0020,  //!< Group read permission
-	SCE_S_IWGRP		= 0x0010,  //!< Group write permission
-	SCE_S_IXGRP		= 0x0008,  //!< Group execute permission
-
-	SCE_S_IRWXU		= 0x0007,  //!< User access rights mask
-	SCE_S_IRUSR		= 0x0004,  //!< User read permission
-	SCE_S_IWUSR		= 0x0002,  //!< User write permission
-	SCE_S_IXUSR		= 0x0001,  //!< User execute permission
+	SCE_S_IFLNK		= 0x4000,  //!< Symbolic link
+	SCE_S_IFMT		= 0xF000,  //!< Format bits mask
 } SceIoAccessMode;
 
 // File mode checking macros
@@ -47,13 +47,13 @@ typedef enum SceIoAccessMode {
 
 /** File modes, used for the st_attr parameter in SceIoStat (confirm?). */
 typedef enum SceIoFileMode {
-	SCE_SO_IFMT             = 0x0038,               //!< Format mask
+	SCE_SO_IXOTH            = 0x0001,               //!< Hidden execute permission
+	SCE_SO_IWOTH            = 0x0002,               //!< Hidden write permission
+	SCE_SO_IROTH            = 0x0004,               //!< Hidden read permission
 	SCE_SO_IFLNK            = 0x0008,               //!< Symbolic link
 	SCE_SO_IFDIR            = 0x0010,               //!< Directory
 	SCE_SO_IFREG            = 0x0020,               //!< Regular file
-	SCE_SO_IROTH            = 0x0004,               //!< Hidden read permission
-	SCE_SO_IWOTH            = 0x0002,               //!< Hidden write permission
-	SCE_SO_IXOTH            = 0x0001,               //!< Hidden execute permission
+	SCE_SO_IFMT             = 0x0038,               //!< Format mask	
 } SceIoFileMode;
 
 // File mode checking macros

--- a/include/psp2kern/io/stat.h
+++ b/include/psp2kern/io/stat.h
@@ -7,57 +7,38 @@
 #ifndef _PSP2_IO_STAT_H_
 #define _PSP2_IO_STAT_H_
 
-#include <psp2/types.h>
+#include <psp2kern/types.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/** Access modes for st_mode in SceIoStat (confirm?). */
-enum {
-	/** Format bits mask */
-	SCE_S_IFMT		= 0xF000,
-	/** Symbolic link */
-	SCE_S_IFLNK		= 0x4000,
-	/** Directory */
-	SCE_S_IFDIR		= 0x1000,
-	/** Regular file */
-	SCE_S_IFREG		= 0x2000,
+/** Access modes for st_mode in ::SceIoStat. */
+typedef enum SceIoAccessMode {
+	SCE_S_IFMT		= 0xF000,  //!< Format bits mask
+	SCE_S_IFLNK		= 0x4000,  //!< Symbolic link
+	SCE_S_IFDIR		= 0x1000,  //!< Directory
+	SCE_S_IFREG		= 0x2000,  //!< Regular file
 
-	/** Set UID */
-	SCE_S_ISUID		= 0x0800,
-	/** Set GID */
-	SCE_S_ISGID		= 0x0400,
-	/** Sticky */
-	SCE_S_ISVTX		= 0x0200,
+	SCE_S_ISUID		= 0x0800,  //!< Set UID
+	SCE_S_ISGID		= 0x0400,  //!< Set GID
+	SCE_S_ISVTX		= 0x0200,  //!< Sticky
 
-	/** Others access rights mask */
-	SCE_S_IRWXO		= 0x01C0,
-	/** Others read permission */
-	SCE_S_IROTH		= 0x0100,
-	/** Others write permission */
-	SCE_S_IWOTH		= 0x0080,
-	/** Others execute permission */
-	SCE_S_IXOTH		= 0x0040,
+	SCE_S_IRWXO		= 0x01C0,  //!< Others access rights mask
+	SCE_S_IROTH		= 0x0100,  //!< Others read permission
+	SCE_S_IWOTH		= 0x0080,  //!< Others write permission
+	SCE_S_IXOTH		= 0x0040,  //!< Others execute permission
 
-	/** Group access rights mask */
-	SCE_S_IRWXG		= 0x0038,
-	/** Group read permission */
-	SCE_S_IRGRP		= 0x0020,
-	/** Group write permission */
-	SCE_S_IWGRP		= 0x0010,
-	/** Group execute permission */
-	SCE_S_IXGRP		= 0x0008,
+	SCE_S_IRWXG		= 0x0038,  //!< Group access rights mask
+	SCE_S_IRGRP		= 0x0020,  //!< Group read permission
+	SCE_S_IWGRP		= 0x0010,  //!< Group write permission
+	SCE_S_IXGRP		= 0x0008,  //!< Group execute permission
 
-	/** User access rights mask */
-	SCE_S_IRWXU		= 0x0007,
-	/** User read permission */
-	SCE_S_IRUSR		= 0x0004,
-	/** User write permission */
-	SCE_S_IWUSR		= 0x0002,
-	/** User execute permission */
-	SCE_S_IXUSR		= 0x0001,
-};
+	SCE_S_IRWXU		= 0x0007,  //!< User access rights mask
+	SCE_S_IRUSR		= 0x0004,  //!< User read permission
+	SCE_S_IWUSR		= 0x0002,  //!< User write permission
+	SCE_S_IXUSR		= 0x0001,  //!< User execute permission
+} SceIoAccessMode;
 
 // File mode checking macros
 #define SCE_S_ISLNK(m)	(((m) & SCE_S_IFMT) == SCE_S_IFLNK)
@@ -65,23 +46,15 @@ enum {
 #define SCE_S_ISDIR(m)	(((m) & SCE_S_IFMT) == SCE_S_IFDIR)
 
 /** File modes, used for the st_attr parameter in SceIoStat (confirm?). */
-enum {
-	/** Format mask */
-	SCE_SO_IFMT             = 0x0038,               // Format mask
-	/** Symlink */
-	SCE_SO_IFLNK            = 0x0008,               // Symbolic link
-	/** Directory */
-	SCE_SO_IFDIR            = 0x0010,               // Directory
-	/** Regular file */
-	SCE_SO_IFREG            = 0x0020,               // Regular file
-
-	/** Hidden read permission */
-	SCE_SO_IROTH            = 0x0004,               // read
-	/** Hidden write permission */
-	SCE_SO_IWOTH            = 0x0002,               // write
-	/** Hidden execute permission */
-	SCE_SO_IXOTH            = 0x0001,               // execute
-};
+typedef enum SceIoFileMode {
+	SCE_SO_IFMT             = 0x0038,               //!< Format mask
+	SCE_SO_IFLNK            = 0x0008,               //!< Symbolic link
+	SCE_SO_IFDIR            = 0x0010,               //!< Directory
+	SCE_SO_IFREG            = 0x0020,               //!< Regular file
+	SCE_SO_IROTH            = 0x0004,               //!< Hidden read permission
+	SCE_SO_IWOTH            = 0x0002,               //!< Hidden write permission
+	SCE_SO_IXOTH            = 0x0001,               //!< Hidden execute permission
+} SceIoFileMode;
 
 // File mode checking macros
 #define SCE_SO_ISLNK(m)	(((m) & SCE_SO_IFMT) == SCE_SO_IFLNK)
@@ -90,25 +63,20 @@ enum {
 
 /** Structure to hold the status information about a file */
 typedef struct SceIoStat {
-	SceMode	st_mode;
-	unsigned int	st_attr;
-	/** Size of the file in bytes. */
-	SceOff	st_size;
-	/** Creation time. */
-	SceDateTime	st_ctime;
-	/** Access time. */
-	SceDateTime	st_atime;
-	/** Modification time. */
-	SceDateTime	st_mtime;
-	/** Device-specific data. */
-	unsigned int	st_private[6];
+	SceMode st_mode;             //!< One or more ::SceIoAccessMode
+	unsigned int st_attr;        //!< One or more ::SceIoFileMode
+	SceOff st_size;              //!< Size of the file in bytes
+	SceDateTime st_ctime;        //!< Creation time
+	SceDateTime st_atime;        //!< Last access time
+	SceDateTime st_mtime;        //!< Last modification time
+	unsigned int st_private[6];  //!< Device-specific data
 } SceIoStat;
 
 /**
  * Make a directory file
  *
- * @param dir
- * @param mode - Access mode.
+ * @param dir - The path to the directory
+ * @param mode - Access mode (One or more ::SceIoAccessMode).
  * @return Returns the value 0 if it's successful, otherwise -1
  */
 int ksceIoMkdir(const char *dir, SceMode mode);
@@ -125,7 +93,7 @@ int ksceIoRmdir(const char *path);
   * Get the status of a file.
   *
   * @param file - The path to the file.
-  * @param stat - A pointer to an io_stat_t structure.
+  * @param stat - A pointer to a ::SceIoStat structure.
   *
   * @return < 0 on error.
   */
@@ -135,7 +103,7 @@ int ksceIoGetstat(const char *file, SceIoStat *stat);
   * Get the status of a file descriptor.
   *
   * @param fd - The file descriptor.
-  * @param stat - A pointer to an io_stat_t structure.
+  * @param stat - A pointer to a ::SceIoStat structure.
   *
   * @return < 0 on error.
   */
@@ -145,7 +113,7 @@ int ksceIoGetstatByFd(SceUID fd, SceIoStat *stat);
   * Change the status of a file.
   *
   * @param file - The path to the file.
-  * @param stat - A pointer to an io_stat_t structure.
+  * @param stat - A pointer to a ::SceIoStat structure.
   * @param bits - Bitmask defining which bits to change.
   *
   * @return < 0 on error.


### PR DESCRIPTION
What this contains:

- Named some anonymous enums.
- Added missing SceIoMode values.
- Added SceIoDevType enum for sceIoGetDevType results.
- Made the documentation more doxygen-friendly.
- Added missing comments.
- Replaced references to posix io to sceIo ones (eg. SEEK_END -> SCE_SEEK_END in some samples).
- Minor typo fixes.