### PR TITLE
Big db.yml update

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -1741,254 +1741,12 @@ modules:
         nid: 0x63A519E5
         kernel: true
         functions:
-          SceSysmemForKernel_00BC5B4A: 0x00BC5B4A
-          SceSysmemForKernel_01DE3AB7: 0x01DE3AB7
-          SceSysmemForKernel_07FEBBCA: 0x07FEBBCA
-          SceSysmemForKernel_080BA2F3: 0x080BA2F3
-          SceSysmemForKernel_08AB3DAE: 0x08AB3DAE
-          SceSysmemForKernel_0A8D14EC: 0x0A8D14EC
-          SceSysmemForKernel_0FD6B756: 0x0FD6B756
-          SceSysmemForKernel_114E6476: 0x114E6476
-          SceSysmemForKernel_12ED88AE: 0x12ED88AE
-          SceSysmemForKernel_131CEF52: 0x131CEF52
-          SceSysmemForKernel_153A08A0: 0x153A08A0
-          SceSysmemForKernel_17F1AA22: 0x17F1AA22
-          SceSysmemForKernel_18B99FDD: 0x18B99FDD
-          SceSysmemForKernel_19CAEF35: 0x19CAEF35
-          SceSysmemForKernel_1E11F41D: 0x1E11F41D
-          SceSysmemForKernel_210DB518: 0x210DB518
-          SceSysmemForKernel_21285F40: 0x21285F40
-          SceSysmemForKernel_219E90FD: 0x219E90FD
-          SceSysmemForKernel_22708F14: 0x22708F14
-          SceSysmemForKernel_22A26637: 0x22A26637
-          SceSysmemForKernel_22F79E82: 0x22F79E82
-          SceSysmemForKernel_2364A170: 0x2364A170
-          SceSysmemForKernel_2476B90F: 0x2476B90F
-          SceSysmemForKernel_2658EE0A: 0x2658EE0A
-          SceSysmemForKernel_2770A7D7: 0x2770A7D7
-          SceSysmemForKernel_2791F109: 0x2791F109
-          SceSysmemForKernel_289BE3EC: 0x289BE3EC
-          SceSysmemForKernel_2A79C51C: 0x2A79C51C
-          SceSysmemForKernel_2AEA9E09: 0x2AEA9E09
-          SceSysmemForKernel_2E36E0C4: 0x2E36E0C4
-          SceSysmemForKernel_2EE50533: 0x2EE50533
-          SceSysmemForKernel_2F6F9C2C: 0x2F6F9C2C
-          SceSysmemForKernel_3203AE64: 0x3203AE64
-          SceSysmemForKernel_3650963F: 0x3650963F
-          SceSysmemForKernel_36830F46: 0x36830F46
-          SceSysmemForKernel_3B75CBED: 0x3B75CBED
-          SceSysmemForKernel_3EC2345B: 0x3EC2345B
-          SceSysmemForKernel_3F74E45C: 0x3F74E45C
-          SceSysmemForKernel_3FCA782B: 0x3FCA782B
-          SceSysmemForKernel_43DFCE89: 0x43DFCE89
-          SceSysmemForKernel_43E81C4B: 0x43E81C4B
-          SceSysmemForKernel_4492421F: 0x4492421F
-          SceSysmemForKernel_45F2A59C: 0x45F2A59C
-          SceSysmemForKernel_46A5CB84: 0x46A5CB84
-          SceSysmemForKernel_48750A5A: 0x48750A5A
-          SceSysmemForKernel_48D87E17: 0x48D87E17
-          SceSysmemForKernel_4A3737F0: 0x4A3737F0
-          SceSysmemForKernel_4B5C85AC: 0x4B5C85AC
-          SceSysmemForKernel_4CCA935D: 0x4CCA935D
-          SceSysmemForKernel_4D38F861: 0x4D38F861
-          SceSysmemForKernel_4D809B47: 0x4D809B47
-          SceSysmemForKernel_4FA4A624: 0x4FA4A624
-          SceSysmemForKernel_53A2E272: 0x53A2E272
-          SceSysmemForKernel_53E1FFDE: 0x53E1FFDE
-          SceSysmemForKernel_5409397F: 0x5409397F
-          SceSysmemForKernel_54E85275: 0x54E85275
-          SceSysmemForKernel_571660AA: 0x571660AA
-          SceSysmemForKernel_59F577E8: 0x59F577E8
-          SceSysmemForKernel_5C257482: 0x5C257482
-          SceSysmemForKernel_5E169FEF: 0x5E169FEF
-          SceSysmemForKernel_5FFE4B79: 0x5FFE4B79
-          SceSysmemForKernel_60735311: 0x60735311
-          SceSysmemForKernel_61C2AA52: 0x61C2AA52
-          SceSysmemForKernel_620E00E7: 0x620E00E7
-          SceSysmemForKernel_62989905: 0x62989905
-          SceSysmemForKernel_63D83911: 0x63D83911
-          SceSysmemForKernel_64133268: 0x64133268
-          SceSysmemForKernel_6427560F: 0x6427560F
-          SceSysmemForKernel_653B0849: 0x653B0849
-          SceSysmemForKernel_66636970: 0x66636970
-          SceSysmemForKernel_67955EE9: 0x67955EE9
-          SceSysmemForKernel_67BAD5B4: 0x67BAD5B4
-          SceSysmemForKernel_68451777: 0x68451777
-          SceSysmemForKernel_686AA15C: 0x686AA15C
-          SceSysmemForKernel_68CB9266: 0x68CB9266
-          SceSysmemForKernel_6B3F4102: 0x6B3F4102
-          SceSysmemForKernel_6BB6AF94: 0x6BB6AF94
-          SceSysmemForKernel_71869119: 0x71869119
-          SceSysmemForKernel_72E7BFAC: 0x72E7BFAC
-          SceSysmemForKernel_775AA5E3: 0x775AA5E3
-          SceSysmemForKernel_77876A8D: 0x77876A8D
-          SceSysmemForKernel_789CD5BF: 0x789CD5BF
-          SceSysmemForKernel_7ABFA9A7: 0x7ABFA9A7
-          SceSysmemForKernel_7BD56D6D: 0x7BD56D6D
-          SceSysmemForKernel_7BE4D3D1: 0x7BE4D3D1
-          SceSysmemForKernel_7D92B2D3: 0x7D92B2D3
-          SceSysmemForKernel_7DC46969: 0x7DC46969
-          SceSysmemForKernel_7FD757FE: 0x7FD757FE
-          SceSysmemForKernel_7FDF483A: 0x7FDF483A
-          SceSysmemForKernel_812E7A53: 0x812E7A53
-          SceSysmemForKernel_86E83C0D: 0x86E83C0D
-          SceSysmemForKernel_876A7F44: 0x876A7F44
-          SceSysmemForKernel_89CE1F31: 0x89CE1F31
-          SceSysmemForKernel_8B07BB52: 0x8B07BB52
-          SceSysmemForKernel_8C8E2DD1: 0x8C8E2DD1
-          SceSysmemForKernel_8D6AF468: 0x8D6AF468
-          SceSysmemForKernel_8FB73A29: 0x8FB73A29
-          SceSysmemForKernel_91733EF4: 0x91733EF4
-          SceSysmemForKernel_942D15FC: 0x942D15FC
-          SceSysmemForKernel_95ABFDC3: 0x95ABFDC3
-          SceSysmemForKernel_9894B9E1: 0x9894B9E1
-          SceSysmemForKernel_98E6905B: 0x98E6905B
-          SceSysmemForKernel_9C53F457: 0x9C53F457
-          SceSysmemForKernel_9C7B62AB: 0x9C7B62AB
-          SceSysmemForKernel_A1FFA2C9: 0xA1FFA2C9
-          SceSysmemForKernel_A2CD1697: 0xA2CD1697
-          SceSysmemForKernel_A504BA60: 0xA504BA60
-          SceSysmemForKernel_A6F95838: 0xA6F95838
-          SceSysmemForKernel_A88F6D88: 0xA88F6D88
-          SceSysmemForKernel_ABAB0FAB: 0xABAB0FAB
-          SceSysmemForKernel_AD5A83E3: 0xAD5A83E3
-          SceSysmemForKernel_AF180A3F: 0xAF180A3F
-          SceSysmemForKernel_AF42AAD5: 0xAF42AAD5
-          SceSysmemForKernel_AF729575: 0xAF729575
-          SceSysmemForKernel_B16D5136: 0xB16D5136
-          SceSysmemForKernel_B339A865: 0xB339A865
-          SceSysmemForKernel_B3E2AA7A: 0xB3E2AA7A
-          SceSysmemForKernel_B543A23C: 0xB543A23C
-          SceSysmemForKernel_B60568F9: 0xB60568F9
-          SceSysmemForKernel_B8D769C6: 0xB8D769C6
-          SceSysmemForKernel_BC2E2B2B: 0xBC2E2B2B
-          SceSysmemForKernel_BF0294E4: 0xBF0294E4
-          SceSysmemForKernel_BF04FC83: 0xBF04FC83
-          SceSysmemForKernel_C0A4D2F3: 0xC0A4D2F3
-          SceSysmemForKernel_C0BF149E: 0xC0BF149E
-          SceSysmemForKernel_C105604E: 0xC105604E
-          SceSysmemForKernel_C2F7D8A4: 0xC2F7D8A4
-          SceSysmemForKernel_C38B4D52: 0xC38B4D52
-          SceSysmemForKernel_C69666C3: 0xC69666C3
-          SceSysmemForKernel_C6F04370: 0xC6F04370
-          SceSysmemForKernel_C8672A3D: 0xC8672A3D
-          SceSysmemForKernel_CA91B9D5: 0xCA91B9D5
-          SceSysmemForKernel_CB8D03C0: 0xCB8D03C0
-          SceSysmemForKernel_CC7BB240: 0xCC7BB240
-          SceSysmemForKernel_CD985AEB: 0xCD985AEB
-          SceSysmemForKernel_CE72839E: 0xCE72839E
-          SceSysmemForKernel_CEBA8031: 0xCEBA8031
-          SceSysmemForKernel_CF53EEE4: 0xCF53EEE4
-          SceSysmemForKernel_CF5A2311: 0xCF5A2311
-          SceSysmemForKernel_D449547B: 0xD449547B
-          SceSysmemForKernel_D514BB56: 0xD514BB56
-          SceSysmemForKernel_D7B323EB: 0xD7B323EB
-          SceSysmemForKernel_E443253B: 0xE443253B
-          SceSysmemForKernel_E65EA709: 0xE65EA709
-          SceSysmemForKernel_E68A9F1B: 0xE68A9F1B
-          SceSysmemForKernel_E7938BFB: 0xE7938BFB
-          SceSysmemForKernel_E90CFD62: 0xE90CFD62
-          SceSysmemForKernel_EB350679: 0xEB350679
-          SceSysmemForKernel_EC1293D2: 0xEC1293D2
-          SceSysmemForKernel_EC7D36EF: 0xEC7D36EF
-          SceSysmemForKernel_ECC68E7B: 0xECC68E7B
-          SceSysmemForKernel_ECF9435A: 0xECF9435A
-          SceSysmemForKernel_ED221825: 0xED221825
-          SceSysmemForKernel_EEB85560: 0xEEB85560
-          SceSysmemForKernel_F0C3FCFC: 0xF0C3FCFC
-          SceSysmemForKernel_F1433852: 0xF1433852
-          SceSysmemForKernel_F2179820: 0xF2179820
-          SceSysmemForKernel_F2D7FE3A: 0xF2D7FE3A
-          SceSysmemForKernel_F4FA0575: 0xF4FA0575
-          SceSysmemForKernel_F7250E6C: 0xF7250E6C
-          SceSysmemForKernel_F81F4672: 0xF81F4672
-          SceSysmemForKernel_F8E95A5A: 0xF8E95A5A
-          SceSysmemForKernel_FAD03241: 0xFAD03241
-          SceSysmemForKernel_FAF96C1F: 0xFAF96C1F
-          SceSysmemForKernel_FC74A355: 0xFC74A355
-          SceSysmemForKernel_FDC0EA11: 0xFDC0EA11
-          SceSysmemForKernel_FEF54604: 0xFEF54604
           ksceKernelCreateUidObj: 0xDF0288D7
           ksceKernelRxMemcpyKernelToUserForPid: 0x30931572
       SceSysmemForDriver:
         nid: 0x6F25E18A
         kernel: true
         functions:
-          SceSysmemForDriver_00575B00: 0x00575B00
-          SceSysmemForDriver_04059C4B: 0x04059C4B
-          SceSysmemForDriver_08A8A7E8: 0x08A8A7E8
-          SceSysmemForDriver_09896EB7: 0x09896EB7
-          SceSysmemForDriver_0AAA4FDD: 0x0AAA4FDD
-          SceSysmemForDriver_0B1FD5C3: 0x0B1FD5C3
-          SceSysmemForDriver_0B4ED16A: 0x0B4ED16A
-          SceSysmemForDriver_0FC24464: 0x0FC24464
-          SceSysmemForDriver_12624884: 0x12624884
-          SceSysmemForDriver_13805CA8: 0x13805CA8
-          SceSysmemForDriver_16713BE8: 0x16713BE8
-          SceSysmemForDriver_16844CE6: 0x16844CE6
-          SceSysmemForDriver_184172B1: 0x184172B1
-          SceSysmemForDriver_19A51AC7: 0x19A51AC7
-          SceSysmemForDriver_1BD44DD5: 0x1BD44DD5
-          SceSysmemForDriver_1EFC96EA: 0x1EFC96EA
-          SceSysmemForDriver_20C811FA: 0x20C811FA
-          SceSysmemForDriver_22CBE925: 0x22CBE925
-          SceSysmemForDriver_24A99FFF: 0x24A99FFF
-          SceSysmemForDriver_2D711589: 0x2D711589
-          SceSysmemForDriver_32257A24: 0x32257A24
-          SceSysmemForDriver_49D4DD9B: 0x49D4DD9B
-          SceSysmemForDriver_4C584B29: 0x4C584B29
-          SceSysmemForDriver_4CFA4100: 0x4CFA4100
-          SceSysmemForDriver_513B9DDD: 0x513B9DDD
-          SceSysmemForDriver_59A4402F: 0x59A4402F
-          SceSysmemForDriver_61A67D32: 0x61A67D32
-          SceSysmemForDriver_64DBE472: 0x64DBE472
-          SceSysmemForDriver_65419BD3: 0x65419BD3
-          SceSysmemForDriver_659586BF: 0x659586BF
-          SceSysmemForDriver_6A0792A3: 0x6A0792A3
-          SceSysmemForDriver_6C76AD89: 0x6C76AD89
-          SceSysmemForDriver_72A98D17: 0x72A98D17
-          SceSysmemForDriver_75C70DE0: 0x75C70DE0
-          SceSysmemForDriver_77066FD1: 0x77066FD1
-          SceSysmemForDriver_7750CEA7: 0x7750CEA7
-          SceSysmemForDriver_78337B62: 0x78337B62
-          SceSysmemForDriver_856FA2E3: 0x856FA2E3
-          SceSysmemForDriver_857F1D5A: 0x857F1D5A
-          SceSysmemForDriver_89475192: 0x89475192
-          SceSysmemForDriver_89A44858: 0x89A44858
-          SceSysmemForDriver_8C43B052: 0x8C43B052
-          SceSysmemForDriver_8DA0BCA5: 0x8DA0BCA5
-          SceSysmemForDriver_987EE587: 0x987EE587
-          SceSysmemForDriver_98C15666: 0x98C15666
-          SceSysmemForDriver_9C78064C: 0x9C78064C
-          SceSysmemForDriver_9F6E45E3: 0x9F6E45E3
-          SceSysmemForDriver_A73CFFEF: 0xA73CFFEF
-          SceSysmemForDriver_A78755EB: 0xA78755EB
-          SceSysmemForDriver_A7C0D1FC: 0xA7C0D1FC
-          SceSysmemForDriver_A8525B06: 0xA8525B06
-          SceSysmemForDriver_AE36C775: 0xAE36C775
-          SceSysmemForDriver_B3575090: 0xB3575090
-          SceSysmemForDriver_B415B5A8: 0xB415B5A8
-          SceSysmemForDriver_B81CF0A3: 0xB81CF0A3
-          SceSysmemForDriver_BB3B02C2: 0xBB3B02C2
-          SceSysmemForDriver_BC0A1D60: 0xBC0A1D60
-          SceSysmemForDriver_BDA6E42B: 0xBDA6E42B
-          SceSysmemForDriver_C50A9C0D: 0xC50A9C0D
-          SceSysmemForDriver_C74B0152: 0xC74B0152
-          SceSysmemForDriver_C9928F5E: 0xC9928F5E
-          SceSysmemForDriver_CB0F3A33: 0xCB0F3A33
-          SceSysmemForDriver_CED1547B: 0xCED1547B
-          SceSysmemForDriver_D44F464D: 0xD44F464D
-          SceSysmemForDriver_D76E7452: 0xD76E7452
-          SceSysmemForDriver_E655852F: 0xE655852F
-          SceSysmemForDriver_E83855FD: 0xE83855FD
-          SceSysmemForDriver_E9728A12: 0xE9728A12
-          SceSysmemForDriver_EAF3849B: 0xEAF3849B
-          SceSysmemForDriver_F3BBE2E1: 0xF3BBE2E1
-          SceSysmemForDriver_F4AD89D8: 0xF4AD89D8
-          SceSysmemForDriver_F50BDC0C: 0xF50BDC0C
-          SceSysmemForDriver_F6DB54BA: 0xF6DB54BA
-          SceSysmemForDriver_FB817A59: 0xFB817A59
-          SceSysmemForDriver_FE6D7FAE: 0xFE6D7FAE
           ksceKernelAllocHeapMemory: 0x7B4CB60A
           ksceKernelAllocMemBlock: 0xC94850C9
           ksceKernelCreateClass: 0x61317102
@@ -2056,21 +1814,12 @@ modules:
         nid: 0xAE004C0A
         kernel: false
         functions:
-          SceDebugLed_0E6B9890: 0x0E6B9890
-          SceDebugLed_2B6EABAD: 0x2B6EABAD
           sceKernelGetGPI: 0x14F582CF
           sceKernelSetGPO: 0x78E702D3
       SceDebugLedForDriver:
         nid: 0x7BC05EAD
         kernel: true
         functions:
-          SceDebugLedForDriver_098473B0: 0x098473B0
-          SceDebugLedForDriver_0E6B9890: 0x0E6B9890
-          SceDebugLedForDriver_24173819: 0x24173819
-          SceDebugLedForDriver_2B6EABAD: 0x2B6EABAD
-          SceDebugLedForDriver_3BB289F7: 0x3BB289F7
-          SceDebugLedForDriver_51C5325A: 0x51C5325A
-          SceDebugLedForDriver_F62154E7: 0xF62154E7
           ksceKernelGetGPI: 0x14F582CF
           ksceKernelSetGPO: 0x78E702D3
       SceDipsw:
@@ -2084,7 +1833,6 @@ modules:
         nid: 0xC9E26388
         kernel: true
         functions:
-          SceDipswForDriver_B2AD48BE: 0xB2AD48BE
           ksceKernelCheckDipsw: 0xA98FC2FD
           ksceKernelClearDipsw: 0xF1F3E9FE
           ksceKernelSetDipsw: 0x82E45FBF
@@ -2100,18 +1848,6 @@ modules:
         nid: 0x88C17370
         kernel: true
         functions:
-          SceDebugForKernel_082B8D6A: 0x082B8D6A
-          SceDebugForKernel_1526DD83: 0x1526DD83
-          SceDebugForKernel_254A4997: 0x254A4997
-          SceDebugForKernel_25E31E18: 0x25E31E18
-          SceDebugForKernel_66D82EC8: 0x66D82EC8
-          SceDebugForKernel_B5943011: 0xB5943011
-          SceDebugForKernel_BE2C05A2: 0xBE2C05A2
-          SceDebugForKernel_BEF921A2: 0xBEF921A2
-          SceDebugForKernel_CE9060F1: 0xCE9060F1
-          SceDebugForKernel_EFF9962B: 0xEFF9962B
-          SceDebugForKernel_F1F861CF: 0xF1F861CF
-          SceDebugForKernel_F624CE22: 0xF624CE22
           ksceDebugDisableInfoDump: 0xF857CDD6
           ksceDebugGetPutcharHandler: 0xE783518C
           ksceDebugPutchar: 0x82D2EDCE
@@ -2121,54 +1857,12 @@ modules:
         nid: 0x88758561
         kernel: true
         functions:
-          SceDebugForDriver_00CCE39C: 0x00CCE39C
-          SceDebugForDriver_1A3F2AA4: 0x1A3F2AA4
-          SceDebugForDriver_35A35322: 0x35A35322
-          SceDebugForDriver_374B7868: 0x374B7868
-          SceDebugForDriver_391B5B74: 0x391B5B74
-          SceDebugForDriver_411C0733: 0x411C0733
-          SceDebugForDriver_611A158B: 0x611A158B
-          SceDebugForDriver_62466B0A: 0x62466B0A
-          SceDebugForDriver_821A2D59: 0x821A2D59
-          SceDebugForDriver_912CF2BA: 0x912CF2BA
-          SceDebugForDriver_95B38C6C: 0x95B38C6C
-          SceDebugForDriver_CC5365D3: 0xCC5365D3
-          SceDebugForDriver_D9703808: 0xD9703808
-          SceDebugForDriver_FD753E7A: 0xFD753E7A
           ksceDebugPrintf2: 0x02B04343
           ksceDebugPrintf: 0x391B74B7
       SceSysclibForDriver:
         nid: 0x7EE45391
         kernel: true
         functions:
-          SceSysclibForDriver_12504E09: 0x12504E09
-          SceSysclibForDriver_1A30BB28: 0x1A30BB28
-          SceSysclibForDriver_224BE33F: 0x224BE33F
-          SceSysclibForDriver_2518CD9E: 0x2518CD9E
-          SceSysclibForDriver_33EE298B: 0x33EE298B
-          SceSysclibForDriver_35DBB110: 0x35DBB110
-          SceSysclibForDriver_3DDBE2E1: 0x3DDBE2E1
-          SceSysclibForDriver_4E5042DA: 0x4E5042DA
-          SceSysclibForDriver_545DA5FD: 0x545DA5FD
-          SceSysclibForDriver_709077A1: 0x709077A1
-          SceSysclibForDriver_72D31F9D: 0x72D31F9D
-          SceSysclibForDriver_7554AB04: 0x7554AB04
-          SceSysclibForDriver_7DBE7007: 0x7DBE7007
-          SceSysclibForDriver_87AAAFA2: 0x87AAAFA2
-          SceSysclibForDriver_8A0B0815: 0x8A0B0815
-          SceSysclibForDriver_96268C53: 0x96268C53
-          SceSysclibForDriver_9D148CDE: 0x9D148CDE
-          SceSysclibForDriver_AC86B4BA: 0xAC86B4BA
-          SceSysclibForDriver_B5A4D745: 0xB5A4D745
-          SceSysclibForDriver_CBF64DF6: 0xCBF64DF6
-          SceSysclibForDriver_CDF7F155: 0xCDF7F155
-          SceSysclibForDriver_CF86EA38: 0xCF86EA38
-          SceSysclibForDriver_DE4666F0: 0xDE4666F0
-          SceSysclibForDriver_E38E7605: 0xE38E7605
-          SceSysclibForDriver_E46C47E6: 0xE46C47E6
-          SceSysclibForDriver_FE39AEAC: 0xFE39AEAC
-          SceSysclibForDriver_FE900DE8: 0xFE900DE8
-          SceSysclibForDriver_FEE5E751: 0xFEE5E751
           __aeabi_uidiv: 0xA9FF1205
           __aeabi_uidivmod: 0xA46CB7DE
           __stack_chk_fail: 0xB997493D
@@ -2196,138 +1890,6 @@ modules:
         nid: 0x3691DA45
         kernel: true
         functions:
-          SceSysrootForKernel_06182D59: 0x06182D59
-          SceSysrootForKernel_085C2BCB: 0x085C2BCB
-          SceSysrootForKernel_0A12227B: 0x0A12227B
-          SceSysrootForKernel_0B79E220: 0x0B79E220
-          SceSysrootForKernel_0DF574A9: 0x0DF574A9
-          SceSysrootForKernel_0EB5D7CD: 0x0EB5D7CD
-          SceSysrootForKernel_0F2F2B4E: 0x0F2F2B4E
-          SceSysrootForKernel_118657C6: 0x118657C6
-          SceSysrootForKernel_1247A825: 0x1247A825
-          SceSysrootForKernel_14D81797: 0x14D81797
-          SceSysrootForKernel_1D84C4D4: 0x1D84C4D4
-          SceSysrootForKernel_1D8DB3A5: 0x1D8DB3A5
-          SceSysrootForKernel_20009397: 0x20009397
-          SceSysrootForKernel_20D2A0DF: 0x20D2A0DF
-          SceSysrootForKernel_21F5790B: 0x21F5790B
-          SceSysrootForKernel_256B2394: 0x256B2394
-          SceSysrootForKernel_26458702: 0x26458702
-          SceSysrootForKernel_27D30DB2: 0x27D30DB2
-          SceSysrootForKernel_2A03DFA1: 0x2A03DFA1
-          SceSysrootForKernel_2D6B2A79: 0x2D6B2A79
-          SceSysrootForKernel_2F75C1DC: 0x2F75C1DC
-          SceSysrootForKernel_2F97041A: 0x2F97041A
-          SceSysrootForKernel_340575CB: 0x340575CB
-          SceSysrootForKernel_36916C30: 0x36916C30
-          SceSysrootForKernel_377895EB: 0x377895EB
-          SceSysrootForKernel_37EC12BB: 0x37EC12BB
-          SceSysrootForKernel_38751FB7: 0x38751FB7
-          SceSysrootForKernel_3999F917: 0x3999F917
-          SceSysrootForKernel_3ACACD22: 0x3ACACD22
-          SceSysrootForKernel_3F76D531: 0x3F76D531
-          SceSysrootForKernel_403B509E: 0x403B509E
-          SceSysrootForKernel_40F28DC6: 0x40F28DC6
-          SceSysrootForKernel_41636522: 0x41636522
-          SceSysrootForKernel_42FC9FFF: 0x42FC9FFF
-          SceSysrootForKernel_47724459: 0x47724459
-          SceSysrootForKernel_491CE8DF: 0x491CE8DF
-          SceSysrootForKernel_4F0A4066: 0x4F0A4066
-          SceSysrootForKernel_4F57A13F: 0x4F57A13F
-          SceSysrootForKernel_571E5B79: 0x571E5B79
-          SceSysrootForKernel_59B76D23: 0x59B76D23
-          SceSysrootForKernel_5B5EBFB1: 0x5B5EBFB1
-          SceSysrootForKernel_5C426B19: 0x5C426B19
-          SceSysrootForKernel_5C86E49B: 0x5C86E49B
-          SceSysrootForKernel_5F2CE289: 0x5F2CE289
-          SceSysrootForKernel_6050A467: 0x6050A467
-          SceSysrootForKernel_611F17A4: 0x611F17A4
-          SceSysrootForKernel_62E8F511: 0x62E8F511
-          SceSysrootForKernel_63EBB05B: 0x63EBB05B
-          SceSysrootForKernel_642123EB: 0x642123EB
-          SceSysrootForKernel_6C036B53: 0x6C036B53
-          SceSysrootForKernel_6D111FA7: 0x6D111FA7
-          SceSysrootForKernel_6D44F190: 0x6D44F190
-          SceSysrootForKernel_71DB83A2: 0x71DB83A2
-          SceSysrootForKernel_7334F1E8: 0x7334F1E8
-          SceSysrootForKernel_733C243E: 0x733C243E
-          SceSysrootForKernel_73522F65: 0x73522F65
-          SceSysrootForKernel_73601453: 0x73601453
-          SceSysrootForKernel_7385CADE: 0x7385CADE
-          SceSysrootForKernel_77CF3FBD: 0x77CF3FBD
-          SceSysrootForKernel_7918D44E: 0x7918D44E
-          SceSysrootForKernel_7968F091: 0x7968F091
-          SceSysrootForKernel_7A7E7C0C: 0x7A7E7C0C
-          SceSysrootForKernel_7B7ED1E9: 0x7B7ED1E9
-          SceSysrootForKernel_7B7F8171: 0x7B7F8171
-          SceSysrootForKernel_7FC7A163: 0x7FC7A163
-          SceSysrootForKernel_82FC6405: 0x82FC6405
-          SceSysrootForKernel_84783B71: 0x84783B71
-          SceSysrootForKernel_8498E23F: 0x8498E23F
-          SceSysrootForKernel_84C0BE05: 0x84C0BE05
-          SceSysrootForKernel_8747D415: 0x8747D415
-          SceSysrootForKernel_88DE85EF: 0x88DE85EF
-          SceSysrootForKernel_89532E2F: 0x89532E2F
-          SceSysrootForKernel_8E4B61F1: 0x8E4B61F1
-          SceSysrootForKernel_9139E22B: 0x9139E22B
-          SceSysrootForKernel_9991B1AF: 0x9991B1AF
-          SceSysrootForKernel_9A8871F1: 0x9A8871F1
-          SceSysrootForKernel_9CFF80F9: 0x9CFF80F9
-          SceSysrootForKernel_9D058A32: 0x9D058A32
-          SceSysrootForKernel_A799F22A: 0xA799F22A
-          SceSysrootForKernel_A84676E3: 0xA84676E3
-          SceSysrootForKernel_A9510EFE: 0xA9510EFE
-          SceSysrootForKernel_AA8D34EE: 0xAA8D34EE
-          SceSysrootForKernel_AB3CC7D0: 0xAB3CC7D0
-          SceSysrootForKernel_AD74BEB3: 0xAD74BEB3
-          SceSysrootForKernel_AE2132FD: 0xAE2132FD
-          SceSysrootForKernel_AE55B7CC: 0xAE55B7CC
-          SceSysrootForKernel_AE7A8F1D: 0xAE7A8F1D
-          SceSysrootForKernel_B171CC2D: 0xB171CC2D
-          SceSysrootForKernel_B27B7530: 0xB27B7530
-          SceSysrootForKernel_B39CD708: 0xB39CD708
-          SceSysrootForKernel_B4C24588: 0xB4C24588
-          SceSysrootForKernel_B501E861: 0xB501E861
-          SceSysrootForKernel_BBFD2E3C: 0xBBFD2E3C
-          SceSysrootForKernel_BE1EF51C: 0xBE1EF51C
-          SceSysrootForKernel_BF82931F: 0xBF82931F
-          SceSysrootForKernel_C5EAF5F7: 0xC5EAF5F7
-          SceSysrootForKernel_C67A1FA9: 0xC67A1FA9
-          SceSysrootForKernel_C728BC61: 0xC728BC61
-          SceSysrootForKernel_C81B7E2B: 0xC81B7E2B
-          SceSysrootForKernel_C8C8C321: 0xC8C8C321
-          SceSysrootForKernel_CA497324: 0xCA497324
-          SceSysrootForKernel_CA8D1A2B: 0xCA8D1A2B
-          SceSysrootForKernel_CBD377B7: 0xCBD377B7
-          SceSysrootForKernel_CC119171: 0xCC119171
-          SceSysrootForKernel_CC7A0E63: 0xCC7A0E63
-          SceSysrootForKernel_CC85905B: 0xCC85905B
-          SceSysrootForKernel_CC893F37: 0xCC893F37
-          SceSysrootForKernel_CCB8BB5E: 0xCCB8BB5E
-          SceSysrootForKernel_CD4B84F7: 0xCD4B84F7
-          SceSysrootForKernel_CD8B5D37: 0xCD8B5D37
-          SceSysrootForKernel_D02281A8: 0xD02281A8
-          SceSysrootForKernel_D29BCA77: 0xD29BCA77
-          SceSysrootForKernel_D351EBC8: 0xD351EBC8
-          SceSysrootForKernel_D3872270: 0xD3872270
-          SceSysrootForKernel_D441DC34: 0xD441DC34
-          SceSysrootForKernel_D4457D4F: 0xD4457D4F
-          SceSysrootForKernel_D7198963: 0xD7198963
-          SceSysrootForKernel_D7207203: 0xD7207203
-          SceSysrootForKernel_DADFF828: 0xDADFF828
-          SceSysrootForKernel_DD7821AA: 0xDD7821AA
-          SceSysrootForKernel_E20F6FC8: 0xE20F6FC8
-          SceSysrootForKernel_E4EA1960: 0xE4EA1960
-          SceSysrootForKernel_ECADF8C3: 0xECADF8C3
-          SceSysrootForKernel_EEB867C0: 0xEEB867C0
-          SceSysrootForKernel_F2BC9E1D: 0xF2BC9E1D
-          SceSysrootForKernel_F4340469: 0xF4340469
-          SceSysrootForKernel_F6A6D205: 0xF6A6D205
-          SceSysrootForKernel_F8769E86: 0xF8769E86
-          SceSysrootForKernel_FBB91741: 0xFBB91741
-          SceSysrootForKernel_FF44A7BA: 0xFF44A7BA
-          SceSysrootForKernel_FF9F80FF: 0xFF9F80FF
-          SceSysrootForKernel_FFD6E24D: 0xFFD6E24D
           ksceKernelGetProcessTitleId: 0xEC3124A3
           ksceKernelGetSysbase: 0x3E455842
           ksceKernelGetSysrootBuffer: 0x9DB56D1F
@@ -2343,21 +1905,6 @@ modules:
         nid: 0x496AD8B4
         kernel: true
         functions:
-          SceKernelUtilsForDriver_0C39954E: 0x0C39954E
-          SceKernelUtilsForDriver_1DF3792A: 0x1DF3792A
-          SceKernelUtilsForDriver_222986EF: 0x222986EF
-          SceKernelUtilsForDriver_227B2E53: 0x227B2E53
-          SceKernelUtilsForDriver_335AF34D: 0x335AF34D
-          SceKernelUtilsForDriver_60ED6EA9: 0x60ED6EA9
-          SceKernelUtilsForDriver_801D0ED4: 0x801D0ED4
-          SceKernelUtilsForDriver_919C12E2: 0x919C12E2
-          SceKernelUtilsForDriver_A0D45D25: 0xA0D45D25
-          SceKernelUtilsForDriver_AE6C45FB: 0xAE6C45FB
-          SceKernelUtilsForDriver_AFD56168: 0xAFD56168
-          SceKernelUtilsForDriver_B55C69B7: 0xB55C69B7
-          SceKernelUtilsForDriver_BB6E35CD: 0xBB6E35CD
-          SceKernelUtilsForDriver_C76A7685: 0xC76A7685
-          SceKernelUtilsForDriver_D428CC2A: 0xD428CC2A
           ksceAESDecrypt2: 0xE39CD272
           ksceAESDecrypt: 0xD8678061
           ksceAESEncrypt2: 0x302947B6
@@ -2404,30 +1951,6 @@ modules:
         nid: 0x7290B21C
         kernel: true
         functions:
-          SceKernelSuspendForDriver_0106C0F0: 0x0106C0F0
-          SceKernelSuspendForDriver_0A6CA124: 0x0A6CA124
-          SceKernelSuspendForDriver_0DE3CC02: 0x0DE3CC02
-          SceKernelSuspendForDriver_105C5752: 0x105C5752
-          SceKernelSuspendForDriver_1FA2F8F1: 0x1FA2F8F1
-          SceKernelSuspendForDriver_230495ED: 0x230495ED
-          SceKernelSuspendForDriver_250ACD90: 0x250ACD90
-          SceKernelSuspendForDriver_254525F8: 0x254525F8
-          SceKernelSuspendForDriver_2BB92967: 0x2BB92967
-          SceKernelSuspendForDriver_4DF40893: 0x4DF40893
-          SceKernelSuspendForDriver_4E5A3A23: 0x4E5A3A23
-          SceKernelSuspendForDriver_6A503956: 0x6A503956
-          SceKernelSuspendForDriver_81D9E41C: 0x81D9E41C
-          SceKernelSuspendForDriver_8B3F02B8: 0x8B3F02B8
-          SceKernelSuspendForDriver_AEA9440D: 0xAEA9440D
-          SceKernelSuspendForDriver_B4B13615: 0xB4B13615
-          SceKernelSuspendForDriver_B5C58EE8: 0xB5C58EE8
-          SceKernelSuspendForDriver_C00826AC: 0xC00826AC
-          SceKernelSuspendForDriver_CE7A2207: 0xCE7A2207
-          SceKernelSuspendForDriver_D4958E6F: 0xD4958E6F
-          SceKernelSuspendForDriver_D6124071: 0xD6124071
-          SceKernelSuspendForDriver_E677B343: 0xE677B343
-          SceKernelSuspendForDriver_F2B07167: 0xF2B07167
-          SceKernelSuspendForDriver_FE2118BD: 0xFE2118BD
           ksceKernelNotifySuspendCallback: 0xD4622EA8
           ksceKernelPowerTick: 0xE0489831
           ksceKernelRegisterSuspendCallback: 0x04C05D10
@@ -2436,49 +1959,14 @@ modules:
         nid: 0x4E29D3B6
         kernel: true
         functions:
-          SceQafMgrForDriver_082A4FC2: 0x082A4FC2
-          SceQafMgrForDriver_0E588747: 0x0E588747
-          SceQafMgrForDriver_10283EB8: 0x10283EB8
-          SceQafMgrForDriver_36E5312E: 0x36E5312E
-          SceQafMgrForDriver_382C71E8: 0x382C71E8
-          SceQafMgrForDriver_3CB55F98: 0x3CB55F98
-          SceQafMgrForDriver_41E04800: 0x41E04800
-          SceQafMgrForDriver_4BC1883F: 0x4BC1883F
-          SceQafMgrForDriver_52B4E164: 0x52B4E164
-          SceQafMgrForDriver_694D1096: 0x694D1096
-          SceQafMgrForDriver_70A67A4B: 0x70A67A4B
-          SceQafMgrForDriver_7B14DC45: 0x7B14DC45
-          SceQafMgrForDriver_883E9465: 0x883E9465
-          SceQafMgrForDriver_8C423C18: 0x8C423C18
-          SceQafMgrForDriver_9644171D: 0x9644171D
-          SceQafMgrForDriver_AE033133: 0xAE033133
-          SceQafMgrForDriver_B7B195B2: 0xB7B195B2
-          SceQafMgrForDriver_B9770A13: 0xB9770A13
-          SceQafMgrForDriver_BFD5E463: 0xBFD5E463
-          SceQafMgrForDriver_C1EA75C8: 0xC1EA75C8
-          SceQafMgrForDriver_CAD47130: 0xCAD47130
-          SceQafMgrForDriver_DEC6DF4E: 0xDEC6DF4E
-          SceQafMgrForDriver_E573F124: 0xE573F124
-          SceQafMgrForDriver_E8B8F31F: 0xE8B8F31F
-          SceQafMgrForDriver_F8BFEE48: 0xF8BFEE48
       ScePmMgrForDriver:
         nid: 0xF13F32F9
         kernel: true
         functions:
-          ScePmMgrForDriver_2AC815A2: 0x2AC815A2
-          ScePmMgrForDriver_BD1F193B: 0xBD1F193B
       SceSblAIMgrForDriver:
         nid: 0xFD00C69A
         kernel: true
         functions:
-          SceSblAIMgrForDriver_05F79D4A: 0x05F79D4A
-          SceSblAIMgrForDriver_14345161: 0x14345161
-          SceSblAIMgrForDriver_37A79140: 0x37A79140
-          SceSblAIMgrForDriver_6D5A3FC9: 0x6D5A3FC9
-          SceSblAIMgrForDriver_B33CEC8F: 0xB33CEC8F
-          SceSblAIMgrForDriver_BB9D146B: 0xBB9D146B
-          SceSblAIMgrForDriver_E5E47FF7: 0xE5E47FF7
-          SceSblAIMgrForDriver_FF5784B9: 0xFF5784B9
           ksceSblAimgrGetSMI: 0x47D9CF13
           ksceSblAimgrIsCEX: 0xD78B04A2
           ksceSblAimgrIsDEX: 0xF4B98F66
@@ -2492,186 +1980,10 @@ modules:
         nid: 0x887F19D0
         kernel: true
         functions:
-          SceProcEventForDriver_2A43912D: 0x2A43912D
-          SceProcEventForDriver_3DED57CC: 0x3DED57CC
-          SceProcEventForDriver_414CC813: 0x414CC813
       SceSysrootForDriver:
         nid: 0x2ED7F97A
         kernel: true
         functions:
-          SceSysrootForDriver_05093E7B: 0x05093E7B
-          SceSysrootForDriver_05CD0DD9: 0x05CD0DD9
-          SceSysrootForDriver_06436EF0: 0x06436EF0
-          SceSysrootForDriver_0A52A59C: 0x0A52A59C
-          SceSysrootForDriver_0ECD711E: 0x0ECD711E
-          SceSysrootForDriver_0F07C3FC: 0x0F07C3FC
-          SceSysrootForDriver_0F59B369: 0x0F59B369
-          SceSysrootForDriver_10788257: 0x10788257
-          SceSysrootForDriver_1160FCA1: 0x1160FCA1
-          SceSysrootForDriver_1434D90E: 0x1434D90E
-          SceSysrootForDriver_17DD213C: 0x17DD213C
-          SceSysrootForDriver_1834D482: 0x1834D482
-          SceSysrootForDriver_1B3FA457: 0x1B3FA457
-          SceSysrootForDriver_1BA0C6C1: 0x1BA0C6C1
-          SceSysrootForDriver_1D61C837: 0x1D61C837
-          SceSysrootForDriver_1FFD2AFA: 0x1FFD2AFA
-          SceSysrootForDriver_20D2A0DF: 0x20D2A0DF
-          SceSysrootForDriver_217B2871: 0x217B2871
-          SceSysrootForDriver_246AAAB3: 0x246AAAB3
-          SceSysrootForDriver_256B2394: 0x256B2394
-          SceSysrootForDriver_26AA237C: 0x26AA237C
-          SceSysrootForDriver_273EAE53: 0x273EAE53
-          SceSysrootForDriver_27D30DB2: 0x27D30DB2
-          SceSysrootForDriver_2816A813: 0x2816A813
-          SceSysrootForDriver_2A5DBD38: 0x2A5DBD38
-          SceSysrootForDriver_2BE874EF: 0x2BE874EF
-          SceSysrootForDriver_2C9E7797: 0x2C9E7797
-          SceSysrootForDriver_2D6B2A79: 0x2D6B2A79
-          SceSysrootForDriver_3276086B: 0x3276086B
-          SceSysrootForDriver_34281746: 0x34281746
-          SceSysrootForDriver_35875119: 0x35875119
-          SceSysrootForDriver_377895EB: 0x377895EB
-          SceSysrootForDriver_38751FB7: 0x38751FB7
-          SceSysrootForDriver_3999F917: 0x3999F917
-          SceSysrootForDriver_39F1FD07: 0x39F1FD07
-          SceSysrootForDriver_39F9C968: 0x39F9C968
-          SceSysrootForDriver_3ACACD22: 0x3ACACD22
-          SceSysrootForDriver_3AE319DA: 0x3AE319DA
-          SceSysrootForDriver_3B19B06B: 0x3B19B06B
-          SceSysrootForDriver_3F76D531: 0x3F76D531
-          SceSysrootForDriver_400B9793: 0x400B9793
-          SceSysrootForDriver_40F28DC6: 0x40F28DC6
-          SceSysrootForDriver_421EFC96: 0x421EFC96
-          SceSysrootForDriver_42FC9FFF: 0x42FC9FFF
-          SceSysrootForDriver_44EA3197: 0x44EA3197
-          SceSysrootForDriver_47724459: 0x47724459
-          SceSysrootForDriver_47F19DD3: 0x47F19DD3
-          SceSysrootForDriver_483EF108: 0x483EF108
-          SceSysrootForDriver_49843C16: 0x49843C16
-          SceSysrootForDriver_4D98B15B: 0x4D98B15B
-          SceSysrootForDriver_51F9C118: 0x51F9C118
-          SceSysrootForDriver_525B24C5: 0x525B24C5
-          SceSysrootForDriver_5458BF6D: 0x5458BF6D
-          SceSysrootForDriver_56C4C949: 0x56C4C949
-          SceSysrootForDriver_56D85EB0: 0x56D85EB0
-          SceSysrootForDriver_571E5B79: 0x571E5B79
-          SceSysrootForDriver_579CC758: 0x579CC758
-          SceSysrootForDriver_582616EC: 0x582616EC
-          SceSysrootForDriver_591BB490: 0x591BB490
-          SceSysrootForDriver_5A4A7F7E: 0x5A4A7F7E
-          SceSysrootForDriver_5A7FFDC1: 0x5A7FFDC1
-          SceSysrootForDriver_5B106EB3: 0x5B106EB3
-          SceSysrootForDriver_5C86E49B: 0x5C86E49B
-          SceSysrootForDriver_6050A467: 0x6050A467
-          SceSysrootForDriver_6219CC14: 0x6219CC14
-          SceSysrootForDriver_631141E2: 0x631141E2
-          SceSysrootForDriver_65F3D598: 0x65F3D598
-          SceSysrootForDriver_6655F48C: 0x6655F48C
-          SceSysrootForDriver_67AAB627: 0x67AAB627
-          SceSysrootForDriver_6C036B53: 0x6C036B53
-          SceSysrootForDriver_6D44F190: 0x6D44F190
-          SceSysrootForDriver_6E0BC27C: 0x6E0BC27C
-          SceSysrootForDriver_709799BB: 0x709799BB
-          SceSysrootForDriver_70A60BBA: 0x70A60BBA
-          SceSysrootForDriver_70AD47A9: 0x70AD47A9
-          SceSysrootForDriver_71DB83A2: 0x71DB83A2
-          SceSysrootForDriver_73522F65: 0x73522F65
-          SceSysrootForDriver_778D0966: 0x778D0966
-          SceSysrootForDriver_77CF3FBD: 0x77CF3FBD
-          SceSysrootForDriver_7918D44E: 0x7918D44E
-          SceSysrootForDriver_79458ACB: 0x79458ACB
-          SceSysrootForDriver_7998F5B5: 0x7998F5B5
-          SceSysrootForDriver_7AAC4EE7: 0x7AAC4EE7
-          SceSysrootForDriver_7B4A377C: 0x7B4A377C
-          SceSysrootForDriver_7B7ED1E9: 0x7B7ED1E9
-          SceSysrootForDriver_7B7F8171: 0x7B7F8171
-          SceSysrootForDriver_7C0BE393: 0x7C0BE393
-          SceSysrootForDriver_7C2C10E2: 0x7C2C10E2
-          SceSysrootForDriver_80FBC69D: 0x80FBC69D
-          SceSysrootForDriver_82FC6405: 0x82FC6405
-          SceSysrootForDriver_8498E23F: 0x8498E23F
-          SceSysrootForDriver_84C0BE05: 0x84C0BE05
-          SceSysrootForDriver_8747D415: 0x8747D415
-          SceSysrootForDriver_89532E2F: 0x89532E2F
-          SceSysrootForDriver_8A760856: 0x8A760856
-          SceSysrootForDriver_8AA268D6: 0x8AA268D6
-          SceSysrootForDriver_8B8F1D01: 0x8B8F1D01
-          SceSysrootForDriver_8CD02748: 0x8CD02748
-          SceSysrootForDriver_930B1342: 0x930B1342
-          SceSysrootForDriver_93CD44CD: 0x93CD44CD
-          SceSysrootForDriver_9421B223: 0x9421B223
-          SceSysrootForDriver_951C7943: 0x951C7943
-          SceSysrootForDriver_97E2FB77: 0x97E2FB77
-          SceSysrootForDriver_9A486846: 0x9A486846
-          SceSysrootForDriver_9A8871F1: 0x9A8871F1
-          SceSysrootForDriver_9AF075D4: 0x9AF075D4
-          SceSysrootForDriver_9BF782CA: 0x9BF782CA
-          SceSysrootForDriver_9CDE3623: 0x9CDE3623
-          SceSysrootForDriver_9CFF80F9: 0x9CFF80F9
-          SceSysrootForDriver_9D058A32: 0x9D058A32
-          SceSysrootForDriver_9DCD0894: 0x9DCD0894
-          SceSysrootForDriver_9E96D990: 0x9E96D990
-          SceSysrootForDriver_9EC02A41: 0x9EC02A41
-          SceSysrootForDriver_A12C9950: 0xA12C9950
-          SceSysrootForDriver_A43599E9: 0xA43599E9
-          SceSysrootForDriver_A6A0A038: 0xA6A0A038
-          SceSysrootForDriver_A799F22A: 0xA799F22A
-          SceSysrootForDriver_A7A01DF0: 0xA7A01DF0
-          SceSysrootForDriver_A85FF3B2: 0xA85FF3B2
-          SceSysrootForDriver_A9510EFE: 0xA9510EFE
-          SceSysrootForDriver_AA770EF7: 0xAA770EF7
-          SceSysrootForDriver_AA8D34EE: 0xAA8D34EE
-          SceSysrootForDriver_AE7A8F1D: 0xAE7A8F1D
-          SceSysrootForDriver_B0E3E791: 0xB0E3E791
-          SceSysrootForDriver_B27B7530: 0xB27B7530
-          SceSysrootForDriver_B501E861: 0xB501E861
-          SceSysrootForDriver_BFD8F2A2: 0xBFD8F2A2
-          SceSysrootForDriver_C5EAF5F7: 0xC5EAF5F7
-          SceSysrootForDriver_C67A1FA9: 0xC67A1FA9
-          SceSysrootForDriver_C728BC61: 0xC728BC61
-          SceSysrootForDriver_C81B7E2B: 0xC81B7E2B
-          SceSysrootForDriver_C94C76FA: 0xC94C76FA
-          SceSysrootForDriver_CA497324: 0xCA497324
-          SceSysrootForDriver_CAE820B2: 0xCAE820B2
-          SceSysrootForDriver_CC7A0E63: 0xCC7A0E63
-          SceSysrootForDriver_CCB8BB5E: 0xCCB8BB5E
-          SceSysrootForDriver_CD4B84F7: 0xCD4B84F7
-          SceSysrootForDriver_CD8CD242: 0xCD8CD242
-          SceSysrootForDriver_D02281A8: 0xD02281A8
-          SceSysrootForDriver_D03741B8: 0xD03741B8
-          SceSysrootForDriver_D04C7723: 0xD04C7723
-          SceSysrootForDriver_D1E54BF4: 0xD1E54BF4
-          SceSysrootForDriver_D2423D6B: 0xD2423D6B
-          SceSysrootForDriver_D4457D4F: 0xD4457D4F
-          SceSysrootForDriver_D56A2F3E: 0xD56A2F3E
-          SceSysrootForDriver_D7207203: 0xD7207203
-          SceSysrootForDriver_D75D4F37: 0xD75D4F37
-          SceSysrootForDriver_D86BD6DC: 0xD86BD6DC
-          SceSysrootForDriver_DABD4A47: 0xDABD4A47
-          SceSysrootForDriver_DC651D22: 0xDC651D22
-          SceSysrootForDriver_DD473B05: 0xDD473B05
-          SceSysrootForDriver_E06C14FD: 0xE06C14FD
-          SceSysrootForDriver_E2515A08: 0xE2515A08
-          SceSysrootForDriver_E25D2FD5: 0xE25D2FD5
-          SceSysrootForDriver_E2E88E3E: 0xE2E88E3E
-          SceSysrootForDriver_E384DD93: 0xE384DD93
-          SceSysrootForDriver_E4EA1960: 0xE4EA1960
-          SceSysrootForDriver_E541959B: 0xE541959B
-          SceSysrootForDriver_E8EBF179: 0xE8EBF179
-          SceSysrootForDriver_E9B4221F: 0xE9B4221F
-          SceSysrootForDriver_EB19AAF6: 0xEB19AAF6
-          SceSysrootForDriver_ECADF8C3: 0xECADF8C3
-          SceSysrootForDriver_ED22CF8F: 0xED22CF8F
-          SceSysrootForDriver_ED688AEE: 0xED688AEE
-          SceSysrootForDriver_EE5D6CE9: 0xEE5D6CE9
-          SceSysrootForDriver_EE934615: 0xEE934615
-          SceSysrootForDriver_EEF091A7: 0xEEF091A7
-          SceSysrootForDriver_F0C91CD3: 0xF0C91CD3
-          SceSysrootForDriver_F2BC9E1D: 0xF2BC9E1D
-          SceSysrootForDriver_F404026C: 0xF404026C
-          SceSysrootForDriver_F4340469: 0xF4340469
-          SceSysrootForDriver_F804F761: 0xF804F761
-          SceSysrootForDriver_FF2DD7AB: 0xFF2DD7AB
           ksceSysrootIsAuCodecIcConexant: 0x46E72428
           ksceSysrootIsBsodReboot: 0x4373AC96
           ksceSysrootIsExternalBootMode: 0x89D19090
@@ -2689,38 +2001,6 @@ modules:
         nid: 0x54BF2BAB
         kernel: true
         functions:
-          SceCpuForKernel_04008CF7: 0x04008CF7
-          SceCpuForKernel_1BB2BB8D: 0x1BB2BB8D
-          SceCpuForKernel_2A46E800: 0x2A46E800
-          SceCpuForKernel_337473B5: 0x337473B5
-          SceCpuForKernel_37FBFD12: 0x37FBFD12
-          SceCpuForKernel_43CC6E20: 0x43CC6E20
-          SceCpuForKernel_4553FBDE: 0x4553FBDE
-          SceCpuForKernel_470EAE1E: 0x470EAE1E
-          SceCpuForKernel_4C4C7D6B: 0x4C4C7D6B
-          SceCpuForKernel_4CD4D921: 0x4CD4D921
-          SceCpuForKernel_583F30D1: 0x583F30D1
-          SceCpuForKernel_5B6B3274: 0x5B6B3274
-          SceCpuForKernel_5F64E5ED: 0x5F64E5ED
-          SceCpuForKernel_6190A018: 0x6190A018
-          SceCpuForKernel_67343A07: 0x67343A07
-          SceCpuForKernel_6C7E7B57: 0x6C7E7B57
-          SceCpuForKernel_76EB0DD4: 0x76EB0DD4
-          SceCpuForKernel_7FB4E7AC: 0x7FB4E7AC
-          SceCpuForKernel_8510FA52: 0x8510FA52
-          SceCpuForKernel_98E91C1C: 0x98E91C1C
-          SceCpuForKernel_9A3281C0: 0x9A3281C0
-          SceCpuForKernel_9B8173F4: 0x9B8173F4
-          SceCpuForKernel_9CB82EB0: 0x9CB82EB0
-          SceCpuForKernel_9D72DD1B: 0x9D72DD1B
-          SceCpuForKernel_A5C9DBBA: 0xA5C9DBBA
-          SceCpuForKernel_AEE0B489: 0xAEE0B489
-          SceCpuForKernel_C5C1EE4E: 0xC5C1EE4E
-          SceCpuForKernel_C8E8C9E9: 0xC8E8C9E9
-          SceCpuForKernel_D0D85FF8: 0xD0D85FF8
-          SceCpuForKernel_D37AABE5: 0xD37AABE5
-          SceCpuForKernel_D8A7216C: 0xD8A7216C
-          SceCpuForKernel_F7159B55: 0xF7159B55
           ksceKernelCpuDcacheInvalidateAll: 0x2F3BF020
           ksceKernelCpuDcacheWritebackAll: 0x73A30DB2
           ksceKernelCpuDcacheWritebackInvalidateAll: 0x76DAB4D0
@@ -2733,101 +2013,6 @@ modules:
         nid: 0x40ECDB0E
         kernel: true
         functions:
-          SceCpuForDriver_004F09D1: 0x004F09D1
-          SceCpuForDriver_03887992: 0x03887992
-          SceCpuForDriver_043FD446: 0x043FD446
-          SceCpuForDriver_06CCFA4B: 0x06CCFA4B
-          SceCpuForDriver_0836537E: 0x0836537E
-          SceCpuForDriver_085532C8: 0x085532C8
-          SceCpuForDriver_093925BD: 0x093925BD
-          SceCpuForDriver_0EE04C03: 0x0EE04C03
-          SceCpuForDriver_0F84AFE9: 0x0F84AFE9
-          SceCpuForDriver_10EB35EB: 0x10EB35EB
-          SceCpuForDriver_18A17E07: 0x18A17E07
-          SceCpuForDriver_1B3336B0: 0x1B3336B0
-          SceCpuForDriver_1BE58599: 0x1BE58599
-          SceCpuForDriver_1E850481: 0x1E850481
-          SceCpuForDriver_1F157DC3: 0x1F157DC3
-          SceCpuForDriver_2149CD4C: 0x2149CD4C
-          SceCpuForDriver_225DF91A: 0x225DF91A
-          SceCpuForDriver_267D0B33: 0x267D0B33
-          SceCpuForDriver_26F71995: 0x26F71995
-          SceCpuForDriver_27C0B340: 0x27C0B340
-          SceCpuForDriver_29599FC8: 0x29599FC8
-          SceCpuForDriver_2A40BB93: 0x2A40BB93
-          SceCpuForDriver_2A71B03C: 0x2A71B03C
-          SceCpuForDriver_3168BC57: 0x3168BC57
-          SceCpuForDriver_32B62B1A: 0x32B62B1A
-          SceCpuForDriver_337CBDF3: 0x337CBDF3
-          SceCpuForDriver_341B6E81: 0x341B6E81
-          SceCpuForDriver_3627F4E0: 0x3627F4E0
-          SceCpuForDriver_382D1466: 0x382D1466
-          SceCpuForDriver_3E218AF7: 0x3E218AF7
-          SceCpuForDriver_3EE9B5B8: 0x3EE9B5B8
-          SceCpuForDriver_3F42B434: 0x3F42B434
-          SceCpuForDriver_4244BE65: 0x4244BE65
-          SceCpuForDriver_45153D4E: 0x45153D4E
-          SceCpuForDriver_4A820BC5: 0x4A820BC5
-          SceCpuForDriver_4AE1BCC0: 0x4AE1BCC0
-          SceCpuForDriver_4B527009: 0x4B527009
-          SceCpuForDriver_4C38CE4D: 0x4C38CE4D
-          SceCpuForDriver_4E459A03: 0x4E459A03
-          SceCpuForDriver_4F7790B4: 0x4F7790B4
-          SceCpuForDriver_515682C9: 0x515682C9
-          SceCpuForDriver_532CA3E8: 0x532CA3E8
-          SceCpuForDriver_55760309: 0x55760309
-          SceCpuForDriver_59F74E94: 0x59F74E94
-          SceCpuForDriver_5AC9D394: 0x5AC9D394
-          SceCpuForDriver_5CC62CEC: 0x5CC62CEC
-          SceCpuForDriver_5D515F1B: 0x5D515F1B
-          SceCpuForDriver_5E4D5DE1: 0x5E4D5DE1
-          SceCpuForDriver_5F6A8743: 0x5F6A8743
-          SceCpuForDriver_646003D6: 0x646003D6
-          SceCpuForDriver_692C51B3: 0x692C51B3
-          SceCpuForDriver_6B050D7C: 0x6B050D7C
-          SceCpuForDriver_6F63F56D: 0x6F63F56D
-          SceCpuForDriver_711801E6: 0x711801E6
-          SceCpuForDriver_740A0750: 0x740A0750
-          SceCpuForDriver_77E34309: 0x77E34309
-          SceCpuForDriver_78C1F148: 0x78C1F148
-          SceCpuForDriver_7B43D0D7: 0x7B43D0D7
-          SceCpuForDriver_875B094D: 0x875B094D
-          SceCpuForDriver_88BA6002: 0x88BA6002
-          SceCpuForDriver_8E538AB5: 0x8E538AB5
-          SceCpuForDriver_8E9C086D: 0x8E9C086D
-          SceCpuForDriver_9A693F5B: 0x9A693F5B
-          SceCpuForDriver_9EC91017: 0x9EC91017
-          SceCpuForDriver_A4884C4E: 0xA4884C4E
-          SceCpuForDriver_A7585370: 0xA7585370
-          SceCpuForDriver_ADD39B84: 0xADD39B84
-          SceCpuForDriver_B281D52A: 0xB281D52A
-          SceCpuForDriver_B5F8919C: 0xB5F8919C
-          SceCpuForDriver_BAF47F7B: 0xBAF47F7B
-          SceCpuForDriver_BC248C30: 0xBC248C30
-          SceCpuForDriver_BDF6F8E4: 0xBDF6F8E4
-          SceCpuForDriver_BF82DEB2: 0xBF82DEB2
-          SceCpuForDriver_C381CE8C: 0xC381CE8C
-          SceCpuForDriver_C3868071: 0xC3868071
-          SceCpuForDriver_CAC9AE80: 0xCAC9AE80
-          SceCpuForDriver_CB73D6D5: 0xCB73D6D5
-          SceCpuForDriver_CB8ABDF0: 0xCB8ABDF0
-          SceCpuForDriver_CDA96E81: 0xCDA96E81
-          SceCpuForDriver_D18E7B54: 0xD18E7B54
-          SceCpuForDriver_D2DEE625: 0xD2DEE625
-          SceCpuForDriver_D6ED0C46: 0xD6ED0C46
-          SceCpuForDriver_D8E675C0: 0xD8E675C0
-          SceCpuForDriver_DE6482C6: 0xDE6482C6
-          SceCpuForDriver_DF899E4B: 0xDF899E4B
-          SceCpuForDriver_E212ECAD: 0xE212ECAD
-          SceCpuForDriver_E36F3A46: 0xE36F3A46
-          SceCpuForDriver_E551F99B: 0xE551F99B
-          SceCpuForDriver_E813EBB2: 0xE813EBB2
-          SceCpuForDriver_EB085370: 0xEB085370
-          SceCpuForDriver_EC53D007: 0xEC53D007
-          SceCpuForDriver_F02467D1: 0xF02467D1
-          SceCpuForDriver_F5FD5676: 0xF5FD5676
-          SceCpuForDriver_F891CF2A: 0xF891CF2A
-          SceCpuForDriver_FCDCD4DE: 0xFCDCD4DE
           ksceKernelCpuDcacheAndL2InvalidateRange: 0x02796361
           ksceKernelCpuDcacheAndL2WritebackInvalidateRange: 0x364E68A4
           ksceKernelCpuDcacheAndL2WritebackRange: 0x103872A5
@@ -2844,241 +2029,19 @@ modules:
         nid: 0xA8CA0EFD
         kernel: true
         functions:
-          SceThreadmgrForKernel_000DF999: 0x000DF999
-          SceThreadmgrForKernel_02EEDF17: 0x02EEDF17
-          SceThreadmgrForKernel_091322E5: 0x091322E5
-          SceThreadmgrForKernel_09444C33: 0x09444C33
-          SceThreadmgrForKernel_09CEAAA4: 0x09CEAAA4
-          SceThreadmgrForKernel_14ADCC1F: 0x14ADCC1F
-          SceThreadmgrForKernel_150AEF74: 0x150AEF74
-          SceThreadmgrForKernel_15AAB4F9: 0x15AAB4F9
-          SceThreadmgrForKernel_17A4E56B: 0x17A4E56B
-          SceThreadmgrForKernel_1928DFBB: 0x1928DFBB
-          SceThreadmgrForKernel_2EC8E376: 0x2EC8E376
-          SceThreadmgrForKernel_315869B6: 0x315869B6
-          SceThreadmgrForKernel_333B26AD: 0x333B26AD
-          SceThreadmgrForKernel_3B4B8293: 0x3B4B8293
-          SceThreadmgrForKernel_3CD03673: 0x3CD03673
-          SceThreadmgrForKernel_41BCA03A: 0x41BCA03A
-          SceThreadmgrForKernel_41CF346A: 0x41CF346A
-          SceThreadmgrForKernel_43D13895: 0x43D13895
-          SceThreadmgrForKernel_4679280D: 0x4679280D
-          SceThreadmgrForKernel_4C3887B4: 0x4C3887B4
-          SceThreadmgrForKernel_5785D18E: 0x5785D18E
-          SceThreadmgrForKernel_5A410D2B: 0x5A410D2B
-          SceThreadmgrForKernel_5AB30D35: 0x5AB30D35
-          SceThreadmgrForKernel_6ECCDCBD: 0x6ECCDCBD
-          SceThreadmgrForKernel_72E5DA4E: 0x72E5DA4E
-          SceThreadmgrForKernel_766028E7: 0x766028E7
-          SceThreadmgrForKernel_796D3A65: 0x796D3A65
-          SceThreadmgrForKernel_82F080A8: 0x82F080A8
-          SceThreadmgrForKernel_87B3D598: 0x87B3D598
-          SceThreadmgrForKernel_88D5BC33: 0x88D5BC33
-          SceThreadmgrForKernel_8B6F201E: 0x8B6F201E
-          SceThreadmgrForKernel_8F3E9E35: 0x8F3E9E35
-          SceThreadmgrForKernel_97780FA6: 0x97780FA6
-          SceThreadmgrForKernel_9C96317A: 0x9C96317A
-          SceThreadmgrForKernel_9F5ECAD5: 0x9F5ECAD5
-          SceThreadmgrForKernel_A1939BC9: 0xA1939BC9
-          SceThreadmgrForKernel_A4127F82: 0xA4127F82
-          SceThreadmgrForKernel_AEA9213B: 0xAEA9213B
-          SceThreadmgrForKernel_AEEE955F: 0xAEEE955F
-          SceThreadmgrForKernel_BE5247A2: 0xBE5247A2
-          SceThreadmgrForKernel_C75A4609: 0xC75A4609
-          SceThreadmgrForKernel_CC1D6D9F: 0xCC1D6D9F
-          SceThreadmgrForKernel_CE99E69C: 0xCE99E69C
-          SceThreadmgrForKernel_D2BE5EFB: 0xD2BE5EFB
-          SceThreadmgrForKernel_D8117AFB: 0xD8117AFB
-          SceThreadmgrForKernel_D8B9AC8D: 0xD8B9AC8D
-          SceThreadmgrForKernel_DBE2EE32: 0xDBE2EE32
-          SceThreadmgrForKernel_E00333A6: 0xE00333A6
-          SceThreadmgrForKernel_E0833C77: 0xE0833C77
-          SceThreadmgrForKernel_E3CE20AA: 0xE3CE20AA
-          SceThreadmgrForKernel_E92C1784: 0xE92C1784
-          SceThreadmgrForKernel_F282AE42: 0xF282AE42
-          SceThreadmgrForKernel_F74B7E34: 0xF74B7E34
-          SceThreadmgrForKernel_F9BD4A0D: 0xF9BD4A0D
-          SceThreadmgrForKernel_FA53F581: 0xFA53F581
-          ksceKernelCreateMutexForKernel: 0xFBAA026E
-          ksceKernelCreateSemaForKernel: 0x30E93C31
-          ksceKernelDeleteMutexForKernel: 0x0A912340
-          ksceKernelDeleteSemaForKernel: 0x16A35E58
-          ksceKernelLockMutex_089ForKernel: 0x16AC80C5
-          ksceKernelRunWithStackForKernel: 0xE54FD746
-          ksceKernelSignalSemaForKernel: 0xD270498B
-          ksceKernelUnlockMutex_089ForKernel: 0x1E82E5D0
-          ksceKernelWaitSemaForKernel: 0x3C8B55A9
+          ksceKernelCreateMutex: 0xFBAA026E
+          ksceKernelCreateSema: 0x30E93C31
+          ksceKernelDeleteMutex: 0x0A912340
+          ksceKernelDeleteSema: 0x16A35E58
+          ksceKernelLockMutex_089: 0x16AC80C5
+          ksceKernelRunWithStack: 0xE54FD746
+          ksceKernelSignalSema: 0xD270498B
+          ksceKernelUnlockMutex_089: 0x1E82E5D0
+          ksceKernelWaitSema: 0x3C8B55A9
       SceThreadmgrForDriver:
         nid: 0xE2C40624
         kernel: true
         functions:
-          SceThreadmgrForDriver_02EEDF17: 0x02EEDF17
-          SceThreadmgrForDriver_032E8F73: 0x032E8F73
-          SceThreadmgrForDriver_04150799: 0x04150799
-          SceThreadmgrForDriver_04C6764B: 0x04C6764B
-          SceThreadmgrForDriver_069D8A20: 0x069D8A20
-          SceThreadmgrForDriver_09346D1A: 0x09346D1A
-          SceThreadmgrForDriver_0A4AD37A: 0x0A4AD37A
-          SceThreadmgrForDriver_0B604A3C: 0x0B604A3C
-          SceThreadmgrForDriver_0C6BCB8C: 0x0C6BCB8C
-          SceThreadmgrForDriver_0D0644DA: 0x0D0644DA
-          SceThreadmgrForDriver_0EB0ABF0: 0x0EB0ABF0
-          SceThreadmgrForDriver_10517330: 0x10517330
-          SceThreadmgrForDriver_1096042E: 0x1096042E
-          SceThreadmgrForDriver_12FC0FAB: 0x12FC0FAB
-          SceThreadmgrForDriver_1378F6EF: 0x1378F6EF
-          SceThreadmgrForDriver_14F8167C: 0x14F8167C
-          SceThreadmgrForDriver_15287EF6: 0x15287EF6
-          SceThreadmgrForDriver_154F2C2A: 0x154F2C2A
-          SceThreadmgrForDriver_19F3E92A: 0x19F3E92A
-          SceThreadmgrForDriver_1AAFA818: 0x1AAFA818
-          SceThreadmgrForDriver_207E0E18: 0x207E0E18
-          SceThreadmgrForDriver_20C228E4: 0x20C228E4
-          SceThreadmgrForDriver_2322A2F3: 0x2322A2F3
-          SceThreadmgrForDriver_25AB8F6B: 0x25AB8F6B
-          SceThreadmgrForDriver_2828F884: 0x2828F884
-          SceThreadmgrForDriver_2B60B793: 0x2B60B793
-          SceThreadmgrForDriver_2BDE3B40: 0x2BDE3B40
-          SceThreadmgrForDriver_2E95B628: 0x2E95B628
-          SceThreadmgrForDriver_2F9F75AA: 0x2F9F75AA
-          SceThreadmgrForDriver_2FC0FFF6: 0x2FC0FFF6
-          SceThreadmgrForDriver_32452017: 0x32452017
-          SceThreadmgrForDriver_332E127C: 0x332E127C
-          SceThreadmgrForDriver_33E85E9E: 0x33E85E9E
-          SceThreadmgrForDriver_357A8177: 0x357A8177
-          SceThreadmgrForDriver_360C655C: 0x360C655C
-          SceThreadmgrForDriver_3634FFE6: 0x3634FFE6
-          SceThreadmgrForDriver_36F8E58A: 0x36F8E58A
-          SceThreadmgrForDriver_374C3267: 0x374C3267
-          SceThreadmgrForDriver_37F51E91: 0x37F51E91
-          SceThreadmgrForDriver_3857C94E: 0x3857C94E
-          SceThreadmgrForDriver_385831A1: 0x385831A1
-          SceThreadmgrForDriver_3A72C6D8: 0x3A72C6D8
-          SceThreadmgrForDriver_3C297724: 0x3C297724
-          SceThreadmgrForDriver_3F5E1D56: 0x3F5E1D56
-          SceThreadmgrForDriver_419E6736: 0x419E6736
-          SceThreadmgrForDriver_44CCF310: 0x44CCF310
-          SceThreadmgrForDriver_453B764A: 0x453B764A
-          SceThreadmgrForDriver_477F7C8A: 0x477F7C8A
-          SceThreadmgrForDriver_47F26712: 0x47F26712
-          SceThreadmgrForDriver_48C06CD6: 0x48C06CD6
-          SceThreadmgrForDriver_49A0B679: 0x49A0B679
-          SceThreadmgrForDriver_4A038803: 0x4A038803
-          SceThreadmgrForDriver_4CF1BE58: 0x4CF1BE58
-          SceThreadmgrForDriver_4DE77569: 0x4DE77569
-          SceThreadmgrForDriver_5022689D: 0x5022689D
-          SceThreadmgrForDriver_5053B005: 0x5053B005
-          SceThreadmgrForDriver_5311CFB5: 0x5311CFB5
-          SceThreadmgrForDriver_54566860: 0x54566860
-          SceThreadmgrForDriver_54E1AF04: 0x54E1AF04
-          SceThreadmgrForDriver_555CA6BB: 0x555CA6BB
-          SceThreadmgrForDriver_56C18B11: 0x56C18B11
-          SceThreadmgrForDriver_5870C73A: 0x5870C73A
-          SceThreadmgrForDriver_5CDE387A: 0x5CDE387A
-          SceThreadmgrForDriver_5D8F88B1: 0x5D8F88B1
-          SceThreadmgrForDriver_612277C9: 0x612277C9
-          SceThreadmgrForDriver_64E89DE9: 0x64E89DE9
-          SceThreadmgrForDriver_6624E612: 0x6624E612
-          SceThreadmgrForDriver_6657429E: 0x6657429E
-          SceThreadmgrForDriver_67022B18: 0x67022B18
-          SceThreadmgrForDriver_67DD3BAD: 0x67DD3BAD
-          SceThreadmgrForDriver_6C2E3A49: 0x6C2E3A49
-          SceThreadmgrForDriver_6D0733A8: 0x6D0733A8
-          SceThreadmgrForDriver_6D4C1EB7: 0x6D4C1EB7
-          SceThreadmgrForDriver_70131EA5: 0x70131EA5
-          SceThreadmgrForDriver_714A107A: 0x714A107A
-          SceThreadmgrForDriver_738FF63D: 0x738FF63D
-          SceThreadmgrForDriver_741F4707: 0x741F4707
-          SceThreadmgrForDriver_767CA30C: 0x767CA30C
-          SceThreadmgrForDriver_771522C6: 0x771522C6
-          SceThreadmgrForDriver_7A4EF925: 0x7A4EF925
-          SceThreadmgrForDriver_7D12344A: 0x7D12344A
-          SceThreadmgrForDriver_7E280B69: 0x7E280B69
-          SceThreadmgrForDriver_84EB1EA4: 0x84EB1EA4
-          SceThreadmgrForDriver_85F4DC8C: 0x85F4DC8C
-          SceThreadmgrForDriver_86DAE59B: 0x86DAE59B
-          SceThreadmgrForDriver_8760C8ED: 0x8760C8ED
-          SceThreadmgrForDriver_88206D29: 0x88206D29
-          SceThreadmgrForDriver_89CA5698: 0x89CA5698
-          SceThreadmgrForDriver_8C3C1F78: 0x8C3C1F78
-          SceThreadmgrForDriver_8C48E53B: 0x8C48E53B
-          SceThreadmgrForDriver_8C8A76EF: 0x8C8A76EF
-          SceThreadmgrForDriver_90656C98: 0x90656C98
-          SceThreadmgrForDriver_91382762: 0x91382762
-          SceThreadmgrForDriver_91A8F38B: 0x91A8F38B
-          SceThreadmgrForDriver_920EA1CA: 0x920EA1CA
-          SceThreadmgrForDriver_92A3DCDD: 0x92A3DCDD
-          SceThreadmgrForDriver_995F32E1: 0x995F32E1
-          SceThreadmgrForDriver_9D6A2311: 0x9D6A2311
-          SceThreadmgrForDriver_A0B1AB21: 0xA0B1AB21
-          SceThreadmgrForDriver_A64B00F6: 0xA64B00F6
-          SceThreadmgrForDriver_A90B1E01: 0xA90B1E01
-          SceThreadmgrForDriver_AB977C72: 0xAB977C72
-          SceThreadmgrForDriver_AF302193: 0xAF302193
-          SceThreadmgrForDriver_B247EC4B: 0xB247EC4B
-          SceThreadmgrForDriver_B3453F88: 0xB3453F88
-          SceThreadmgrForDriver_B4A05763: 0xB4A05763
-          SceThreadmgrForDriver_B4CED111: 0xB4CED111
-          SceThreadmgrForDriver_B5C782A3: 0xB5C782A3
-          SceThreadmgrForDriver_B645C7EF: 0xB645C7EF
-          SceThreadmgrForDriver_B6DA4669: 0xB6DA4669
-          SceThreadmgrForDriver_B6FA8305: 0xB6FA8305
-          SceThreadmgrForDriver_B7DF3EDF: 0xB7DF3EDF
-          SceThreadmgrForDriver_B92709C4: 0xB92709C4
-          SceThreadmgrForDriver_BF631145: 0xBF631145
-          SceThreadmgrForDriver_C03799E2: 0xC03799E2
-          SceThreadmgrForDriver_C2AFFBD0: 0xC2AFFBD0
-          SceThreadmgrForDriver_C2DA6286: 0xC2DA6286
-          SceThreadmgrForDriver_C327CA7C: 0xC327CA7C
-          SceThreadmgrForDriver_C4456EC9: 0xC4456EC9
-          SceThreadmgrForDriver_C529EA32: 0xC529EA32
-          SceThreadmgrForDriver_C58DF384: 0xC58DF384
-          SceThreadmgrForDriver_C6741986: 0xC6741986
-          SceThreadmgrForDriver_C7F5FFE0: 0xC7F5FFE0
-          SceThreadmgrForDriver_C8E57BB4: 0xC8E57BB4
-          SceThreadmgrForDriver_C99DCF0D: 0xC99DCF0D
-          SceThreadmgrForDriver_CA704239: 0xCA704239
-          SceThreadmgrForDriver_CB795E13: 0xCB795E13
-          SceThreadmgrForDriver_CBA7FAAA: 0xCBA7FAAA
-          SceThreadmgrForDriver_CE09221A: 0xCE09221A
-          SceThreadmgrForDriver_CFA2FFAF: 0xCFA2FFAF
-          SceThreadmgrForDriver_D0262C55: 0xD0262C55
-          SceThreadmgrForDriver_D08C71C6: 0xD08C71C6
-          SceThreadmgrForDriver_D1FBDFA6: 0xD1FBDFA6
-          SceThreadmgrForDriver_D26BFF26: 0xD26BFF26
-          SceThreadmgrForDriver_D41F53D4: 0xD41F53D4
-          SceThreadmgrForDriver_D7455187: 0xD7455187
-          SceThreadmgrForDriver_D74F66BD: 0xD74F66BD
-          SceThreadmgrForDriver_D7AF2E58: 0xD7AF2E58
-          SceThreadmgrForDriver_D978D16F: 0xD978D16F
-          SceThreadmgrForDriver_DA1544D1: 0xDA1544D1
-          SceThreadmgrForDriver_DBB77032: 0xDBB77032
-          SceThreadmgrForDriver_DD8D9429: 0xDD8D9429
-          SceThreadmgrForDriver_E0C7BCBB: 0xE0C7BCBB
-          SceThreadmgrForDriver_E2B57231: 0xE2B57231
-          SceThreadmgrForDriver_E50E1185: 0xE50E1185
-          SceThreadmgrForDriver_E5CAD3E2: 0xE5CAD3E2
-          SceThreadmgrForDriver_E605ED7A: 0xE605ED7A
-          SceThreadmgrForDriver_E6D80698: 0xE6D80698
-          SceThreadmgrForDriver_E938FB20: 0xE938FB20
-          SceThreadmgrForDriver_E9A99C50: 0xE9A99C50
-          SceThreadmgrForDriver_E9E50096: 0xE9E50096
-          SceThreadmgrForDriver_EA211225: 0xEA211225
-          SceThreadmgrForDriver_EA7B8AEF: 0xEA7B8AEF
-          SceThreadmgrForDriver_EC8343DF: 0xEC8343DF
-          SceThreadmgrForDriver_F285C94F: 0xF285C94F
-          SceThreadmgrForDriver_F2C9DC97: 0xF2C9DC97
-          SceThreadmgrForDriver_F311808F: 0xF311808F
-          SceThreadmgrForDriver_F4C81683: 0xF4C81683
-          SceThreadmgrForDriver_F5074173: 0xF5074173
-          SceThreadmgrForDriver_F8A6013B: 0xF8A6013B
-          SceThreadmgrForDriver_F96FE0D5: 0xF96FE0D5
-          SceThreadmgrForDriver_FA54D49A: 0xFA54D49A
-          SceThreadmgrForDriver_FB3706CB: 0xFB3706CB
-          SceThreadmgrForDriver_FD6150D5: 0xFD6150D5
-          SceThreadmgrForDriver_FD87586C: 0xFD87586C
-          SceThreadmgrForDriver_FDC044AC: 0xFDC044AC
-          SceThreadmgrForDriver_FF8DA217: 0xFF8DA217
           ksceKernelCancelCallback: 0xC040EC1C
           ksceKernelCancelMutex_089: 0x7204B846
           ksceKernelChangeActiveCpuMask: 0x001173F8
@@ -3402,43 +2365,6 @@ modules:
         nid: 0x40FD29C7
         kernel: true
         functions:
-          SceIofilemgrForDriver_0D493274: 0x0D493274
-          SceIofilemgrForDriver_12F8D58E: 0x12F8D58E
-          SceIofilemgrForDriver_15C17487: 0x15C17487
-          SceIofilemgrForDriver_21D57633: 0x21D57633
-          SceIofilemgrForDriver_2EFDFA12: 0x2EFDFA12
-          SceIofilemgrForDriver_3675ECB9: 0x3675ECB9
-          SceIofilemgrForDriver_39ABDB9E: 0x39ABDB9E
-          SceIofilemgrForDriver_3A79FAC9: 0x3A79FAC9
-          SceIofilemgrForDriver_3F0FF9D5: 0x3F0FF9D5
-          SceIofilemgrForDriver_44EDCE57: 0x44EDCE57
-          SceIofilemgrForDriver_5B7E5AB8: 0x5B7E5AB8
-          SceIofilemgrForDriver_69A7E076: 0x69A7E076
-          SceIofilemgrForDriver_6B3CA9F7: 0x6B3CA9F7
-          SceIofilemgrForDriver_6BEEDDB4: 0x6BEEDDB4
-          SceIofilemgrForDriver_6D0FEDB6: 0x6D0FEDB6
-          SceIofilemgrForDriver_8F0DE34D: 0x8F0DE34D
-          SceIofilemgrForDriver_9FCDCE62: 0x9FCDCE62
-          SceIofilemgrForDriver_A1EF2648: 0xA1EF2648
-          SceIofilemgrForDriver_A39A9CA7: 0xA39A9CA7
-          SceIofilemgrForDriver_A7020B0D: 0xA7020B0D
-          SceIofilemgrForDriver_AA253B68: 0xAA253B68
-          SceIofilemgrForDriver_AC0E9AAA: 0xAC0E9AAA
-          SceIofilemgrForDriver_B499287E: 0xB499287E
-          SceIofilemgrForDriver_B987450D: 0xB987450D
-          SceIofilemgrForDriver_BBAC1751: 0xBBAC1751
-          SceIofilemgrForDriver_C20C621C: 0xC20C621C
-          SceIofilemgrForDriver_C3AE93A2: 0xC3AE93A2
-          SceIofilemgrForDriver_C468B5EF: 0xC468B5EF
-          SceIofilemgrForDriver_C722DF35: 0xC722DF35
-          SceIofilemgrForDriver_C85E33A2: 0xC85E33A2
-          SceIofilemgrForDriver_CCE94599: 0xCCE94599
-          SceIofilemgrForDriver_CDF3EF52: 0xCDF3EF52
-          SceIofilemgrForDriver_D6AB5E4B: 0xD6AB5E4B
-          SceIofilemgrForDriver_DC2D8BCE: 0xDC2D8BCE
-          SceIofilemgrForDriver_DCF75F6D: 0xDCF75F6D
-          SceIofilemgrForDriver_DD46CD63: 0xDD46CD63
-          SceIofilemgrForDriver_F4F8C59A: 0xF4F8C59A
           ksceIoCancel: 0x6D59658D
           ksceIoChstat: 0x7D42B8DC
           ksceIoChstatAsync: 0x7EC442BF
@@ -3655,42 +2581,6 @@ modules:
         nid: 0x746EC971
         kernel: true
         functions:
-          SceProcessmgrForDriver_00B1CA0F: 0x00B1CA0F
-          SceProcessmgrForDriver_0CC5B30C: 0x0CC5B30C
-          SceProcessmgrForDriver_11BEFBBE: 0x11BEFBBE
-          SceProcessmgrForDriver_1C70501E: 0x1C70501E
-          SceProcessmgrForDriver_1D0F3185: 0x1D0F3185
-          SceProcessmgrForDriver_21A6F0EC: 0x21A6F0EC
-          SceProcessmgrForDriver_24FA97A5: 0x24FA97A5
-          SceProcessmgrForDriver_2CEB1C7A: 0x2CEB1C7A
-          SceProcessmgrForDriver_33B3D026: 0x33B3D026
-          SceProcessmgrForDriver_3B33FFBA: 0x3B33FFBA
-          SceProcessmgrForDriver_4140D633: 0x4140D633
-          SceProcessmgrForDriver_46221964: 0x46221964
-          SceProcessmgrForDriver_5468892A: 0x5468892A
-          SceProcessmgrForDriver_54D469E2: 0x54D469E2
-          SceProcessmgrForDriver_594319C7: 0x594319C7
-          SceProcessmgrForDriver_5BDA978F: 0x5BDA978F
-          SceProcessmgrForDriver_5E882B60: 0x5E882B60
-          SceProcessmgrForDriver_61B9B6FA: 0x61B9B6FA
-          SceProcessmgrForDriver_6599E5D9: 0x6599E5D9
-          SceProcessmgrForDriver_65B120B8: 0x65B120B8
-          SceProcessmgrForDriver_879153D9: 0x879153D9
-          SceProcessmgrForDriver_8A85FA28: 0x8A85FA28
-          SceProcessmgrForDriver_8CB01675: 0x8CB01675
-          SceProcessmgrForDriver_9C28EA9A: 0x9C28EA9A
-          SceProcessmgrForDriver_A1CF74FA: 0xA1CF74FA
-          SceProcessmgrForDriver_B1C3EFCA: 0xB1C3EFCA
-          SceProcessmgrForDriver_B559410A: 0xB559410A
-          SceProcessmgrForDriver_B80DBD53: 0xB80DBD53
-          SceProcessmgrForDriver_BA0A06A4: 0xBA0A06A4
-          SceProcessmgrForDriver_C5CF15ED: 0xC5CF15ED
-          SceProcessmgrForDriver_C715591F: 0xC715591F
-          SceProcessmgrForDriver_D141C076: 0xD141C076
-          SceProcessmgrForDriver_DD0A58D1: 0xDD0A58D1
-          SceProcessmgrForDriver_E1A67C86: 0xE1A67C86
-          SceProcessmgrForDriver_E8005AFC: 0xE8005AFC
-          SceProcessmgrForDriver_FC2A424E: 0xFC2A424E
           ksceKernelCreateProcessLocalStorage: 0x3801D7D6
           ksceKernelGetPidProcessLocalStorageAddr: 0xAF80F39C
           ksceKernelGetProcessInfo: 0x0AFF3EAE
@@ -3705,61 +2595,6 @@ modules:
         nid: 0x7A69DE86
         kernel: true
         functions:
-          SceProcessmgrForKernel_029378AC: 0x029378AC
-          SceProcessmgrForKernel_05F74BAF: 0x05F74BAF
-          SceProcessmgrForKernel_080CDC59: 0x080CDC59
-          SceProcessmgrForKernel_0A5A2CF1: 0x0A5A2CF1
-          SceProcessmgrForKernel_0A60B40A: 0x0A60B40A
-          SceProcessmgrForKernel_0EE2658E: 0x0EE2658E
-          SceProcessmgrForKernel_1423FA86: 0x1423FA86
-          SceProcessmgrForKernel_15A93CD2: 0x15A93CD2
-          SceProcessmgrForKernel_20174234: 0x20174234
-          SceProcessmgrForKernel_234A80B6: 0x234A80B6
-          SceProcessmgrForKernel_2ABFB6C1: 0x2ABFB6C1
-          SceProcessmgrForKernel_31834C49: 0x31834C49
-          SceProcessmgrForKernel_34FA9645: 0x34FA9645
-          SceProcessmgrForKernel_36728B16: 0x36728B16
-          SceProcessmgrForKernel_381818A1: 0x381818A1
-          SceProcessmgrForKernel_38FB7BCA: 0x38FB7BCA
-          SceProcessmgrForKernel_3C4D2889: 0x3C4D2889
-          SceProcessmgrForKernel_3C5E2F08: 0x3C5E2F08
-          SceProcessmgrForKernel_41815DF2: 0x41815DF2
-          SceProcessmgrForKernel_54D7B16A: 0x54D7B16A
-          SceProcessmgrForKernel_59FA3216: 0x59FA3216
-          SceProcessmgrForKernel_5AC72C5A: 0x5AC72C5A
-          SceProcessmgrForKernel_62D048D2: 0x62D048D2
-          SceProcessmgrForKernel_6A7FF80A: 0x6A7FF80A
-          SceProcessmgrForKernel_6AECE4CD: 0x6AECE4CD
-          SceProcessmgrForKernel_71CF71FD: 0x71CF71FD
-          SceProcessmgrForKernel_76C89783: 0x76C89783
-          SceProcessmgrForKernel_7D8D7885: 0x7D8D7885
-          SceProcessmgrForKernel_8729DE79: 0x8729DE79
-          SceProcessmgrForKernel_89A0A910: 0x89A0A910
-          SceProcessmgrForKernel_8F320D2B: 0x8F320D2B
-          SceProcessmgrForKernel_90C27779: 0x90C27779
-          SceProcessmgrForKernel_915AB8D6: 0x915AB8D6
-          SceProcessmgrForKernel_9321D0E5: 0x9321D0E5
-          SceProcessmgrForKernel_95F9ED94: 0x95F9ED94
-          SceProcessmgrForKernel_A1071106: 0xA1071106
-          SceProcessmgrForKernel_A9C20202: 0xA9C20202
-          SceProcessmgrForKernel_ACBAAB10: 0xACBAAB10
-          SceProcessmgrForKernel_B13E3C7B: 0xB13E3C7B
-          SceProcessmgrForKernel_B75FB970: 0xB75FB970
-          SceProcessmgrForKernel_B7C91F6C: 0xB7C91F6C
-          SceProcessmgrForKernel_C031BFE0: 0xC031BFE0
-          SceProcessmgrForKernel_C1C91BB2: 0xC1C91BB2
-          SceProcessmgrForKernel_C55BF6C3: 0xC55BF6C3
-          SceProcessmgrForKernel_C6820972: 0xC6820972
-          SceProcessmgrForKernel_C77C2085: 0xC77C2085
-          SceProcessmgrForKernel_C7E75A8C: 0xC7E75A8C
-          SceProcessmgrForKernel_CCB4289B: 0xCCB4289B
-          SceProcessmgrForKernel_CF83C23B: 0xCF83C23B
-          SceProcessmgrForKernel_D17D6110: 0xD17D6110
-          SceProcessmgrForKernel_E0A9C9C4: 0xE0A9C9C4
-          SceProcessmgrForKernel_E5A60577: 0xE5A60577
-          SceProcessmgrForKernel_E7174A8D: 0xE7174A8D
-          SceProcessmgrForKernel_F3C4A83B: 0xF3C4A83B
-          SceProcessmgrForKernel_F7FFECF3: 0xF7FFECF3
           ksceKernelExitProcessForUser: 0x4CA7DC42
           ksceKernelGetProcessAuthid: 0xE4C83B0D
           ksceKernelGetProcessKernelBuf: 0xB9E68092
@@ -3772,66 +2607,6 @@ modules:
         nid: 0xCAE9ACE6
         kernel: false
         functions:
-          SceLibKernel_01E00CBF: 0x01E00CBF
-          SceLibKernel_023EAA62: 0x023EAA62
-          SceLibKernel_0A4DF821: 0x0A4DF821
-          SceLibKernel_104D802F: 0x104D802F
-          SceLibKernel_11E263A5: 0x11E263A5
-          SceLibKernel_12C7CD2B: 0x12C7CD2B
-          SceLibKernel_1693032E: 0x1693032E
-          SceLibKernel_17C0CEF4: 0x17C0CEF4
-          SceLibKernel_1F4DF829: 0x1F4DF829
-          SceLibKernel_20E2D4B7: 0x20E2D4B7
-          SceLibKernel_211BEDE8: 0x211BEDE8
-          SceLibKernel_22C9595E: 0x22C9595E
-          SceLibKernel_27E6DEDE: 0x27E6DEDE
-          SceLibKernel_297AA2AE: 0x297AA2AE
-          SceLibKernel_2E05B2DC: 0x2E05B2DC
-          SceLibKernel_2E3B02A1: 0x2E3B02A1
-          SceLibKernel_35D20E49: 0x35D20E49
-          SceLibKernel_37F4ED04: 0x37F4ED04
-          SceLibKernel_3B595E1D: 0x3B595E1D
-          SceLibKernel_499EA781: 0x499EA781
-          SceLibKernel_4AC7EFC9: 0x4AC7EFC9
-          SceLibKernel_56A59D4F: 0x56A59D4F
-          SceLibKernel_58DDAC4F: 0x58DDAC4F
-          SceLibKernel_5F9F0D61: 0x5F9F0D61
-          SceLibKernel_622A81E6: 0x622A81E6
-          SceLibKernel_6314CAA3: 0x6314CAA3
-          SceLibKernel_65126005: 0x65126005
-          SceLibKernel_6C7365C4: 0x6C7365C4
-          SceLibKernel_6D8C0F13: 0x6D8C0F13
-          SceLibKernel_6F9C4CC1: 0x6F9C4CC1
-          SceLibKernel_70867F93: 0x70867F93
-          SceLibKernel_774AE3CB: 0x774AE3CB
-          SceLibKernel_84C75DC3: 0x84C75DC3
-          SceLibKernel_88E72157: 0x88E72157
-          SceLibKernel_8AF15B5F: 0x8AF15B5F
-          SceLibKernel_91FA6614: 0x91FA6614
-          SceLibKernel_93A6570E: 0x93A6570E
-          SceLibKernel_9557D15C: 0x9557D15C
-          SceLibKernel_9B28E1AF: 0x9B28E1AF
-          SceLibKernel_9EF798C1: 0x9EF798C1
-          SceLibKernel_9F793F84: 0x9F793F84
-          SceLibKernel_A7819967: 0xA7819967
-          SceLibKernel_A9002567: 0xA9002567
-          SceLibKernel_AB4B5485: 0xAB4B5485
-          SceLibKernel_AC57B6A4: 0xAC57B6A4
-          SceLibKernel_BEF71602: 0xBEF71602
-          SceLibKernel_C362ECD6: 0xC362ECD6
-          SceLibKernel_C8082804: 0xC8082804
-          SceLibKernel_D7E10BB1: 0xD7E10BB1
-          SceLibKernel_DC277B4D: 0xDC277B4D
-          SceLibKernel_DEAD6277: 0xDEAD6277
-          SceLibKernel_E088B0D0: 0xE088B0D0
-          SceLibKernel_E2984A54: 0xE2984A54
-          SceLibKernel_E48476FE: 0xE48476FE
-          SceLibKernel_E633BAD1: 0xE633BAD1
-          SceLibKernel_EB02F15D: 0xEB02F15D
-          SceLibKernel_EB6DA895: 0xEB6DA895
-          SceLibKernel_EE2D40F7: 0xEE2D40F7
-          SceLibKernel_EFD76235: 0xEFD76235
-          SceLibKernel_F7027E6A: 0xF7027E6A
           __sce_aeabi_idiv0: 0x4373B548
           __sce_aeabi_ldiv0: 0xFB235848
           __stack_chk_fail: 0x37691BF8
@@ -4117,58 +2892,18 @@ modules:
         nid: 0x567AF9A6
         kernel: false
         functions:
-          SceLibGcc_0DFF2B2C: 0x0DFF2B2C
-          SceLibGcc_12472ADD: 0x12472ADD
-          SceLibGcc_29C2EB11: 0x29C2EB11
-          SceLibGcc_4BB45B70: 0x4BB45B70
-          SceLibGcc_6214B80C: 0x6214B80C
-          SceLibGcc_74274866: 0x74274866
-          SceLibGcc_7772C028: 0x7772C028
-          SceLibGcc_7DFC519A: 0x7DFC519A
-          SceLibGcc_83A4F46F: 0x83A4F46F
-          SceLibGcc_8A5F29D8: 0x8A5F29D8
-          SceLibGcc_8D4953C7: 0x8D4953C7
-          SceLibGcc_A22B2436: 0xA22B2436
-          SceLibGcc_AC15DBA5: 0xAC15DBA5
-          SceLibGcc_B1CD7AC2: 0xB1CD7AC2
-          SceLibGcc_BAC00FF7: 0xBAC00FF7
-          SceLibGcc_CD43FEDC: 0xCD43FEDC
-          SceLibGcc_DA5097CE: 0xDA5097CE
-          SceLibGcc_DAB28374: 0xDAB28374
-          SceLibGcc_DBE840D6: 0xDBE840D6
-          SceLibGcc_F16E32FC: 0xF16E32FC
       SceLibSsp:
         nid: 0x8FA98EF1
         kernel: false
         functions:
-          SceLibSsp_39AD080B: 0x39AD080B
       SceRtabi:
         nid: 0xA941943F
         kernel: false
         functions:
-          SceRtabi_0D4F0635: 0x0D4F0635
-          SceRtabi_141BC4CE: 0x141BC4CE
-          SceRtabi_21FF67B9: 0x21FF67B9
-          SceRtabi_317B3774: 0x317B3774
-          SceRtabi_38D62D60: 0x38D62D60
-          SceRtabi_5024AB91: 0x5024AB91
-          SceRtabi_609CA961: 0x609CA961
-          SceRtabi_67104054: 0x67104054
-          SceRtabi_6BB838EF: 0x6BB838EF
-          SceRtabi_6CBB0E84: 0x6CBB0E84
-          SceRtabi_A5DB3A86: 0xA5DB3A86
-          SceRtabi_AA1F1B50: 0xAA1F1B50
-          SceRtabi_C33391D1: 0xC33391D1
-          SceRtabi_CBDA815C: 0xCBDA815C
-          SceRtabi_CDF7708E: 0xCDF7708E
-          SceRtabi_FB311F87: 0xFB311F87
       SceKernelForVM:
         nid: 0xA2B3EA8F
         kernel: false
         functions:
-          SceKernelForVM_010BB885: 0x010BB885
-          SceKernelForVM_70F3F49D: 0x70F3F49D
-          SceKernelForVM_F5F8F795: 0xF5F8F795
       SceLibRng:
         nid: 0xF9AC7CF8
         kernel: false
@@ -4178,12 +2913,6 @@ modules:
         nid: 0x5FEEA076
         kernel: false
         functions:
-          SceKernelForMono_1BECC64C: 0x1BECC64C
-          SceKernelForMono_38839DA2: 0x38839DA2
-          SceKernelForMono_92A0964D: 0x92A0964D
-          SceKernelForMono_9A6D085B: 0x9A6D085B
-          SceKernelForMono_AD210F16: 0xAD210F16
-          SceKernelForMono_E513151F: 0xE513151F
   SceLibMonoBridge:
     nid: 0x53
     libraries:
@@ -5331,9 +4060,6 @@ modules:
         nid: 0x9F4924F2
         kernel: true
         functions:
-          ScePsmDrmForDriver_4CD5375C: 0x4CD5375C
-          ScePsmDrmForDriver_791198CE: 0x791198CE
-          ScePsmDrmForDriver_B09003A7: 0xB09003A7
           ScePsmDrmForDriver_get_info: 0x984F9017
           ScePsmDrmForDriver_get_info_2: 0x8C8CFD01
           ScePsmDrmForDriver_set_psm_act_data: 0xCB73E9D3
@@ -5341,9 +4067,6 @@ modules:
         nid: 0x3F2B0888
         kernel: false
         functions:
-          ScePsmDrm_0E193CBB: 0x0E193CBB
-          ScePsmDrm_3E881391: 0x3E881391
-          ScePsmDrm_A89653B3: 0xA89653B3
           ScePsmDrm_get_info: 0x207A2C53
           ScePsmDrm_get_info_2: 0xE31A6220
           ScePsmDrm_get_rif_name: 0x0D6470DA
@@ -5812,80 +4535,6 @@ modules:
         nid: 0x1590166F
         kernel: true
         functions:
-          ScePowerForDriver_0074EF9B: 0x0074EF9B
-          ScePowerForDriver_02DB1035: 0x02DB1035
-          ScePowerForDriver_06AF03DB: 0x06AF03DB
-          ScePowerForDriver_0856FD0A: 0x0856FD0A
-          ScePowerForDriver_08951418: 0x08951418
-          ScePowerForDriver_0C6973B8: 0x0C6973B8
-          ScePowerForDriver_0CD21B1F: 0x0CD21B1F
-          ScePowerForDriver_0D56C601: 0x0D56C601
-          ScePowerForDriver_0D80B917: 0x0D80B917
-          ScePowerForDriver_0E333BEC: 0x0E333BEC
-          ScePowerForDriver_0E58FCDF: 0x0E58FCDF
-          ScePowerForDriver_165CE085: 0x165CE085
-          ScePowerForDriver_166922EC: 0x166922EC
-          ScePowerForDriver_1BA2FCAE: 0x1BA2FCAE
-          ScePowerForDriver_20A33D58: 0x20A33D58
-          ScePowerForDriver_23BB0A60: 0x23BB0A60
-          ScePowerForDriver_264C24FC: 0x264C24FC
-          ScePowerForDriver_2777A517: 0x2777A517
-          ScePowerForDriver_2784A6BD: 0x2784A6BD
-          ScePowerForDriver_2B51FE2F: 0x2B51FE2F
-          ScePowerForDriver_2E9000F7: 0x2E9000F7
-          ScePowerForDriver_38415146: 0x38415146
-          ScePowerForDriver_394DE492: 0x394DE492
-          ScePowerForDriver_3951AF53: 0x3951AF53
-          ScePowerForDriver_4159E0D9: 0x4159E0D9
-          ScePowerForDriver_43D5CE1D: 0x43D5CE1D
-          ScePowerForDriver_475BCC82: 0x475BCC82
-          ScePowerForDriver_4A69163A: 0x4A69163A
-          ScePowerForDriver_5210A6FE: 0x5210A6FE
-          ScePowerForDriver_621BD8FD: 0x621BD8FD
-          ScePowerForDriver_627A89C6: 0x627A89C6
-          ScePowerForDriver_62C5406C: 0x62C5406C
-          ScePowerForDriver_642E0AF2: 0x642E0AF2
-          ScePowerForDriver_64641E6A: 0x64641E6A
-          ScePowerForDriver_660D5AB4: 0x660D5AB4
-          ScePowerForDriver_661D670D: 0x661D670D
-          ScePowerForDriver_668F01D4: 0x668F01D4
-          ScePowerForDriver_675A84ED: 0x675A84ED
-          ScePowerForDriver_6BC26FC7: 0x6BC26FC7
-          ScePowerForDriver_6D2CA84B: 0x6D2CA84B
-          ScePowerForDriver_711C68DF: 0x711C68DF
-          ScePowerForDriver_733F973B: 0x733F973B
-          ScePowerForDriver_77027B6B: 0x77027B6B
-          ScePowerForDriver_86CB5218: 0x86CB5218
-          ScePowerForDriver_8921A7A0: 0x8921A7A0
-          ScePowerForDriver_8C0D2051: 0x8C0D2051
-          ScePowerForDriver_8D18F728: 0x8D18F728
-          ScePowerForDriver_90285886: 0x90285886
-          ScePowerForDriver_991BDEAF: 0x991BDEAF
-          ScePowerForDriver_9F26222A: 0x9F26222A
-          ScePowerForDriver_A6FF5997: 0xA6FF5997
-          ScePowerForDriver_A902CDDF: 0xA902CDDF
-          ScePowerForDriver_ACC857A4: 0xACC857A4
-          ScePowerForDriver_B104EFE2: 0xB104EFE2
-          ScePowerForDriver_B24263F0: 0xB24263F0
-          ScePowerForDriver_C1853BA7: 0xC1853BA7
-          ScePowerForDriver_C62B6164: 0xC62B6164
-          ScePowerForDriver_C63DACD5: 0xC63DACD5
-          ScePowerForDriver_C715F4F0: 0xC715F4F0
-          ScePowerForDriver_C743E392: 0xC743E392
-          ScePowerForDriver_CBCC11CC: 0xCBCC11CC
-          ScePowerForDriver_CF8F0529: 0xCF8F0529
-          ScePowerForDriver_D516D446: 0xD516D446
-          ScePowerForDriver_D8759B55: 0xD8759B55
-          ScePowerForDriver_DD3D4DAC: 0xDD3D4DAC
-          ScePowerForDriver_E4E3C316: 0xE4E3C316
-          ScePowerForDriver_E5573571: 0xE5573571
-          ScePowerForDriver_EDC13FE5: 0xEDC13FE5
-          ScePowerForDriver_EFD3C963: 0xEFD3C963
-          ScePowerForDriver_F1E14EA9: 0xF1E14EA9
-          ScePowerForDriver_F535D928: 0xF535D928
-          ScePowerForDriver_FB5C3C75: 0xFB5C3C75
-          ScePowerForDriver_FE35B73D: 0xFE35B73D
-          ScePowerForDriver_FFC84E69: 0xFFC84E69
           kscePowerBatteryUpdateInfo: 0x27F3292C
           kscePowerCancelRequest: 0xDB62C9CF
           kscePowerGetArmClockFrequency: 0xABC6F88F
@@ -6153,32 +4802,10 @@ modules:
         nid: 0xCC88EAB1
         kernel: false
         functions:
-          SceRegMgrForDebugger_46AC0CCB: 0x46AC0CCB
-          SceRegMgrForDebugger_53970232: 0x53970232
-          SceRegMgrForDebugger_810D2F09: 0x810D2F09
-          SceRegMgrForDebugger_8AE5757E: 0x8AE5757E
-          SceRegMgrForDebugger_8E798E47: 0x8E798E47
-          SceRegMgrForDebugger_B9A0BB77: 0xB9A0BB77
-          SceRegMgrForDebugger_C588D3E7: 0xC588D3E7
-          SceRegMgrForDebugger_C64C67A8: 0xC64C67A8
-          SceRegMgrForDebugger_D668ABD2: 0xD668ABD2
       SceRegMgrForTool:
         nid: 0x1F121C9E
         kernel: false
         functions:
-          SceRegMgrForTool_0B623D0B: 0x0B623D0B
-          SceRegMgrForTool_0CFA929B: 0x0CFA929B
-          SceRegMgrForTool_2A76051A: 0x2A76051A
-          SceRegMgrForTool_2D415472: 0x2D415472
-          SceRegMgrForTool_3AAB71EF: 0x3AAB71EF
-          SceRegMgrForTool_4EDF87F9: 0x4EDF87F9
-          SceRegMgrForTool_6276E7D8: 0x6276E7D8
-          SceRegMgrForTool_6808B7AD: 0x6808B7AD
-          SceRegMgrForTool_7B30AC2C: 0x7B30AC2C
-          SceRegMgrForTool_B441660B: 0xB441660B
-          SceRegMgrForTool_C689E36C: 0xC689E36C
-          SceRegMgrForTool_E6E81558: 0xE6E81558
-          SceRegMgrForTool_F55E6E4F: 0xF55E6E4F
   SceRtc:
     nid: 0x1E923AD1
     libraries:
@@ -7310,11 +5937,6 @@ modules:
         nid: 0xFF4CD67F
         kernel: false
         functions:
-          SceDrmBridge_1BBB62E9: 0x1BBB62E9
-          SceDrmBridge_6D483DFC: 0x6D483DFC
-          SceDrmBridge_B81B597A: 0xB81B597A
-          SceDrmBridge_E04F767B: 0xE04F767B
-          SceDrmBridge_FFB164E2: 0xFFB164E2
   SceStdio:
     nid: 0x771A73C0
     libraries:
@@ -7332,50 +5954,10 @@ modules:
         nid: 0x74580D9F
         kernel: true
         functions:
-          SceSblSsMgrForKernel_516ECC08: 0x516ECC08
-          SceSblSsMgrForKernel_83D254FF: 0x83D254FF
-          SceSblSsMgrForKernel_C2EC8F5A: 0xC2EC8F5A
-          SceSblSsMgrForKernel_E29E161C: 0xE29E161C
-          SceSblSsMgrForKernel_E2DD0378: 0xE2DD0378
       SceSblSsMgrForDriver:
         nid: 0x61E9428D
         kernel: true
         functions:
-          SceSblSsMgrForDriver_01BE0374: 0x01BE0374
-          SceSblSsMgrForDriver_04843835: 0x04843835
-          SceSblSsMgrForDriver_05B38698: 0x05B38698
-          SceSblSsMgrForDriver_0F7D28AF: 0x0F7D28AF
-          SceSblSsMgrForDriver_121FA69F: 0x121FA69F
-          SceSblSsMgrForDriver_1901CB5E: 0x1901CB5E
-          SceSblSsMgrForDriver_197ACF6F: 0x197ACF6F
-          SceSblSsMgrForDriver_1B14658D: 0x1B14658D
-          SceSblSsMgrForDriver_21EC51F6: 0x21EC51F6
-          SceSblSsMgrForDriver_249ADB07: 0x249ADB07
-          SceSblSsMgrForDriver_37DD5CBF: 0x37DD5CBF
-          SceSblSsMgrForDriver_6704D985: 0x6704D985
-          SceSblSsMgrForDriver_711C057A: 0x711C057A
-          SceSblSsMgrForDriver_79F38554: 0x79F38554
-          SceSblSsMgrForDriver_7C978BE7: 0x7C978BE7
-          SceSblSsMgrForDriver_7D46768C: 0x7D46768C
-          SceSblSsMgrForDriver_82B5DCEF: 0x82B5DCEF
-          SceSblSsMgrForDriver_83B058F5: 0x83B058F5
-          SceSblSsMgrForDriver_8B4700CB: 0x8B4700CB
-          SceSblSsMgrForDriver_8EAFB18A: 0x8EAFB18A
-          SceSblSsMgrForDriver_926BCCF0: 0x926BCCF0
-          SceSblSsMgrForDriver_92E37656: 0x92E37656
-          SceSblSsMgrForDriver_934DB6B5: 0x934DB6B5
-          SceSblSsMgrForDriver_9641374E: 0x9641374E
-          SceSblSsMgrForDriver_9A9676D0: 0x9A9676D0
-          SceSblSsMgrForDriver_B8B298FD: 0xB8B298FD
-          SceSblSsMgrForDriver_C38D0CEA: 0xC38D0CEA
-          SceSblSsMgrForDriver_C517770D: 0xC517770D
-          SceSblSsMgrForDriver_CD98CC92: 0xCD98CC92
-          SceSblSsMgrForDriver_E0B13BA7: 0xE0B13BA7
-          SceSblSsMgrForDriver_E0DC2587: 0xE0DC2587
-          SceSblSsMgrForDriver_E6E1AD15: 0xE6E1AD15
-          SceSblSsMgrForDriver_EA6ACB6D: 0xEA6ACB6D
-          SceSblSsMgrForDriver_EB3AF9B5: 0xEB3AF9B5
-          SceSblSsMgrForDriver_FDD6D5DE: 0xFDD6D5DE
           ksceKernelGetRandomNumber: 0x4F9BFBE5
           ksceSblSsMgrGetConsoleId: 0xFC6CDD68
           ksceSblSsMgrGetOpenPsId: 0xA5B5D269
@@ -7428,96 +6010,10 @@ modules:
         nid: 0x11F9B314
         kernel: true
         functions:
-          SceSblACMgrForKernel_02422F1F: 0x02422F1F
-          SceSblACMgrForKernel_04C0ED3F: 0x04C0ED3F
-          SceSblACMgrForKernel_05FDC646: 0x05FDC646
-          SceSblACMgrForKernel_06BE9F0F: 0x06BE9F0F
-          SceSblACMgrForKernel_0E489631: 0x0E489631
-          SceSblACMgrForKernel_11C9158B: 0x11C9158B
-          SceSblACMgrForKernel_165C3C7A: 0x165C3C7A
-          SceSblACMgrForKernel_1948E9DB: 0x1948E9DB
-          SceSblACMgrForKernel_1B160234: 0x1B160234
-          SceSblACMgrForKernel_2AE6CF27: 0x2AE6CF27
-          SceSblACMgrForKernel_30575458: 0x30575458
-          SceSblACMgrForKernel_31C23B66: 0x31C23B66
-          SceSblACMgrForKernel_3388F595: 0x3388F595
-          SceSblACMgrForKernel_356B9139: 0x356B9139
-          SceSblACMgrForKernel_384D20FD: 0x384D20FD
-          SceSblACMgrForKernel_3F99279F: 0x3F99279F
-          SceSblACMgrForKernel_410357AF: 0x410357AF
-          SceSblACMgrForKernel_47B67F72: 0x47B67F72
-          SceSblACMgrForKernel_48F4D5EE: 0x48F4D5EE
-          SceSblACMgrForKernel_49509A83: 0x49509A83
-          SceSblACMgrForKernel_4C4B7D6B: 0x4C4B7D6B
-          SceSblACMgrForKernel_570D6AD3: 0x570D6AD3
-          SceSblACMgrForKernel_5AC59172: 0x5AC59172
-          SceSblACMgrForKernel_5E6BA11C: 0x5E6BA11C
-          SceSblACMgrForKernel_7529E364: 0x7529E364
-          SceSblACMgrForKernel_75AAF981: 0x75AAF981
-          SceSblACMgrForKernel_7C2AF978: 0x7C2AF978
-          SceSblACMgrForKernel_7F294A09: 0x7F294A09
-          SceSblACMgrForKernel_8241AB5C: 0x8241AB5C
-          SceSblACMgrForKernel_930CD037: 0x930CD037
-          SceSblACMgrForKernel_96403142: 0x96403142
-          SceSblACMgrForKernel_966B3738: 0x966B3738
-          SceSblACMgrForKernel_98B28671: 0x98B28671
-          SceSblACMgrForKernel_9EDAF856: 0x9EDAF856
-          SceSblACMgrForKernel_A50FDA27: 0xA50FDA27
-          SceSblACMgrForKernel_A7C3001D: 0xA7C3001D
-          SceSblACMgrForKernel_AF6F208E: 0xAF6F208E
-          SceSblACMgrForKernel_BBA13D9C: 0xBBA13D9C
-          SceSblACMgrForKernel_C90A9216: 0xC90A9216
-          SceSblACMgrForKernel_CCDBB74D: 0xCCDBB74D
-          SceSblACMgrForKernel_D442962E: 0xD442962E
-          SceSblACMgrForKernel_DC49E160: 0xDC49E160
-          SceSblACMgrForKernel_E273ED8C: 0xE273ED8C
-          SceSblACMgrForKernel_F5AD56E4: 0xF5AD56E4
-          SceSblACMgrForKernel_F9FEF5F0: 0xF9FEF5F0
-          SceSblACMgrForKernel_FB2AC5B4: 0xFB2AC5B4
-          SceSblACMgrForKernel_FBA1A256: 0xFBA1A256
       SceSblACMgrForDriver:
         nid: 0x9AD8E213
         kernel: true
         functions:
-          SceSblACMgrForDriver_0139FC20: 0x0139FC20
-          SceSblACMgrForDriver_0606B87E: 0x0606B87E
-          SceSblACMgrForDriver_062CAEB2: 0x062CAEB2
-          SceSblACMgrForDriver_091F7247: 0x091F7247
-          SceSblACMgrForDriver_0924896F: 0x0924896F
-          SceSblACMgrForDriver_0948F41C: 0x0948F41C
-          SceSblACMgrForDriver_0B6E6CD7: 0x0B6E6CD7
-          SceSblACMgrForDriver_2A29453C: 0x2A29453C
-          SceSblACMgrForDriver_2E992B02: 0x2E992B02
-          SceSblACMgrForDriver_3B356B98: 0x3B356B98
-          SceSblACMgrForDriver_426A4E8C: 0x426A4E8C
-          SceSblACMgrForDriver_4322F188: 0x4322F188
-          SceSblACMgrForDriver_456DA7AC: 0x456DA7AC
-          SceSblACMgrForDriver_48CFCEA2: 0x48CFCEA2
-          SceSblACMgrForDriver_4CBD6156: 0x4CBD6156
-          SceSblACMgrForDriver_4DB7F512: 0x4DB7F512
-          SceSblACMgrForDriver_5C4BC352: 0x5C4BC352
-          SceSblACMgrForDriver_5F9AF49C: 0x5F9AF49C
-          SceSblACMgrForDriver_6210D745: 0x6210D745
-          SceSblACMgrForDriver_6D8A88B7: 0x6D8A88B7
-          SceSblACMgrForDriver_84604EED: 0x84604EED
-          SceSblACMgrForDriver_8A54DF3A: 0x8A54DF3A
-          SceSblACMgrForDriver_962CD237: 0x962CD237
-          SceSblACMgrForDriver_96AF69BD: 0x96AF69BD
-          SceSblACMgrForDriver_991FDC15: 0x991FDC15
-          SceSblACMgrForDriver_A27E47A7: 0xA27E47A7
-          SceSblACMgrForDriver_A67E8E5B: 0xA67E8E5B
-          SceSblACMgrForDriver_A92CD636: 0xA92CD636
-          SceSblACMgrForDriver_AD717E7A: 0xAD717E7A
-          SceSblACMgrForDriver_AE1AF154: 0xAE1AF154
-          SceSblACMgrForDriver_B12CEAA8: 0xB12CEAA8
-          SceSblACMgrForDriver_B836CF13: 0xB836CF13
-          SceSblACMgrForDriver_BE5667C5: 0xBE5667C5
-          SceSblACMgrForDriver_C98D82EE: 0xC98D82EE
-          SceSblACMgrForDriver_D0E11C89: 0xD0E11C89
-          SceSblACMgrForDriver_D7AD8471: 0xD7AD8471
-          SceSblACMgrForDriver_E79C7A8D: 0xE79C7A8D
-          SceSblACMgrForDriver_F5AE24AC: 0xF5AE24AC
-          SceSblACMgrForDriver_FF7125DE: 0xFF7125DE
           ksceSblACMgrHasCapability: 0xC2D1F2FC
           ksceSblACMgrIsDevelopmentMode: 0xE87D1777
           ksceSblACMgrIsGameProgram: 0x1298C647
@@ -7655,19 +6151,6 @@ modules:
         nid: 0x31F237B6
         kernel: false
         functions:
-          ScePromoterUtil_1F5EA997: 0x1F5EA997
-          ScePromoterUtil_30A36AAF: 0x30A36AAF
-          ScePromoterUtil_59A6CDAE: 0x59A6CDAE
-          ScePromoterUtil_59DA665E: 0x59DA665E
-          ScePromoterUtil_5FF5CACF: 0x5FF5CACF
-          ScePromoterUtil_6A547384: 0x6A547384
-          ScePromoterUtil_739BC292: 0x739BC292
-          ScePromoterUtil_82E69783: 0x82E69783
-          ScePromoterUtil_8494C742: 0x8494C742
-          ScePromoterUtil_999AD6CE: 0x999AD6CE
-          ScePromoterUtil_B27DA268: 0xB27DA268
-          ScePromoterUtil_D4E87DCB: 0xD4E87DCB
-          ScePromoterUtil_FDCCBE33: 0xFDCCBE33
           ScePromoterUtil_heartbeat: 0x395739DF
           scePromoterUtilityCheckExist: 0x0D76CD38
           scePromoterUtilityCheckExist: 0xBA9871E5
@@ -7800,20 +6283,12 @@ modules:
         nid: 0x7ABF5135
         kernel: true
         functions:
-          SceSblAuthMgrForKernel_026ACBAD: 0x026ACBAD
-          SceSblAuthMgrForKernel_2A83A012: 0x2A83A012
-          SceSblAuthMgrForKernel_89CCDA2C: 0x89CCDA2C
-          SceSblAuthMgrForKernel_A9CD2A09: 0xA9CD2A09
-          SceSblAuthMgrForKernel_ABAB8466: 0xABAB8466
-          SceSblAuthMgrForKernel_BC422443: 0xBC422443
-          SceSblAuthMgrForKernel_F3411881: 0xF3411881
           sceSblAuthMgrClearDmac5Key: 0xF2BB723E
           sceSblAuthMgrSetDmac5Key: 0x122ACDEA
       SceSblAuthMgrForDriver:
         nid: 0x4EB2B1BB
         kernel: true
         functions:
-          SceSblAuthMgrForDriver_24C4CE64: 0x24C4CE64
           sceSblAuthMgrDecBindData: 0x41DAEA12
           sceSblAuthMgrGetEKc: 0x868B9E9A
   SceMotionDev:
@@ -7973,111 +6448,6 @@ modules:
         nid: 0x66845469
         kernel: true
         functions:
-          SceAvcodecForDriver_01387A93: 0x01387A93
-          SceAvcodecForDriver_04080710: 0x04080710
-          SceAvcodecForDriver_04F734CC: 0x04F734CC
-          SceAvcodecForDriver_0CC84413: 0x0CC84413
-          SceAvcodecForDriver_12DAE04A: 0x12DAE04A
-          SceAvcodecForDriver_13C530E4: 0x13C530E4
-          SceAvcodecForDriver_16B501C9: 0x16B501C9
-          SceAvcodecForDriver_1A584DB7: 0x1A584DB7
-          SceAvcodecForDriver_1BE9F5A4: 0x1BE9F5A4
-          SceAvcodecForDriver_20892154: 0x20892154
-          SceAvcodecForDriver_20C83C00: 0x20C83C00
-          SceAvcodecForDriver_229AB2CF: 0x229AB2CF
-          SceAvcodecForDriver_22D7B653: 0x22D7B653
-          SceAvcodecForDriver_2641888C: 0x2641888C
-          SceAvcodecForDriver_27211864: 0x27211864
-          SceAvcodecForDriver_2895CB6D: 0x2895CB6D
-          SceAvcodecForDriver_2A0AF392: 0x2A0AF392
-          SceAvcodecForDriver_2C7A9841: 0x2C7A9841
-          SceAvcodecForDriver_2C8271BA: 0x2C8271BA
-          SceAvcodecForDriver_301CCA25: 0x301CCA25
-          SceAvcodecForDriver_32DEE3C5: 0x32DEE3C5
-          SceAvcodecForDriver_361238E2: 0x361238E2
-          SceAvcodecForDriver_3CB7661A: 0x3CB7661A
-          SceAvcodecForDriver_3F146942: 0x3F146942
-          SceAvcodecForDriver_427914D5: 0x427914D5
-          SceAvcodecForDriver_43985AA8: 0x43985AA8
-          SceAvcodecForDriver_43A9CD35: 0x43A9CD35
-          SceAvcodecForDriver_468949D7: 0x468949D7
-          SceAvcodecForDriver_47D8E150: 0x47D8E150
-          SceAvcodecForDriver_48247A20: 0x48247A20
-          SceAvcodecForDriver_48DECA56: 0x48DECA56
-          SceAvcodecForDriver_4AE6B437: 0x4AE6B437
-          SceAvcodecForDriver_4DB66E3A: 0x4DB66E3A
-          SceAvcodecForDriver_4DD3826D: 0x4DD3826D
-          SceAvcodecForDriver_4F11F915: 0x4F11F915
-          SceAvcodecForDriver_536C8296: 0x536C8296
-          SceAvcodecForDriver_58835DCB: 0x58835DCB
-          SceAvcodecForDriver_58F1E353: 0x58F1E353
-          SceAvcodecForDriver_5C3434FB: 0x5C3434FB
-          SceAvcodecForDriver_663B3195: 0x663B3195
-          SceAvcodecForDriver_6DC39EDC: 0x6DC39EDC
-          SceAvcodecForDriver_6E250A5F: 0x6E250A5F
-          SceAvcodecForDriver_6F1CF77F: 0x6F1CF77F
-          SceAvcodecForDriver_71C37694: 0x71C37694
-          SceAvcodecForDriver_73401748: 0x73401748
-          SceAvcodecForDriver_7385FB51: 0x7385FB51
-          SceAvcodecForDriver_77529FD2: 0x77529FD2
-          SceAvcodecForDriver_78BA8E98: 0x78BA8E98
-          SceAvcodecForDriver_7DC13C29: 0x7DC13C29
-          SceAvcodecForDriver_7E8CC4E5: 0x7E8CC4E5
-          SceAvcodecForDriver_80F63723: 0x80F63723
-          SceAvcodecForDriver_823E187E: 0x823E187E
-          SceAvcodecForDriver_864FC454: 0x864FC454
-          SceAvcodecForDriver_866B49BF: 0x866B49BF
-          SceAvcodecForDriver_86AD5A4F: 0x86AD5A4F
-          SceAvcodecForDriver_86B1ACC5: 0x86B1ACC5
-          SceAvcodecForDriver_90F394E6: 0x90F394E6
-          SceAvcodecForDriver_91B27CF3: 0x91B27CF3
-          SceAvcodecForDriver_91E94B76: 0x91E94B76
-          SceAvcodecForDriver_95E8AFCA: 0x95E8AFCA
-          SceAvcodecForDriver_A0E63278: 0xA0E63278
-          SceAvcodecForDriver_A2085B6B: 0xA2085B6B
-          SceAvcodecForDriver_A6CAE217: 0xA6CAE217
-          SceAvcodecForDriver_B2A51EB0: 0xB2A51EB0
-          SceAvcodecForDriver_B6882013: 0xB6882013
-          SceAvcodecForDriver_B77B5BFC: 0xB77B5BFC
-          SceAvcodecForDriver_B8A9632A: 0xB8A9632A
-          SceAvcodecForDriver_BC244D21: 0xBC244D21
-          SceAvcodecForDriver_BC55D10F: 0xBC55D10F
-          SceAvcodecForDriver_BCB769EB: 0xBCB769EB
-          SceAvcodecForDriver_BF3835E2: 0xBF3835E2
-          SceAvcodecForDriver_C114C499: 0xC114C499
-          SceAvcodecForDriver_C363B31A: 0xC363B31A
-          SceAvcodecForDriver_C518A109: 0xC518A109
-          SceAvcodecForDriver_C5C10C8B: 0xC5C10C8B
-          SceAvcodecForDriver_C5E720E2: 0xC5E720E2
-          SceAvcodecForDriver_C8366BB8: 0xC8366BB8
-          SceAvcodecForDriver_C84AFFC4: 0xC84AFFC4
-          SceAvcodecForDriver_C93DA0C7: 0xC93DA0C7
-          SceAvcodecForDriver_C99242F5: 0xC99242F5
-          SceAvcodecForDriver_C9EF7057: 0xC9EF7057
-          SceAvcodecForDriver_CD7FE8D0: 0xCD7FE8D0
-          SceAvcodecForDriver_D0647B74: 0xD0647B74
-          SceAvcodecForDriver_D2ACCE22: 0xD2ACCE22
-          SceAvcodecForDriver_D46B8463: 0xD46B8463
-          SceAvcodecForDriver_D5A34236: 0xD5A34236
-          SceAvcodecForDriver_D7CD7F82: 0xD7CD7F82
-          SceAvcodecForDriver_D9FCDF3E: 0xD9FCDF3E
-          SceAvcodecForDriver_DE515BFF: 0xDE515BFF
-          SceAvcodecForDriver_DFC0AAC6: 0xDFC0AAC6
-          SceAvcodecForDriver_E0232BFE: 0xE0232BFE
-          SceAvcodecForDriver_E355CAAE: 0xE355CAAE
-          SceAvcodecForDriver_E4F668C5: 0xE4F668C5
-          SceAvcodecForDriver_E782E735: 0xE782E735
-          SceAvcodecForDriver_E7E14DE4: 0xE7E14DE4
-          SceAvcodecForDriver_EA07A3B7: 0xEA07A3B7
-          SceAvcodecForDriver_EAAE7737: 0xEAAE7737
-          SceAvcodecForDriver_EAEB16D5: 0xEAEB16D5
-          SceAvcodecForDriver_F305E3B3: 0xF305E3B3
-          SceAvcodecForDriver_F67F93DC: 0xF67F93DC
-          SceAvcodecForDriver_F714DB9A: 0xF714DB9A
-          SceAvcodecForDriver_F8BCBE20: 0xF8BCBE20
-          SceAvcodecForDriver_F9E271DE: 0xF9E271DE
-          SceAvcodecForDriver_FACCD284: 0xFACCD284
-          SceAvcodecForDriver_FD805BF1: 0xFD805BF1
       SceAvcodec:
         nid: 0xA166C96E
         kernel: false
@@ -8224,24 +6594,6 @@ modules:
         nid: 0x60C7478A
         kernel: true
         functions:
-          SceOledForDriver_26F9EEA8: 0x26F9EEA8
-          SceOledForDriver_2F0C4B67: 0x2F0C4B67
-          SceOledForDriver_3C990F53: 0x3C990F53
-          SceOledForDriver_3E6AE8A2: 0x3E6AE8A2
-          SceOledForDriver_4891257F: 0x4891257F
-          SceOledForDriver_4C7836C7: 0x4C7836C7
-          SceOledForDriver_4F8A1D4A: 0x4F8A1D4A
-          SceOledForDriver_5AF31932: 0x5AF31932
-          SceOledForDriver_6B1E0B52: 0x6B1E0B52
-          SceOledForDriver_9F4ABDDC: 0x9F4ABDDC
-          SceOledForDriver_AD6C7FB8: 0xAD6C7FB8
-          SceOledForDriver_BC84602E: 0xBC84602E
-          SceOledForDriver_BF5C5624: 0xBF5C5624
-          SceOledForDriver_C9D5987C: 0xC9D5987C
-          SceOledForDriver_DABBD9D3: 0xDABBD9D3
-          SceOledForDriver_DDB1412B: 0xDDB1412B
-          SceOledForDriver_E30604CC: 0xE30604CC
-          SceOledForDriver_ED2D6F19: 0xED2D6F19
           ksceOledGetBrightness: 0x43EF811A
           ksceOledSetBrightness: 0xF9624C47
           ksceOledWaitReady: 0x0CC6BCB4
@@ -8252,26 +6604,6 @@ modules:
         nid: 0x1926B182
         kernel: true
         functions:
-          SceSblGcAuthMgrDrmBBForDriver_050DC6DF: 0x050DC6DF
-          SceSblGcAuthMgrDrmBBForDriver_22FD5D23: 0x22FD5D23
-          SceSblGcAuthMgrDrmBBForDriver_30A0B441: 0x30A0B441
-          SceSblGcAuthMgrDrmBBForDriver_3C25F9FA: 0x3C25F9FA
-          SceSblGcAuthMgrDrmBBForDriver_48D7784E: 0x48D7784E
-          SceSblGcAuthMgrDrmBBForDriver_4B506BE7: 0x4B506BE7
-          SceSblGcAuthMgrDrmBBForDriver_4C5DE1AA: 0x4C5DE1AA
-          SceSblGcAuthMgrDrmBBForDriver_4CEA150C: 0x4CEA150C
-          SceSblGcAuthMgrDrmBBForDriver_4FE89ADB: 0x4FE89ADB
-          SceSblGcAuthMgrDrmBBForDriver_500F5157: 0x500F5157
-          SceSblGcAuthMgrDrmBBForDriver_535B87BC: 0x535B87BC
-          SceSblGcAuthMgrDrmBBForDriver_6E6D2B89: 0x6E6D2B89
-          SceSblGcAuthMgrDrmBBForDriver_6EF3C9DB: 0x6EF3C9DB
-          SceSblGcAuthMgrDrmBBForDriver_7F98E4E2: 0x7F98E4E2
-          SceSblGcAuthMgrDrmBBForDriver_812B2B5C: 0x812B2B5C
-          SceSblGcAuthMgrDrmBBForDriver_B13577E2: 0xB13577E2
-          SceSblGcAuthMgrDrmBBForDriver_BB451E83: 0xBB451E83
-          SceSblGcAuthMgrDrmBBForDriver_BB70DDC0: 0xBB70DDC0
-          SceSblGcAuthMgrDrmBBForDriver_C0F37F18: 0xC0F37F18
-          SceSblGcAuthMgrDrmBBForDriver_E950BE32: 0xE950BE32
       SceSblGcAuthMgrGcAuthForDriver:
         nid: 0xC6627F5E
         kernel: true
@@ -8281,13 +6613,10 @@ modules:
         nid: 0x29ED0109
         kernel: true
         functions:
-          SceSblGcAuthMgrMlnpsnlForDriver_296ABD68: 0x296ABD68
-          SceSblGcAuthMgrMlnpsnlForDriver_DABC01F5: 0xDABC01F5
       SceSblGcAuthMgrPkgForDriver:
         nid: 0x082FBA7D
         kernel: true
         functions:
-          SceSblGcAuthMgrPkgForDriver_E459A9A8: 0xE459A9A8
       SceSblGcAuthMgrPsmactForDriver:
         nid: 0x1C53F37D
         kernel: true
@@ -8297,18 +6626,10 @@ modules:
         nid: 0xF24F760D
         kernel: true
         functions:
-          SceSblGcAuthMgrSclkForDriver_11D5570B: 0x11D5570B
-          SceSblGcAuthMgrSclkForDriver_F723A9BA: 0xF723A9BA
       SceSblGcAuthMgrMsSaveBBForDriver:
         nid: 0x5032E8D4
         kernel: true
         functions:
-          SceSblGcAuthMgrMsSaveBBForDriver_3C185A67: 0x3C185A67
-          SceSblGcAuthMgrMsSaveBBForDriver_4A249828: 0x4A249828
-          SceSblGcAuthMgrMsSaveBBForDriver_79A9BE44: 0x79A9BE44
-          SceSblGcAuthMgrMsSaveBBForDriver_805C860B: 0x805C860B
-          SceSblGcAuthMgrMsSaveBBForDriver_8E6626A0: 0x8E6626A0
-          SceSblGcAuthMgrMsSaveBBForDriver_F66D5F76: 0xF66D5F76
       SceSblGcAuthMgr:
         nid: 0x7B13BCF7
         kernel: false
@@ -8352,119 +6673,10 @@ modules:
     libraries:
       SceSblPostSsMgrForDriver:
         functions:
-          SceSblPostSsMgrForDriver_0298382B: 0x0298382B
-          SceSblPostSsMgrForDriver_07BAD056: 0x07BAD056
-          SceSblPostSsMgrForDriver_08525D8D: 0x08525D8D
-          SceSblPostSsMgrForDriver_128FB35A: 0x128FB35A
-          SceSblPostSsMgrForDriver_15F37282: 0x15F37282
-          SceSblPostSsMgrForDriver_1923D80D: 0x1923D80D
-          SceSblPostSsMgrForDriver_19B63D65: 0x19B63D65
-          SceSblPostSsMgrForDriver_1FF699DD: 0x1FF699DD
-          SceSblPostSsMgrForDriver_22599675: 0x22599675
-          SceSblPostSsMgrForDriver_2646DE64: 0x2646DE64
-          SceSblPostSsMgrForDriver_2BF04B8E: 0x2BF04B8E
-          SceSblPostSsMgrForDriver_2C463AF1: 0x2C463AF1
-          SceSblPostSsMgrForDriver_33275F95: 0x33275F95
-          SceSblPostSsMgrForDriver_3DB69911: 0x3DB69911
-          SceSblPostSsMgrForDriver_3F9BDEDF: 0x3F9BDEDF
-          SceSblPostSsMgrForDriver_4100B9E9: 0x4100B9E9
-          SceSblPostSsMgrForDriver_42474C8B: 0x42474C8B
-          SceSblPostSsMgrForDriver_4663C195: 0x4663C195
-          SceSblPostSsMgrForDriver_4FF2682F: 0x4FF2682F
-          SceSblPostSsMgrForDriver_686B9461: 0x686B9461
-          SceSblPostSsMgrForDriver_739C981E: 0x739C981E
-          SceSblPostSsMgrForDriver_7ACCAA50: 0x7ACCAA50
-          SceSblPostSsMgrForDriver_942010A0: 0x942010A0
-          SceSblPostSsMgrForDriver_9B49C249: 0x9B49C249
-          SceSblPostSsMgrForDriver_9D1D8EE5: 0x9D1D8EE5
-          SceSblPostSsMgrForDriver_9D2E2D39: 0x9D2E2D39
-          SceSblPostSsMgrForDriver_9FD835B0: 0x9FD835B0
-          SceSblPostSsMgrForDriver_ABDD68CD: 0xABDD68CD
-          SceSblPostSsMgrForDriver_AD3B0078: 0xAD3B0078
-          SceSblPostSsMgrForDriver_ADF92824: 0xADF92824
-          SceSblPostSsMgrForDriver_BDF18922: 0xBDF18922
-          SceSblPostSsMgrForDriver_C2E58CE3: 0xC2E58CE3
-          SceSblPostSsMgrForDriver_C6684F7E: 0xC6684F7E
-          SceSblPostSsMgrForDriver_C93C0A0D: 0xC93C0A0D
-          SceSblPostSsMgrForDriver_C977601E: 0xC977601E
-          SceSblPostSsMgrForDriver_CB5436BD: 0xCB5436BD
-          SceSblPostSsMgrForDriver_CC5AA5A5: 0xCC5AA5A5
-          SceSblPostSsMgrForDriver_D8A2D465: 0xD8A2D465
-          SceSblPostSsMgrForDriver_DC68EE5C: 0xDC68EE5C
-          SceSblPostSsMgrForDriver_DDA6FA6D: 0xDDA6FA6D
-          SceSblPostSsMgrForDriver_DE5150FE: 0xDE5150FE
-          SceSblPostSsMgrForDriver_F7F1015B: 0xF7F1015B
-          SceSblPostSsMgrForDriver_F86F1452: 0xF86F1452
-          SceSblPostSsMgrForDriver_FE92A318: 0xFE92A318
         nid: 0x2254E1B2
         kernel: true
       SceZlibForDriver:
         functions:
-          SceZlibForDriver_00561385: 0x00561385
-          SceZlibForDriver_05F712FE: 0x05F712FE
-          SceZlibForDriver_0BDDF66A: 0x0BDDF66A
-          SceZlibForDriver_0FA805A3: 0x0FA805A3
-          SceZlibForDriver_134E91EA: 0x134E91EA
-          SceZlibForDriver_1C344E27: 0x1C344E27
-          SceZlibForDriver_1E135CC1: 0x1E135CC1
-          SceZlibForDriver_20A122F8: 0x20A122F8
-          SceZlibForDriver_211D25F5: 0x211D25F5
-          SceZlibForDriver_21A03034: 0x21A03034
-          SceZlibForDriver_25F28DA7: 0x25F28DA7
-          SceZlibForDriver_3252D28C: 0x3252D28C
-          SceZlibForDriver_3370B9AD: 0x3370B9AD
-          SceZlibForDriver_35E0108C: 0x35E0108C
-          SceZlibForDriver_3B4466F4: 0x3B4466F4
-          SceZlibForDriver_3F33F55F: 0x3F33F55F
-          SceZlibForDriver_408311E8: 0x408311E8
-          SceZlibForDriver_44DA19D2: 0x44DA19D2
-          SceZlibForDriver_4C27A382: 0x4C27A382
-          SceZlibForDriver_4CB63BCD: 0x4CB63BCD
-          SceZlibForDriver_4EE6C080: 0x4EE6C080
-          SceZlibForDriver_517BC5F7: 0x517BC5F7
-          SceZlibForDriver_520CAA7F: 0x520CAA7F
-          SceZlibForDriver_5377643A: 0x5377643A
-          SceZlibForDriver_5492B3F2: 0x5492B3F2
-          SceZlibForDriver_5A0078D6: 0x5A0078D6
-          SceZlibForDriver_5B718E55: 0x5B718E55
-          SceZlibForDriver_67A085C4: 0x67A085C4
-          SceZlibForDriver_68CFEA45: 0x68CFEA45
-          SceZlibForDriver_6ED5B677: 0x6ED5B677
-          SceZlibForDriver_7048F14C: 0x7048F14C
-          SceZlibForDriver_723495A5: 0x723495A5
-          SceZlibForDriver_7993ADAB: 0x7993ADAB
-          SceZlibForDriver_7B16DBD6: 0x7B16DBD6
-          SceZlibForDriver_7C40CC39: 0x7C40CC39
-          SceZlibForDriver_7E823337: 0x7E823337
-          SceZlibForDriver_81D0667B: 0x81D0667B
-          SceZlibForDriver_82167CD9: 0x82167CD9
-          SceZlibForDriver_834CC4A2: 0x834CC4A2
-          SceZlibForDriver_86FF6C8B: 0x86FF6C8B
-          SceZlibForDriver_89A13883: 0x89A13883
-          SceZlibForDriver_89B30588: 0x89B30588
-          SceZlibForDriver_9030BAE4: 0x9030BAE4
-          SceZlibForDriver_904AA7AE: 0x904AA7AE
-          SceZlibForDriver_93168F72: 0x93168F72
-          SceZlibForDriver_938F34FA: 0x938F34FA
-          SceZlibForDriver_98619620: 0x98619620
-          SceZlibForDriver_A1E7E8B3: 0xA1E7E8B3
-          SceZlibForDriver_A5D70E95: 0xA5D70E95
-          SceZlibForDriver_AC2F8437: 0xAC2F8437
-          SceZlibForDriver_AD23EEBB: 0xAD23EEBB
-          SceZlibForDriver_B03E109B: 0xB03E109B
-          SceZlibForDriver_BC022D38: 0xBC022D38
-          SceZlibForDriver_BE5CE88A: 0xBE5CE88A
-          SceZlibForDriver_D4A85178: 0xD4A85178
-          SceZlibForDriver_D9BDC778: 0xD9BDC778
-          SceZlibForDriver_E0CE06C0: 0xE0CE06C0
-          SceZlibForDriver_E2DF5A8B: 0xE2DF5A8B
-          SceZlibForDriver_E323828B: 0xE323828B
-          SceZlibForDriver_E4F34A68: 0xE4F34A68
-          SceZlibForDriver_E6EB524C: 0xE6EB524C
-          SceZlibForDriver_E859D60F: 0xE859D60F
-          SceZlibForDriver_E94663DD: 0xE94663DD
-          SceZlibForDriver_EEC6D267: 0xEEC6D267
-          SceZlibForDriver_F2D8FC1A: 0xF2D8FC1A
         nid: 0xE241534E
         kernel: true
       SceSblPmMgr:
@@ -8501,18 +6713,10 @@ modules:
         kernel: false
       SceSblUtMgr:
         functions:
-          SceSblUtMgr_04CA1311: 0x04CA1311
-          SceSblUtMgr_1CD57182: 0x1CD57182
-          SceSblUtMgr_BDE74645: 0xBDE74645
-          SceSblUtMgr_CFCB1355: 0xCFCB1355
-          SceSblUtMgr_D2836E0D: 0xD2836E0D
         nid: 0x000DF81A
         kernel: false
       SceSblFwLoaderForDriver:
         functions:
-          SceSblFwLoaderForDriver_91C73A54: 0x91C73A54
-          SceSblFwLoaderForDriver_A6278D27: 0xA6278D27
-          SceSblFwLoaderForDriver_BB59FC7A: 0xBB59FC7A
         nid: 0x6FE424E4
         kernel: true
   SceSblSsSmComm:
@@ -8540,22 +6744,3 @@ modules:
         nid: 0xD6A45C93
         kernel: true
         functions:
-          SceUlobjMgrForDriver_0C29AFEC: 0x0C29AFEC
-          SceUlobjMgrForDriver_332F2E58: 0x332F2E58
-          SceUlobjMgrForDriver_362C9488: 0x362C9488
-          SceUlobjMgrForDriver_3685D4FB: 0x3685D4FB
-          SceUlobjMgrForDriver_3D6E2EF3: 0x3D6E2EF3
-          SceUlobjMgrForDriver_525A9BDB: 0x525A9BDB
-          SceUlobjMgrForDriver_5D7A7925: 0x5D7A7925
-          SceUlobjMgrForDriver_6BCB4568: 0x6BCB4568
-          SceUlobjMgrForDriver_6D2C8928: 0x6D2C8928
-          SceUlobjMgrForDriver_6F868221: 0x6F868221
-          SceUlobjMgrForDriver_74B9199C: 0x74B9199C
-          SceUlobjMgrForDriver_8E200387: 0x8E200387
-          SceUlobjMgrForDriver_A48A5B3C: 0xA48A5B3C
-          SceUlobjMgrForDriver_A90A564C: 0xA90A564C
-          SceUlobjMgrForDriver_ADAAA961: 0xADAAA961
-          SceUlobjMgrForDriver_B978DB70: 0xB978DB70
-          SceUlobjMgrForDriver_BB11EB2F: 0xBB11EB2F
-          SceUlobjMgrForDriver_CDAD91AD: 0xCDAD91AD
-          SceUlobjMgrForDriver_FFC8C811: 0xFFC8C811

--- a/db.yml
+++ b/db.yml
@@ -3140,7 +3140,7 @@ modules:
           ksceKernelSignalCondAll: 0x6EC78CD0
           ksceKernelSignalCondTo: 0x61533DA9
           ksceKernelSignalSema: 0xD270498B
-          ksceKernelStartThread_089: 0x21F5419B
+          ksceKernelStartThread: 0x21F5419B
           ksceKernelStartTimer: 0x84C4CE4D
           ksceKernelStopTimer: 0x474F214B
           ksceKernelTryLockMutex_089: 0x270993A6
@@ -3331,7 +3331,7 @@ modules:
           sceKernelSignalCondAll: 0xC2E7AC22
           sceKernelSignalCondTo: 0x1269F4EC
           sceKernelSignalSema: 0xE6B761D1
-          sceKernelStartThread_089: 0x21F5419B
+          sceKernelStartThread: 0x21F5419B
           sceKernelStartTimer: 0x48091E0C
           sceKernelStopTimer: 0x869E9F20
           sceKernelSuspendThreadForVM: 0x1FF5960D

--- a/db.yml
+++ b/db.yml
@@ -3513,6 +3513,8 @@ modules:
           ksceIo_set_1914_CB: 0xCFAECF18
           kscePfsMgrVfsMount: 0xFEEE44A9
           kscePfsMgrVfsUmount: 0xD220539D
+          ksceVfs_func12: 0xB07B307D
+          ksceVfs_func13: 0xF7DAC0F5
           ksceVfsAddVfs: 0x673D2FCD
           ksceVfsDeleteVfs: 0x9CBFA725
           ksceVfsGetNewNode: 0xD60B5C63
@@ -3522,9 +3524,7 @@ modules:
           ksceVfsNode_func10: 0x2F3F8C70
           ksceVfsNode_func11: 0x1D551105
           ksceVfsNode_func12: 0x00C9C2DD
-          ksceVfsNode_func12: 0xB07B307D
           ksceVfsNode_func13: 0x1350F5C7
-          ksceVfsNode_func13: 0xF7DAC0F5
           ksceVfsNode_func14: 0x77584C8F
           ksceVfsNode_func15: 0x50A63ACF
           ksceVfsNode_func16: 0x1974FA92

--- a/db.yml
+++ b/db.yml
@@ -2025,19 +2025,6 @@ modules:
   SceKernelThreadMgr:
     nid: 0xF46ED7B2
     libraries:
-      SceThreadmgrForKernel:
-        nid: 0xA8CA0EFD
-        kernel: true
-        functions:
-          ksceKernelCreateMutex: 0xFBAA026E
-          ksceKernelCreateSema: 0x30E93C31
-          ksceKernelDeleteMutex: 0x0A912340
-          ksceKernelDeleteSema: 0x16A35E58
-          ksceKernelLockMutex_089: 0x16AC80C5
-          ksceKernelRunWithStack: 0xE54FD746
-          ksceKernelSignalSema: 0xD270498B
-          ksceKernelUnlockMutex_089: 0x1E82E5D0
-          ksceKernelWaitSema: 0x3C8B55A9
       SceThreadmgrForDriver:
         nid: 0xE2C40624
         kernel: true

--- a/db.yml
+++ b/db.yml
@@ -1737,129 +1737,300 @@ modules:
   SceSysmem:
     nid: 0x3380B323
     libraries:
-      SceSysmemForDriver:
-        kernel: true
-        nid: 0x6F25E18A
-        functions:
-          ksceKernelMemcpyKernelToUser: 0x6D88EF8A
-          ksceKernelMemcpyUserToKernel: 0xBC996A7A
-          ksceKernelStrncpyKernelToUser: 0x80BD6FEB
-          ksceKernelStrncpyUserToKernel: 0xDB3EC244
-          ksceKernelStrlenUser: 0xB429D419
-          ksceKernelGetPaddr: 0x8D160E65
-          ksceKernelGetPaddrList: 0xE68BEEBD
-          ksceKernelFindMemBlockByAddr: 0x8A1742F6
-          ksceKernelRemapBlock: 0xDFE2C8CB
-          ksceKernelCreateHeap: 0x9328E0E8
-          ksceKernelDeleteHeap: 0xD6437637
-          ksceKernelAllocHeapMemory: 0x7B4CB60A
-          ksceKernelFreeHeapMemory: 0x3EBCE343
-          ksceKernelMapUserBlock: 0x7D4F8B5F
-          ksceKernelSwitchVmaForPid: 0x6F2ACDAE
-          ksceKernelRoMemcpyKernelToUserForPid: 0x571D2739
-          ksceKernelFirstDifferentIntUserForPid: 0x8334454F
-          ksceKernelStrnlenUserForPid: 0x9929EB07
-          ksceKernelStrncpyUserForPid: 0x75AAF178
-          ksceKernelMemcpyKernelToUserForPidUnchecked: 0xFED82F2D
-          ksceKernelMemcpyKernelToUserForPid: 0x6B825479
-          ksceKernelMemcpyUserToKernelForPid: 0x605275F8
-          ksceKernelMemcpyUserToUserForPid: 0x8E086C33
-          ksceKernelKernelUidForUserUid: 0x45D22597
-          ksceKernelCreateUserUid: 0xBF209859
-          ksceKernelGetObjForUid: 0xED6C14
-          ksceKernelGetUidClass: 0x85336A1C
-          ksceKernelCreateClass: 0x61317102
-          ksceKernelDeleteUid: 0x47D32F2
-          ksceKernelDeleteUserUid: 0x84A4AF5E
-          ksceKernelAllocMemBlock: 0xC94850C9
-          ksceKernelGetMemBlockBase: 0xA841EDDA
-          ksceKernelFreeMemBlock: 0x9E1C61
-          ksceKernelGetPidContext: 0x2ECF7944
-          ksceKernelMapBlockUserVisible: 0x58D21746
-          ksceKernelUnmapMemBlock: 0xFFCD9B60
-          ksceKernelUidRetain: 0xF5C84B7
-          ksceKernelUidRelease: 0x149885C4
       SceSysmemForKernel:
-        kernel: true
         nid: 0x63A519E5
+        kernel: true
         functions:
+          SceSysmemForKernel_00BC5B4A: 0x00BC5B4A
+          SceSysmemForKernel_01DE3AB7: 0x01DE3AB7
+          SceSysmemForKernel_07FEBBCA: 0x07FEBBCA
+          SceSysmemForKernel_080BA2F3: 0x080BA2F3
+          SceSysmemForKernel_08AB3DAE: 0x08AB3DAE
+          SceSysmemForKernel_0A8D14EC: 0x0A8D14EC
+          SceSysmemForKernel_0FD6B756: 0x0FD6B756
+          SceSysmemForKernel_114E6476: 0x114E6476
+          SceSysmemForKernel_12ED88AE: 0x12ED88AE
+          SceSysmemForKernel_131CEF52: 0x131CEF52
+          SceSysmemForKernel_153A08A0: 0x153A08A0
+          SceSysmemForKernel_17F1AA22: 0x17F1AA22
+          SceSysmemForKernel_18B99FDD: 0x18B99FDD
+          SceSysmemForKernel_19CAEF35: 0x19CAEF35
+          SceSysmemForKernel_1E11F41D: 0x1E11F41D
+          SceSysmemForKernel_210DB518: 0x210DB518
+          SceSysmemForKernel_21285F40: 0x21285F40
+          SceSysmemForKernel_219E90FD: 0x219E90FD
+          SceSysmemForKernel_22708F14: 0x22708F14
+          SceSysmemForKernel_22A26637: 0x22A26637
+          SceSysmemForKernel_22F79E82: 0x22F79E82
+          SceSysmemForKernel_2364A170: 0x2364A170
+          SceSysmemForKernel_2476B90F: 0x2476B90F
+          SceSysmemForKernel_2658EE0A: 0x2658EE0A
+          SceSysmemForKernel_2770A7D7: 0x2770A7D7
+          SceSysmemForKernel_2791F109: 0x2791F109
+          SceSysmemForKernel_289BE3EC: 0x289BE3EC
+          SceSysmemForKernel_2A79C51C: 0x2A79C51C
+          SceSysmemForKernel_2AEA9E09: 0x2AEA9E09
+          SceSysmemForKernel_2E36E0C4: 0x2E36E0C4
+          SceSysmemForKernel_2EE50533: 0x2EE50533
+          SceSysmemForKernel_2F6F9C2C: 0x2F6F9C2C
+          SceSysmemForKernel_3203AE64: 0x3203AE64
+          SceSysmemForKernel_3650963F: 0x3650963F
+          SceSysmemForKernel_36830F46: 0x36830F46
+          SceSysmemForKernel_3B75CBED: 0x3B75CBED
+          SceSysmemForKernel_3EC2345B: 0x3EC2345B
+          SceSysmemForKernel_3F74E45C: 0x3F74E45C
+          SceSysmemForKernel_3FCA782B: 0x3FCA782B
+          SceSysmemForKernel_43DFCE89: 0x43DFCE89
+          SceSysmemForKernel_43E81C4B: 0x43E81C4B
+          SceSysmemForKernel_4492421F: 0x4492421F
+          SceSysmemForKernel_45F2A59C: 0x45F2A59C
+          SceSysmemForKernel_46A5CB84: 0x46A5CB84
+          SceSysmemForKernel_48750A5A: 0x48750A5A
+          SceSysmemForKernel_48D87E17: 0x48D87E17
+          SceSysmemForKernel_4A3737F0: 0x4A3737F0
+          SceSysmemForKernel_4B5C85AC: 0x4B5C85AC
+          SceSysmemForKernel_4CCA935D: 0x4CCA935D
+          SceSysmemForKernel_4D38F861: 0x4D38F861
+          SceSysmemForKernel_4D809B47: 0x4D809B47
+          SceSysmemForKernel_4FA4A624: 0x4FA4A624
+          SceSysmemForKernel_53A2E272: 0x53A2E272
+          SceSysmemForKernel_53E1FFDE: 0x53E1FFDE
+          SceSysmemForKernel_5409397F: 0x5409397F
+          SceSysmemForKernel_54E85275: 0x54E85275
+          SceSysmemForKernel_571660AA: 0x571660AA
+          SceSysmemForKernel_59F577E8: 0x59F577E8
+          SceSysmemForKernel_5C257482: 0x5C257482
+          SceSysmemForKernel_5E169FEF: 0x5E169FEF
+          SceSysmemForKernel_5FFE4B79: 0x5FFE4B79
+          SceSysmemForKernel_60735311: 0x60735311
+          SceSysmemForKernel_61C2AA52: 0x61C2AA52
+          SceSysmemForKernel_620E00E7: 0x620E00E7
+          SceSysmemForKernel_62989905: 0x62989905
+          SceSysmemForKernel_63D83911: 0x63D83911
+          SceSysmemForKernel_64133268: 0x64133268
+          SceSysmemForKernel_6427560F: 0x6427560F
+          SceSysmemForKernel_653B0849: 0x653B0849
+          SceSysmemForKernel_66636970: 0x66636970
+          SceSysmemForKernel_67955EE9: 0x67955EE9
+          SceSysmemForKernel_67BAD5B4: 0x67BAD5B4
+          SceSysmemForKernel_68451777: 0x68451777
+          SceSysmemForKernel_686AA15C: 0x686AA15C
+          SceSysmemForKernel_68CB9266: 0x68CB9266
+          SceSysmemForKernel_6B3F4102: 0x6B3F4102
+          SceSysmemForKernel_6BB6AF94: 0x6BB6AF94
+          SceSysmemForKernel_71869119: 0x71869119
+          SceSysmemForKernel_72E7BFAC: 0x72E7BFAC
+          SceSysmemForKernel_775AA5E3: 0x775AA5E3
+          SceSysmemForKernel_77876A8D: 0x77876A8D
+          SceSysmemForKernel_789CD5BF: 0x789CD5BF
+          SceSysmemForKernel_7ABFA9A7: 0x7ABFA9A7
+          SceSysmemForKernel_7BD56D6D: 0x7BD56D6D
+          SceSysmemForKernel_7BE4D3D1: 0x7BE4D3D1
+          SceSysmemForKernel_7D92B2D3: 0x7D92B2D3
+          SceSysmemForKernel_7DC46969: 0x7DC46969
+          SceSysmemForKernel_7FD757FE: 0x7FD757FE
+          SceSysmemForKernel_7FDF483A: 0x7FDF483A
+          SceSysmemForKernel_812E7A53: 0x812E7A53
+          SceSysmemForKernel_86E83C0D: 0x86E83C0D
+          SceSysmemForKernel_876A7F44: 0x876A7F44
+          SceSysmemForKernel_89CE1F31: 0x89CE1F31
+          SceSysmemForKernel_8B07BB52: 0x8B07BB52
+          SceSysmemForKernel_8C8E2DD1: 0x8C8E2DD1
+          SceSysmemForKernel_8D6AF468: 0x8D6AF468
+          SceSysmemForKernel_8FB73A29: 0x8FB73A29
+          SceSysmemForKernel_91733EF4: 0x91733EF4
+          SceSysmemForKernel_942D15FC: 0x942D15FC
+          SceSysmemForKernel_95ABFDC3: 0x95ABFDC3
+          SceSysmemForKernel_9894B9E1: 0x9894B9E1
+          SceSysmemForKernel_98E6905B: 0x98E6905B
+          SceSysmemForKernel_9C53F457: 0x9C53F457
+          SceSysmemForKernel_9C7B62AB: 0x9C7B62AB
+          SceSysmemForKernel_A1FFA2C9: 0xA1FFA2C9
+          SceSysmemForKernel_A2CD1697: 0xA2CD1697
+          SceSysmemForKernel_A504BA60: 0xA504BA60
+          SceSysmemForKernel_A6F95838: 0xA6F95838
+          SceSysmemForKernel_A88F6D88: 0xA88F6D88
+          SceSysmemForKernel_ABAB0FAB: 0xABAB0FAB
+          SceSysmemForKernel_AD5A83E3: 0xAD5A83E3
+          SceSysmemForKernel_AF180A3F: 0xAF180A3F
+          SceSysmemForKernel_AF42AAD5: 0xAF42AAD5
+          SceSysmemForKernel_AF729575: 0xAF729575
+          SceSysmemForKernel_B16D5136: 0xB16D5136
+          SceSysmemForKernel_B339A865: 0xB339A865
+          SceSysmemForKernel_B3E2AA7A: 0xB3E2AA7A
+          SceSysmemForKernel_B543A23C: 0xB543A23C
+          SceSysmemForKernel_B60568F9: 0xB60568F9
+          SceSysmemForKernel_B8D769C6: 0xB8D769C6
+          SceSysmemForKernel_BC2E2B2B: 0xBC2E2B2B
+          SceSysmemForKernel_BF0294E4: 0xBF0294E4
+          SceSysmemForKernel_BF04FC83: 0xBF04FC83
+          SceSysmemForKernel_C0A4D2F3: 0xC0A4D2F3
+          SceSysmemForKernel_C0BF149E: 0xC0BF149E
+          SceSysmemForKernel_C105604E: 0xC105604E
+          SceSysmemForKernel_C2F7D8A4: 0xC2F7D8A4
+          SceSysmemForKernel_C38B4D52: 0xC38B4D52
+          SceSysmemForKernel_C69666C3: 0xC69666C3
+          SceSysmemForKernel_C6F04370: 0xC6F04370
+          SceSysmemForKernel_C8672A3D: 0xC8672A3D
+          SceSysmemForKernel_CA91B9D5: 0xCA91B9D5
+          SceSysmemForKernel_CB8D03C0: 0xCB8D03C0
+          SceSysmemForKernel_CC7BB240: 0xCC7BB240
+          SceSysmemForKernel_CD985AEB: 0xCD985AEB
+          SceSysmemForKernel_CE72839E: 0xCE72839E
+          SceSysmemForKernel_CEBA8031: 0xCEBA8031
+          SceSysmemForKernel_CF53EEE4: 0xCF53EEE4
+          SceSysmemForKernel_CF5A2311: 0xCF5A2311
+          SceSysmemForKernel_D449547B: 0xD449547B
+          SceSysmemForKernel_D514BB56: 0xD514BB56
+          SceSysmemForKernel_D7B323EB: 0xD7B323EB
+          SceSysmemForKernel_E443253B: 0xE443253B
+          SceSysmemForKernel_E65EA709: 0xE65EA709
+          SceSysmemForKernel_E68A9F1B: 0xE68A9F1B
+          SceSysmemForKernel_E7938BFB: 0xE7938BFB
+          SceSysmemForKernel_E90CFD62: 0xE90CFD62
+          SceSysmemForKernel_EB350679: 0xEB350679
+          SceSysmemForKernel_EC1293D2: 0xEC1293D2
+          SceSysmemForKernel_EC7D36EF: 0xEC7D36EF
+          SceSysmemForKernel_ECC68E7B: 0xECC68E7B
+          SceSysmemForKernel_ECF9435A: 0xECF9435A
+          SceSysmemForKernel_ED221825: 0xED221825
+          SceSysmemForKernel_EEB85560: 0xEEB85560
+          SceSysmemForKernel_F0C3FCFC: 0xF0C3FCFC
+          SceSysmemForKernel_F1433852: 0xF1433852
+          SceSysmemForKernel_F2179820: 0xF2179820
+          SceSysmemForKernel_F2D7FE3A: 0xF2D7FE3A
+          SceSysmemForKernel_F4FA0575: 0xF4FA0575
+          SceSysmemForKernel_F7250E6C: 0xF7250E6C
+          SceSysmemForKernel_F81F4672: 0xF81F4672
+          SceSysmemForKernel_F8E95A5A: 0xF8E95A5A
+          SceSysmemForKernel_FAD03241: 0xFAD03241
+          SceSysmemForKernel_FAF96C1F: 0xFAF96C1F
+          SceSysmemForKernel_FC74A355: 0xFC74A355
+          SceSysmemForKernel_FDC0EA11: 0xFDC0EA11
+          SceSysmemForKernel_FEF54604: 0xFEF54604
           ksceKernelCreateUidObj: 0xDF0288D7
           ksceKernelRxMemcpyKernelToUserForPid: 0x30931572
-      SceSysclibForDriver:
+      SceSysmemForDriver:
+        nid: 0x6F25E18A
         kernel: true
-        nid: 0x7EE45391
         functions:
-          __stack_chk_fail: 0xB997493D
-          memchr: 0x60DAEA30
-          memcmp: 0xF939E83D
-          memcpy: 0x40C88316
-          memmove: 0x6CC9C1A1
-          memset: 0xAB9BF5C
-          rshift: 0x1D89F6C0
-          snprintf: 0xAE7A8981
-          strchr: 0x38463759
-          strcmp: 0xB33BC43
-          strcpy: 0x7FB4EBEC
-          strlen: 0xCFC6A9AC
-          strncat: 0xA1D1C32C
-          strncmp: 0x12CEE649
-          strncpy: 0x6D286146
-          strnlen: 0xCD4BD884
-          strrchr: 0x7F0E0835
-          strstr: 0x1304A69D
-          strtol: 0xAB77C5AA
-          tolower: 0x0021DAF9
-          toupper: 0xA685DCB1
-      SceCpuForKernel:
-        kernel: true
-        nid: 0x54BF2BAB
-        functions:
-          ksceKernelCpuDcacheInvalidateAll: 0x2F3BF020
-          ksceKernelCpuDcacheWritebackAll: 0x73A30DB2
-          ksceKernelCpuDcacheWritebackInvalidateAll: 0x76DAB4D0
-          ksceKernelCpuIcacheInvalidateRange: 0xF4C7F578
-          ksceKernelCpuIcacheInvalidateAll: 0x264DA250
-          ksceKernelCpuIcacheAndL2WritebackInvalidateRange: 0x19F17BD0
-          ksceKernelCpuSaveContext: 0x211B89DA
-          ksceKernelCpuUnrestrictedMemcpy: 0x8C683DEC
-          ksceKernelCpuDcacheWritebackInvalidateRange: 0x6BA2E51C
-          ksceKernelCpuRestoreContext: 0xA4F0FB9
-      SceCpuForDriver:
-        kernel: true
-        nid: 0x40ECDB0E
-        functions:
-          ksceKernelCpuDcacheAndL2InvalidateRange: 0x02796361
-          ksceKernelCpuDcacheAndL2WritebackRange: 0x103872A5
-          ksceKernelCpuDcacheAndL2WritebackInvalidateRange: 0x364E68A4
-          ksceKernelCpuDisableInterrupts: 0x821FC0EE
-          ksceKernelCpuDcacheWritebackRange: 0x9CB9F0CE
-          ksceKernelCpuDcacheInvalidateRange: 0x8B4C26DF
-          ksceKernelCpuEnableInterrupts: 0xF5BAD43B
-          ksceKernelCpuResumeIntr: 0x7BB9D5DF
-          ksceKernelCpuSuspendIntr: 0xD32ACE9E
-      SceSysrootForKernel:
-        kernel: true
-        nid: 0x3691DA45
-        functions:
-          ksceKernelGetSysrootBuffer: 0x3E455842
-          ksceKernelGetProcessTitleId: 0xEC3124A3
-          ksceSysrootIsAuCodecIcConexant: 0x46E72428
-          ksceSysrootIsBsodReboot: 0x4373AC96
-          ksceSysrootIsExternalBootMode: 0x89D19090
-          ksceSysrootIsManufacturingMode: 0x55392965
-          ksceSysrootIsSafeMode: 0x834439A7
-          ksceSysrootIsUpdateMode: 0xB0E1FC67
-          ksceSysrootIsUsbEnumWakeup: 0x79C9AE10
-          ksceSysrootUseInternalStorage: 0x50FE3B4D
-      SceKernelSuspendForDriver:
-        kernel: true
-        nid: 0x7290B21C
-        functions:
-          ksceKernelRegisterSuspendCallback: 0x04C05D10
-          ksceKernelUnregisterSuspendCallback: 0xDD61D621
-          ksceKernelNotifySuspendCallback: 0xD4622EA8
-          ksceKernelPowerTick: 0xE0489831
+          SceSysmemForDriver_00575B00: 0x00575B00
+          SceSysmemForDriver_04059C4B: 0x04059C4B
+          SceSysmemForDriver_08A8A7E8: 0x08A8A7E8
+          SceSysmemForDriver_09896EB7: 0x09896EB7
+          SceSysmemForDriver_0AAA4FDD: 0x0AAA4FDD
+          SceSysmemForDriver_0B1FD5C3: 0x0B1FD5C3
+          SceSysmemForDriver_0B4ED16A: 0x0B4ED16A
+          SceSysmemForDriver_0FC24464: 0x0FC24464
+          SceSysmemForDriver_12624884: 0x12624884
+          SceSysmemForDriver_13805CA8: 0x13805CA8
+          SceSysmemForDriver_16713BE8: 0x16713BE8
+          SceSysmemForDriver_16844CE6: 0x16844CE6
+          SceSysmemForDriver_184172B1: 0x184172B1
+          SceSysmemForDriver_19A51AC7: 0x19A51AC7
+          SceSysmemForDriver_1BD44DD5: 0x1BD44DD5
+          SceSysmemForDriver_1EFC96EA: 0x1EFC96EA
+          SceSysmemForDriver_20C811FA: 0x20C811FA
+          SceSysmemForDriver_22CBE925: 0x22CBE925
+          SceSysmemForDriver_24A99FFF: 0x24A99FFF
+          SceSysmemForDriver_2D711589: 0x2D711589
+          SceSysmemForDriver_32257A24: 0x32257A24
+          SceSysmemForDriver_49D4DD9B: 0x49D4DD9B
+          SceSysmemForDriver_4C584B29: 0x4C584B29
+          SceSysmemForDriver_4CFA4100: 0x4CFA4100
+          SceSysmemForDriver_513B9DDD: 0x513B9DDD
+          SceSysmemForDriver_59A4402F: 0x59A4402F
+          SceSysmemForDriver_61A67D32: 0x61A67D32
+          SceSysmemForDriver_64DBE472: 0x64DBE472
+          SceSysmemForDriver_65419BD3: 0x65419BD3
+          SceSysmemForDriver_659586BF: 0x659586BF
+          SceSysmemForDriver_6A0792A3: 0x6A0792A3
+          SceSysmemForDriver_6C76AD89: 0x6C76AD89
+          SceSysmemForDriver_72A98D17: 0x72A98D17
+          SceSysmemForDriver_75C70DE0: 0x75C70DE0
+          SceSysmemForDriver_77066FD1: 0x77066FD1
+          SceSysmemForDriver_7750CEA7: 0x7750CEA7
+          SceSysmemForDriver_78337B62: 0x78337B62
+          SceSysmemForDriver_856FA2E3: 0x856FA2E3
+          SceSysmemForDriver_857F1D5A: 0x857F1D5A
+          SceSysmemForDriver_89475192: 0x89475192
+          SceSysmemForDriver_89A44858: 0x89A44858
+          SceSysmemForDriver_8C43B052: 0x8C43B052
+          SceSysmemForDriver_8DA0BCA5: 0x8DA0BCA5
+          SceSysmemForDriver_987EE587: 0x987EE587
+          SceSysmemForDriver_98C15666: 0x98C15666
+          SceSysmemForDriver_9C78064C: 0x9C78064C
+          SceSysmemForDriver_9F6E45E3: 0x9F6E45E3
+          SceSysmemForDriver_A73CFFEF: 0xA73CFFEF
+          SceSysmemForDriver_A78755EB: 0xA78755EB
+          SceSysmemForDriver_A7C0D1FC: 0xA7C0D1FC
+          SceSysmemForDriver_A8525B06: 0xA8525B06
+          SceSysmemForDriver_AE36C775: 0xAE36C775
+          SceSysmemForDriver_B3575090: 0xB3575090
+          SceSysmemForDriver_B415B5A8: 0xB415B5A8
+          SceSysmemForDriver_B81CF0A3: 0xB81CF0A3
+          SceSysmemForDriver_BB3B02C2: 0xBB3B02C2
+          SceSysmemForDriver_BC0A1D60: 0xBC0A1D60
+          SceSysmemForDriver_BDA6E42B: 0xBDA6E42B
+          SceSysmemForDriver_C50A9C0D: 0xC50A9C0D
+          SceSysmemForDriver_C74B0152: 0xC74B0152
+          SceSysmemForDriver_C9928F5E: 0xC9928F5E
+          SceSysmemForDriver_CB0F3A33: 0xCB0F3A33
+          SceSysmemForDriver_CED1547B: 0xCED1547B
+          SceSysmemForDriver_D44F464D: 0xD44F464D
+          SceSysmemForDriver_D76E7452: 0xD76E7452
+          SceSysmemForDriver_E655852F: 0xE655852F
+          SceSysmemForDriver_E83855FD: 0xE83855FD
+          SceSysmemForDriver_E9728A12: 0xE9728A12
+          SceSysmemForDriver_EAF3849B: 0xEAF3849B
+          SceSysmemForDriver_F3BBE2E1: 0xF3BBE2E1
+          SceSysmemForDriver_F4AD89D8: 0xF4AD89D8
+          SceSysmemForDriver_F50BDC0C: 0xF50BDC0C
+          SceSysmemForDriver_F6DB54BA: 0xF6DB54BA
+          SceSysmemForDriver_FB817A59: 0xFB817A59
+          SceSysmemForDriver_FE6D7FAE: 0xFE6D7FAE
+          ksceKernelAllocHeapMemory: 0x7B4CB60A
+          ksceKernelAllocMemBlock: 0xC94850C9
+          ksceKernelCreateClass: 0x61317102
+          ksceKernelCreateEvent: 0x56A13E90
+          ksceKernelCreateHeap: 0x9328E0E8
+          ksceKernelCreateUserUid: 0xBF209859
+          ksceKernelDeleteHeap: 0xD6437637
+          ksceKernelDeleteUid: 0x047D32F2
+          ksceKernelDeleteUserUid: 0x84A4AF5E
+          ksceKernelFindMemBlockByAddr: 0x8A1742F6
+          ksceKernelFirstDifferentIntUserForPid: 0x8334454F
+          ksceKernelFreeHeapMemory: 0x3EBCE343
+          ksceKernelFreeMemBlock: 0x009E1C61
+          ksceKernelGetMemBlockBase: 0xA841EDDA
+          ksceKernelGetObjForUid: 0x00ED6C14
+          ksceKernelGetPaddr: 0x8D160E65
+          ksceKernelGetPaddrList: 0xE68BEEBD
+          ksceKernelGetPidContext: 0x2ECF7944
+          ksceKernelGetUidClass: 0x85336A1C
+          ksceKernelKernelUidForUserUid: 0x45D22597
+          ksceKernelMapBlockUserVisible: 0x58D21746
+          ksceKernelMapUserBlock: 0x7D4F8B5F
+          ksceKernelMapUserBlockDefault2: 0x0091D74D
+          ksceKernelMapUserBlockDefault: 0x278BC201
+          ksceKernelMemcpyKernelToUser: 0x6D88EF8A
+          ksceKernelMemcpyKernelToUserForPid: 0x6B825479
+          ksceKernelMemcpyKernelToUserForPidUnchecked: 0xFED82F2D
+          ksceKernelMemcpyUserToKernel: 0xBC996A7A
+          ksceKernelMemcpyUserToKernelForPid: 0x605275F8
+          ksceKernelMemcpyUserToUserForPid: 0x8E086C33
+          ksceKernelRemapBlock: 0xDFE2C8CB
+          ksceKernelStrncpyKernelToUser: 0x80BD6FEB
+          ksceKernelStrncpyUserForPid: 0x75AAF178
+          ksceKernelStrncpyUserToKernel: 0xDB3EC244
+          ksceKernelStrnlenUser: 0xB429D419
+          ksceKernelStrnlenUserForPid: 0x9929EB07
+          ksceKernelUidRelease: 0x149885C4
+          ksceKernelUidRetain: 0x0F5C84B7
+          ksceKernelUnmapMemBlock: 0xFFCD9B60
       SceSysmem:
+        nid: 0x37FE725A
+        kernel: false
         functions:
           sceKernelAllocMemBlock: 0xB9D5EBDE
           sceKernelAllocMemBlockForVM: 0xE2D7E137
@@ -1873,31 +2044,327 @@ modules:
           sceKernelGetFreeMemorySize: 0x87CC580B
           sceKernelGetMemBlockBase: 0xB8EF5818
           sceKernelGetMemBlockInfoByAddr: 0x4010AD65
-          sceKernelGetMemBlockInfoByRange: 0x6F3DB4
-          sceKernelGetModelForCDialog: 0xA2CB322F
+          sceKernelGetMemBlockInfoByRange: 0x006F3DB4
           sceKernelGetModel: 0xD0D4F729
+          sceKernelGetModelForCDialog: 0xA2CB322F
           sceKernelGetSubbudgetInfo: 0x832B4A65
           sceKernelIsPSVitaTV: 0x1453A5E5
           sceKernelOpenMemBlock: 0x8EB8DFBB
           sceKernelOpenVMDomain: 0x9CA3EB2B
           sceKernelSyncVMDomain: 0x19D2A81A
+      SceDebugLed:
+        nid: 0xAE004C0A
         kernel: false
-        nid: 0x37FE725A
-      SceSblAIMgrForDriver:
         functions:
-          ksceSblAimgrGetSMI: 0x47D9CF13
-          ksceSblAimgrIsTest: 0x3B638885
-          ksceSblAimgrIsTool: 0x274663A0
-          ksceSblAimgrIsDEX: 0xF4B98F66
-          ksceSblAimgrIsCEX: 0xD78B04A2
-          ksceSblAimgrIsVITA: 0x4273B97B
-          ksceSblAimgrIsDolce: 0x71608CA3
-          ksceSblAimgrIsGenuineVITA: 0x963CA644
-          ksceSblAimgrIsGenuineDolce: 0xC6E83F34
+          SceDebugLed_0E6B9890: 0x0E6B9890
+          SceDebugLed_2B6EABAD: 0x2B6EABAD
+          sceKernelGetGPI: 0x14F582CF
+          sceKernelSetGPO: 0x78E702D3
+      SceDebugLedForDriver:
+        nid: 0x7BC05EAD
         kernel: true
-        nid: 0xFD00C69A
-      SceKernelUtilsForDriver:
         functions:
+          SceDebugLedForDriver_098473B0: 0x098473B0
+          SceDebugLedForDriver_0E6B9890: 0x0E6B9890
+          SceDebugLedForDriver_24173819: 0x24173819
+          SceDebugLedForDriver_2B6EABAD: 0x2B6EABAD
+          SceDebugLedForDriver_3BB289F7: 0x3BB289F7
+          SceDebugLedForDriver_51C5325A: 0x51C5325A
+          SceDebugLedForDriver_F62154E7: 0xF62154E7
+          ksceKernelGetGPI: 0x14F582CF
+          ksceKernelSetGPO: 0x78E702D3
+      SceDipsw:
+        nid: 0xB36D5922
+        kernel: false
+        functions:
+          sceKernelCheckDipsw: 0x1C783FB2
+          sceKernelClearDipsw: 0x800EDCC1
+          sceKernelSetDipsw: 0x817053D4
+      SceDipswForDriver:
+        nid: 0xC9E26388
+        kernel: true
+        functions:
+          SceDipswForDriver_B2AD48BE: 0xB2AD48BE
+          ksceKernelCheckDipsw: 0xA98FC2FD
+          ksceKernelClearDipsw: 0xF1F3E9FE
+          ksceKernelSetDipsw: 0x82E45FBF
+      SceUartForKernel:
+        nid: 0xC03DBE40
+        kernel: true
+        functions:
+          ksceUartInit: 0xA9C74212
+          ksceUartRead: 0x9BBF1255
+          ksceUartReadAvailable: 0x38DB7629
+          ksceUartWrite: 0x41973874
+      SceDebugForKernel:
+        nid: 0x88C17370
+        kernel: true
+        functions:
+          SceDebugForKernel_082B8D6A: 0x082B8D6A
+          SceDebugForKernel_1526DD83: 0x1526DD83
+          SceDebugForKernel_254A4997: 0x254A4997
+          SceDebugForKernel_25E31E18: 0x25E31E18
+          SceDebugForKernel_66D82EC8: 0x66D82EC8
+          SceDebugForKernel_B5943011: 0xB5943011
+          SceDebugForKernel_BE2C05A2: 0xBE2C05A2
+          SceDebugForKernel_BEF921A2: 0xBEF921A2
+          SceDebugForKernel_CE9060F1: 0xCE9060F1
+          SceDebugForKernel_EFF9962B: 0xEFF9962B
+          SceDebugForKernel_F1F861CF: 0xF1F861CF
+          SceDebugForKernel_F624CE22: 0xF624CE22
+          ksceDebugDisableInfoDump: 0xF857CDD6
+          ksceDebugGetPutcharHandler: 0xE783518C
+          ksceDebugPutchar: 0x82D2EDCE
+          ksceDebugRegisterPutcharHandler: 0xE6115A72
+          ksceDebugSetHandlers: 0x10067B7B
+      SceDebugForDriver:
+        nid: 0x88758561
+        kernel: true
+        functions:
+          SceDebugForDriver_00CCE39C: 0x00CCE39C
+          SceDebugForDriver_1A3F2AA4: 0x1A3F2AA4
+          SceDebugForDriver_35A35322: 0x35A35322
+          SceDebugForDriver_374B7868: 0x374B7868
+          SceDebugForDriver_391B5B74: 0x391B5B74
+          SceDebugForDriver_411C0733: 0x411C0733
+          SceDebugForDriver_611A158B: 0x611A158B
+          SceDebugForDriver_62466B0A: 0x62466B0A
+          SceDebugForDriver_821A2D59: 0x821A2D59
+          SceDebugForDriver_912CF2BA: 0x912CF2BA
+          SceDebugForDriver_95B38C6C: 0x95B38C6C
+          SceDebugForDriver_CC5365D3: 0xCC5365D3
+          SceDebugForDriver_D9703808: 0xD9703808
+          SceDebugForDriver_FD753E7A: 0xFD753E7A
+          ksceDebugPrintf2: 0x02B04343
+          ksceDebugPrintf: 0x391B74B7
+      SceSysclibForDriver:
+        nid: 0x7EE45391
+        kernel: true
+        functions:
+          SceSysclibForDriver_12504E09: 0x12504E09
+          SceSysclibForDriver_1A30BB28: 0x1A30BB28
+          SceSysclibForDriver_224BE33F: 0x224BE33F
+          SceSysclibForDriver_2518CD9E: 0x2518CD9E
+          SceSysclibForDriver_33EE298B: 0x33EE298B
+          SceSysclibForDriver_35DBB110: 0x35DBB110
+          SceSysclibForDriver_3DDBE2E1: 0x3DDBE2E1
+          SceSysclibForDriver_4E5042DA: 0x4E5042DA
+          SceSysclibForDriver_545DA5FD: 0x545DA5FD
+          SceSysclibForDriver_709077A1: 0x709077A1
+          SceSysclibForDriver_72D31F9D: 0x72D31F9D
+          SceSysclibForDriver_7554AB04: 0x7554AB04
+          SceSysclibForDriver_7DBE7007: 0x7DBE7007
+          SceSysclibForDriver_87AAAFA2: 0x87AAAFA2
+          SceSysclibForDriver_8A0B0815: 0x8A0B0815
+          SceSysclibForDriver_96268C53: 0x96268C53
+          SceSysclibForDriver_9D148CDE: 0x9D148CDE
+          SceSysclibForDriver_AC86B4BA: 0xAC86B4BA
+          SceSysclibForDriver_B5A4D745: 0xB5A4D745
+          SceSysclibForDriver_CBF64DF6: 0xCBF64DF6
+          SceSysclibForDriver_CDF7F155: 0xCDF7F155
+          SceSysclibForDriver_CF86EA38: 0xCF86EA38
+          SceSysclibForDriver_DE4666F0: 0xDE4666F0
+          SceSysclibForDriver_E38E7605: 0xE38E7605
+          SceSysclibForDriver_E46C47E6: 0xE46C47E6
+          SceSysclibForDriver_FE39AEAC: 0xFE39AEAC
+          SceSysclibForDriver_FE900DE8: 0xFE900DE8
+          SceSysclibForDriver_FEE5E751: 0xFEE5E751
+          __aeabi_uidiv: 0xA9FF1205
+          __aeabi_uidivmod: 0xA46CB7DE
+          __stack_chk_fail: 0xB997493D
+          memchr: 0x60DAEA30
+          memcmp: 0xF939E83D
+          memcpy: 0x40C88316
+          memmove: 0x6CC9C1A1
+          memset: 0x0AB9BF5C
+          rshift: 0x1D89F6C0
+          snprintf: 0xAE7A8981
+          strchr: 0x38463759
+          strcmp: 0x0B33BC43
+          strcpy: 0x7FB4EBEC
+          strlen: 0xCFC6A9AC
+          strncat: 0xA1D1C32C
+          strncmp: 0x12CEE649
+          strncpy: 0x6D286146
+          strnlen: 0xCD4BD884
+          strrchr: 0x7F0E0835
+          strstr: 0x1304A69D
+          strtol: 0xAB77C5AA
+          tolower: 0x0021DAF9
+          toupper: 0xA685DCB1
+      SceSysrootForKernel:
+        nid: 0x3691DA45
+        kernel: true
+        functions:
+          SceSysrootForKernel_06182D59: 0x06182D59
+          SceSysrootForKernel_085C2BCB: 0x085C2BCB
+          SceSysrootForKernel_0A12227B: 0x0A12227B
+          SceSysrootForKernel_0B79E220: 0x0B79E220
+          SceSysrootForKernel_0DF574A9: 0x0DF574A9
+          SceSysrootForKernel_0EB5D7CD: 0x0EB5D7CD
+          SceSysrootForKernel_0F2F2B4E: 0x0F2F2B4E
+          SceSysrootForKernel_118657C6: 0x118657C6
+          SceSysrootForKernel_1247A825: 0x1247A825
+          SceSysrootForKernel_14D81797: 0x14D81797
+          SceSysrootForKernel_1D84C4D4: 0x1D84C4D4
+          SceSysrootForKernel_1D8DB3A5: 0x1D8DB3A5
+          SceSysrootForKernel_20009397: 0x20009397
+          SceSysrootForKernel_20D2A0DF: 0x20D2A0DF
+          SceSysrootForKernel_21F5790B: 0x21F5790B
+          SceSysrootForKernel_256B2394: 0x256B2394
+          SceSysrootForKernel_26458702: 0x26458702
+          SceSysrootForKernel_27D30DB2: 0x27D30DB2
+          SceSysrootForKernel_2A03DFA1: 0x2A03DFA1
+          SceSysrootForKernel_2D6B2A79: 0x2D6B2A79
+          SceSysrootForKernel_2F75C1DC: 0x2F75C1DC
+          SceSysrootForKernel_2F97041A: 0x2F97041A
+          SceSysrootForKernel_340575CB: 0x340575CB
+          SceSysrootForKernel_36916C30: 0x36916C30
+          SceSysrootForKernel_377895EB: 0x377895EB
+          SceSysrootForKernel_37EC12BB: 0x37EC12BB
+          SceSysrootForKernel_38751FB7: 0x38751FB7
+          SceSysrootForKernel_3999F917: 0x3999F917
+          SceSysrootForKernel_3ACACD22: 0x3ACACD22
+          SceSysrootForKernel_3F76D531: 0x3F76D531
+          SceSysrootForKernel_403B509E: 0x403B509E
+          SceSysrootForKernel_40F28DC6: 0x40F28DC6
+          SceSysrootForKernel_41636522: 0x41636522
+          SceSysrootForKernel_42FC9FFF: 0x42FC9FFF
+          SceSysrootForKernel_47724459: 0x47724459
+          SceSysrootForKernel_491CE8DF: 0x491CE8DF
+          SceSysrootForKernel_4F0A4066: 0x4F0A4066
+          SceSysrootForKernel_4F57A13F: 0x4F57A13F
+          SceSysrootForKernel_571E5B79: 0x571E5B79
+          SceSysrootForKernel_59B76D23: 0x59B76D23
+          SceSysrootForKernel_5B5EBFB1: 0x5B5EBFB1
+          SceSysrootForKernel_5C426B19: 0x5C426B19
+          SceSysrootForKernel_5C86E49B: 0x5C86E49B
+          SceSysrootForKernel_5F2CE289: 0x5F2CE289
+          SceSysrootForKernel_6050A467: 0x6050A467
+          SceSysrootForKernel_611F17A4: 0x611F17A4
+          SceSysrootForKernel_62E8F511: 0x62E8F511
+          SceSysrootForKernel_63EBB05B: 0x63EBB05B
+          SceSysrootForKernel_642123EB: 0x642123EB
+          SceSysrootForKernel_6C036B53: 0x6C036B53
+          SceSysrootForKernel_6D111FA7: 0x6D111FA7
+          SceSysrootForKernel_6D44F190: 0x6D44F190
+          SceSysrootForKernel_71DB83A2: 0x71DB83A2
+          SceSysrootForKernel_7334F1E8: 0x7334F1E8
+          SceSysrootForKernel_733C243E: 0x733C243E
+          SceSysrootForKernel_73522F65: 0x73522F65
+          SceSysrootForKernel_73601453: 0x73601453
+          SceSysrootForKernel_7385CADE: 0x7385CADE
+          SceSysrootForKernel_77CF3FBD: 0x77CF3FBD
+          SceSysrootForKernel_7918D44E: 0x7918D44E
+          SceSysrootForKernel_7968F091: 0x7968F091
+          SceSysrootForKernel_7A7E7C0C: 0x7A7E7C0C
+          SceSysrootForKernel_7B7ED1E9: 0x7B7ED1E9
+          SceSysrootForKernel_7B7F8171: 0x7B7F8171
+          SceSysrootForKernel_7FC7A163: 0x7FC7A163
+          SceSysrootForKernel_82FC6405: 0x82FC6405
+          SceSysrootForKernel_84783B71: 0x84783B71
+          SceSysrootForKernel_8498E23F: 0x8498E23F
+          SceSysrootForKernel_84C0BE05: 0x84C0BE05
+          SceSysrootForKernel_8747D415: 0x8747D415
+          SceSysrootForKernel_88DE85EF: 0x88DE85EF
+          SceSysrootForKernel_89532E2F: 0x89532E2F
+          SceSysrootForKernel_8E4B61F1: 0x8E4B61F1
+          SceSysrootForKernel_9139E22B: 0x9139E22B
+          SceSysrootForKernel_9991B1AF: 0x9991B1AF
+          SceSysrootForKernel_9A8871F1: 0x9A8871F1
+          SceSysrootForKernel_9CFF80F9: 0x9CFF80F9
+          SceSysrootForKernel_9D058A32: 0x9D058A32
+          SceSysrootForKernel_A799F22A: 0xA799F22A
+          SceSysrootForKernel_A84676E3: 0xA84676E3
+          SceSysrootForKernel_A9510EFE: 0xA9510EFE
+          SceSysrootForKernel_AA8D34EE: 0xAA8D34EE
+          SceSysrootForKernel_AB3CC7D0: 0xAB3CC7D0
+          SceSysrootForKernel_AD74BEB3: 0xAD74BEB3
+          SceSysrootForKernel_AE2132FD: 0xAE2132FD
+          SceSysrootForKernel_AE55B7CC: 0xAE55B7CC
+          SceSysrootForKernel_AE7A8F1D: 0xAE7A8F1D
+          SceSysrootForKernel_B171CC2D: 0xB171CC2D
+          SceSysrootForKernel_B27B7530: 0xB27B7530
+          SceSysrootForKernel_B39CD708: 0xB39CD708
+          SceSysrootForKernel_B4C24588: 0xB4C24588
+          SceSysrootForKernel_B501E861: 0xB501E861
+          SceSysrootForKernel_BBFD2E3C: 0xBBFD2E3C
+          SceSysrootForKernel_BE1EF51C: 0xBE1EF51C
+          SceSysrootForKernel_BF82931F: 0xBF82931F
+          SceSysrootForKernel_C5EAF5F7: 0xC5EAF5F7
+          SceSysrootForKernel_C67A1FA9: 0xC67A1FA9
+          SceSysrootForKernel_C728BC61: 0xC728BC61
+          SceSysrootForKernel_C81B7E2B: 0xC81B7E2B
+          SceSysrootForKernel_C8C8C321: 0xC8C8C321
+          SceSysrootForKernel_CA497324: 0xCA497324
+          SceSysrootForKernel_CA8D1A2B: 0xCA8D1A2B
+          SceSysrootForKernel_CBD377B7: 0xCBD377B7
+          SceSysrootForKernel_CC119171: 0xCC119171
+          SceSysrootForKernel_CC7A0E63: 0xCC7A0E63
+          SceSysrootForKernel_CC85905B: 0xCC85905B
+          SceSysrootForKernel_CC893F37: 0xCC893F37
+          SceSysrootForKernel_CCB8BB5E: 0xCCB8BB5E
+          SceSysrootForKernel_CD4B84F7: 0xCD4B84F7
+          SceSysrootForKernel_CD8B5D37: 0xCD8B5D37
+          SceSysrootForKernel_D02281A8: 0xD02281A8
+          SceSysrootForKernel_D29BCA77: 0xD29BCA77
+          SceSysrootForKernel_D351EBC8: 0xD351EBC8
+          SceSysrootForKernel_D3872270: 0xD3872270
+          SceSysrootForKernel_D441DC34: 0xD441DC34
+          SceSysrootForKernel_D4457D4F: 0xD4457D4F
+          SceSysrootForKernel_D7198963: 0xD7198963
+          SceSysrootForKernel_D7207203: 0xD7207203
+          SceSysrootForKernel_DADFF828: 0xDADFF828
+          SceSysrootForKernel_DD7821AA: 0xDD7821AA
+          SceSysrootForKernel_E20F6FC8: 0xE20F6FC8
+          SceSysrootForKernel_E4EA1960: 0xE4EA1960
+          SceSysrootForKernel_ECADF8C3: 0xECADF8C3
+          SceSysrootForKernel_EEB867C0: 0xEEB867C0
+          SceSysrootForKernel_F2BC9E1D: 0xF2BC9E1D
+          SceSysrootForKernel_F4340469: 0xF4340469
+          SceSysrootForKernel_F6A6D205: 0xF6A6D205
+          SceSysrootForKernel_F8769E86: 0xF8769E86
+          SceSysrootForKernel_FBB91741: 0xFBB91741
+          SceSysrootForKernel_FF44A7BA: 0xFF44A7BA
+          SceSysrootForKernel_FF9F80FF: 0xFF9F80FF
+          SceSysrootForKernel_FFD6E24D: 0xFFD6E24D
+          ksceKernelGetProcessTitleId: 0xEC3124A3
+          ksceKernelGetSysbase: 0x3E455842
+          ksceKernelGetSysrootBuffer: 0x9DB56D1F
+          ksceSysrootGetElfInfo: 0xF10AB792
+          ksceSysrootIsBsodReboot: 0x4373AC96
+          ksceSysrootIsExternalBootMode: 0x89D19090
+          ksceSysrootIsManufacturingMode: 0x55392965
+          ksceSysrootIsSafeMode: 0x834439A7
+          ksceSysrootIsUpdateMode: 0xB0E1FC67
+          ksceSysrootIsUsbEnumWakeup: 0x79C9AE10
+          ksceSysrootUseInternalStorage: 0x50FE3B4D
+      SceKernelUtilsForDriver:
+        nid: 0x496AD8B4
+        kernel: true
+        functions:
+          SceKernelUtilsForDriver_0C39954E: 0x0C39954E
+          SceKernelUtilsForDriver_1DF3792A: 0x1DF3792A
+          SceKernelUtilsForDriver_222986EF: 0x222986EF
+          SceKernelUtilsForDriver_227B2E53: 0x227B2E53
+          SceKernelUtilsForDriver_335AF34D: 0x335AF34D
+          SceKernelUtilsForDriver_60ED6EA9: 0x60ED6EA9
+          SceKernelUtilsForDriver_801D0ED4: 0x801D0ED4
+          SceKernelUtilsForDriver_919C12E2: 0x919C12E2
+          SceKernelUtilsForDriver_A0D45D25: 0xA0D45D25
+          SceKernelUtilsForDriver_AE6C45FB: 0xAE6C45FB
+          SceKernelUtilsForDriver_AFD56168: 0xAFD56168
+          SceKernelUtilsForDriver_B55C69B7: 0xB55C69B7
+          SceKernelUtilsForDriver_BB6E35CD: 0xBB6E35CD
+          SceKernelUtilsForDriver_C76A7685: 0xC76A7685
+          SceKernelUtilsForDriver_D428CC2A: 0xD428CC2A
+          ksceAESDecrypt2: 0xE39CD272
+          ksceAESDecrypt: 0xD8678061
+          ksceAESEncrypt2: 0x302947B6
+          ksceAESEncrypt: 0xC2A61770
+          ksceAESInit2: 0xEDA97D6D
+          ksceAESInit3: 0x72408E29
+          ksceAESInit: 0xF12B6451
           ksceDeflateDecompress: 0x8AF1FAD4
           ksceDeflateDecompressPartial: 0x3D74CCDF
           ksceGzipDecompress: 0x367EE3DF
@@ -1906,6 +2373,10 @@ modules:
           ksceGzipGetInfo: 0xFFC6A10F
           ksceGzipGetName: 0xF901FD3E
           ksceGzipIsValid: 0xD8FAEFD4
+          ksceHmacSha1Digest: 0x29A28957
+          ksceHmacSha224Digest: 0x7F2A7B99
+          ksceHmacSha256Digest: 0x83EFA1CC
+          ksceMt19937Deinit: 0x875B2A1C
           ksceMt19937Init: 0x4C9A5730
           ksceMt19937UInt: 0x92AEDFBC
           ksceSfmt19937FillArray32: 0x2B30548B
@@ -1929,44 +2400,696 @@ modules:
           ksceZlibDecompress: 0x900148DB
           ksceZlibGetCompressedData: 0x01EB6C45
           ksceZlibGetInfo: 0x5B9BCD75
+      SceKernelSuspendForDriver:
+        nid: 0x7290B21C
         kernel: true
-        nid: 0x496AD8B4
-      SceDebugForDriver:
-        kernel: true
-        nid: 0x88758561
         functions:
-          ksceDebugPrintf: 0x391B74B7
-          ksceDebugPrintf2: 0x02B04343
-      SceDebugForKernel:
+          SceKernelSuspendForDriver_0106C0F0: 0x0106C0F0
+          SceKernelSuspendForDriver_0A6CA124: 0x0A6CA124
+          SceKernelSuspendForDriver_0DE3CC02: 0x0DE3CC02
+          SceKernelSuspendForDriver_105C5752: 0x105C5752
+          SceKernelSuspendForDriver_1FA2F8F1: 0x1FA2F8F1
+          SceKernelSuspendForDriver_230495ED: 0x230495ED
+          SceKernelSuspendForDriver_250ACD90: 0x250ACD90
+          SceKernelSuspendForDriver_254525F8: 0x254525F8
+          SceKernelSuspendForDriver_2BB92967: 0x2BB92967
+          SceKernelSuspendForDriver_4DF40893: 0x4DF40893
+          SceKernelSuspendForDriver_4E5A3A23: 0x4E5A3A23
+          SceKernelSuspendForDriver_6A503956: 0x6A503956
+          SceKernelSuspendForDriver_81D9E41C: 0x81D9E41C
+          SceKernelSuspendForDriver_8B3F02B8: 0x8B3F02B8
+          SceKernelSuspendForDriver_AEA9440D: 0xAEA9440D
+          SceKernelSuspendForDriver_B4B13615: 0xB4B13615
+          SceKernelSuspendForDriver_B5C58EE8: 0xB5C58EE8
+          SceKernelSuspendForDriver_C00826AC: 0xC00826AC
+          SceKernelSuspendForDriver_CE7A2207: 0xCE7A2207
+          SceKernelSuspendForDriver_D4958E6F: 0xD4958E6F
+          SceKernelSuspendForDriver_D6124071: 0xD6124071
+          SceKernelSuspendForDriver_E677B343: 0xE677B343
+          SceKernelSuspendForDriver_F2B07167: 0xF2B07167
+          SceKernelSuspendForDriver_FE2118BD: 0xFE2118BD
+          ksceKernelNotifySuspendCallback: 0xD4622EA8
+          ksceKernelPowerTick: 0xE0489831
+          ksceKernelRegisterSuspendCallback: 0x04C05D10
+          ksceKernelUnregisterSuspendCallback: 0xDD61D621
+      SceQafMgrForDriver:
+        nid: 0x4E29D3B6
         kernel: true
-        nid: 0x88C17370
         functions:
-          ksceDebugSetHandlers: 0x10067B7B
-          ksceDebugPutchar: 0x82D2EDCE
-          ksceDebugRegisterPutcharHandler: 0xE6115A72
-          ksceDebugGetPutcharHandler: 0xE783518C
-          ksceDebugDisableInfoDump: 0xF857CDD6
-      SceUartForKernel:
+          SceQafMgrForDriver_082A4FC2: 0x082A4FC2
+          SceQafMgrForDriver_0E588747: 0x0E588747
+          SceQafMgrForDriver_10283EB8: 0x10283EB8
+          SceQafMgrForDriver_36E5312E: 0x36E5312E
+          SceQafMgrForDriver_382C71E8: 0x382C71E8
+          SceQafMgrForDriver_3CB55F98: 0x3CB55F98
+          SceQafMgrForDriver_41E04800: 0x41E04800
+          SceQafMgrForDriver_4BC1883F: 0x4BC1883F
+          SceQafMgrForDriver_52B4E164: 0x52B4E164
+          SceQafMgrForDriver_694D1096: 0x694D1096
+          SceQafMgrForDriver_70A67A4B: 0x70A67A4B
+          SceQafMgrForDriver_7B14DC45: 0x7B14DC45
+          SceQafMgrForDriver_883E9465: 0x883E9465
+          SceQafMgrForDriver_8C423C18: 0x8C423C18
+          SceQafMgrForDriver_9644171D: 0x9644171D
+          SceQafMgrForDriver_AE033133: 0xAE033133
+          SceQafMgrForDriver_B7B195B2: 0xB7B195B2
+          SceQafMgrForDriver_B9770A13: 0xB9770A13
+          SceQafMgrForDriver_BFD5E463: 0xBFD5E463
+          SceQafMgrForDriver_C1EA75C8: 0xC1EA75C8
+          SceQafMgrForDriver_CAD47130: 0xCAD47130
+          SceQafMgrForDriver_DEC6DF4E: 0xDEC6DF4E
+          SceQafMgrForDriver_E573F124: 0xE573F124
+          SceQafMgrForDriver_E8B8F31F: 0xE8B8F31F
+          SceQafMgrForDriver_F8BFEE48: 0xF8BFEE48
+      ScePmMgrForDriver:
+        nid: 0xF13F32F9
         kernel: true
-        nid: 0xC03DBE40
         functions:
-          ksceUartReadAvailable: 0x38DB7629
-          ksceUartWrite: 0x41973874
-          ksceUartRead: 0x9BBF1255
-          ksceUartInit: 0xA9C74212
+          ScePmMgrForDriver_2AC815A2: 0x2AC815A2
+          ScePmMgrForDriver_BD1F193B: 0xBD1F193B
+      SceSblAIMgrForDriver:
+        nid: 0xFD00C69A
+        kernel: true
+        functions:
+          SceSblAIMgrForDriver_05F79D4A: 0x05F79D4A
+          SceSblAIMgrForDriver_14345161: 0x14345161
+          SceSblAIMgrForDriver_37A79140: 0x37A79140
+          SceSblAIMgrForDriver_6D5A3FC9: 0x6D5A3FC9
+          SceSblAIMgrForDriver_B33CEC8F: 0xB33CEC8F
+          SceSblAIMgrForDriver_BB9D146B: 0xBB9D146B
+          SceSblAIMgrForDriver_E5E47FF7: 0xE5E47FF7
+          SceSblAIMgrForDriver_FF5784B9: 0xFF5784B9
+          ksceSblAimgrGetSMI: 0x47D9CF13
+          ksceSblAimgrIsCEX: 0xD78B04A2
+          ksceSblAimgrIsDEX: 0xF4B98F66
+          ksceSblAimgrIsDolce: 0x71608CA3
+          ksceSblAimgrIsGenuineDolce: 0xC6E83F34
+          ksceSblAimgrIsGenuineVITA: 0x963CA644
+          ksceSblAimgrIsTest: 0x3B638885
+          ksceSblAimgrIsTool: 0x274663A0
+          ksceSblAimgrIsVITA: 0x4273B97B
+      SceProcEventForDriver:
+        nid: 0x887F19D0
+        kernel: true
+        functions:
+          SceProcEventForDriver_2A43912D: 0x2A43912D
+          SceProcEventForDriver_3DED57CC: 0x3DED57CC
+          SceProcEventForDriver_414CC813: 0x414CC813
+      SceSysrootForDriver:
+        nid: 0x2ED7F97A
+        kernel: true
+        functions:
+          SceSysrootForDriver_05093E7B: 0x05093E7B
+          SceSysrootForDriver_05CD0DD9: 0x05CD0DD9
+          SceSysrootForDriver_06436EF0: 0x06436EF0
+          SceSysrootForDriver_0A52A59C: 0x0A52A59C
+          SceSysrootForDriver_0ECD711E: 0x0ECD711E
+          SceSysrootForDriver_0F07C3FC: 0x0F07C3FC
+          SceSysrootForDriver_0F59B369: 0x0F59B369
+          SceSysrootForDriver_10788257: 0x10788257
+          SceSysrootForDriver_1160FCA1: 0x1160FCA1
+          SceSysrootForDriver_1434D90E: 0x1434D90E
+          SceSysrootForDriver_17DD213C: 0x17DD213C
+          SceSysrootForDriver_1834D482: 0x1834D482
+          SceSysrootForDriver_1B3FA457: 0x1B3FA457
+          SceSysrootForDriver_1BA0C6C1: 0x1BA0C6C1
+          SceSysrootForDriver_1D61C837: 0x1D61C837
+          SceSysrootForDriver_1FFD2AFA: 0x1FFD2AFA
+          SceSysrootForDriver_20D2A0DF: 0x20D2A0DF
+          SceSysrootForDriver_217B2871: 0x217B2871
+          SceSysrootForDriver_246AAAB3: 0x246AAAB3
+          SceSysrootForDriver_256B2394: 0x256B2394
+          SceSysrootForDriver_26AA237C: 0x26AA237C
+          SceSysrootForDriver_273EAE53: 0x273EAE53
+          SceSysrootForDriver_27D30DB2: 0x27D30DB2
+          SceSysrootForDriver_2816A813: 0x2816A813
+          SceSysrootForDriver_2A5DBD38: 0x2A5DBD38
+          SceSysrootForDriver_2BE874EF: 0x2BE874EF
+          SceSysrootForDriver_2C9E7797: 0x2C9E7797
+          SceSysrootForDriver_2D6B2A79: 0x2D6B2A79
+          SceSysrootForDriver_3276086B: 0x3276086B
+          SceSysrootForDriver_34281746: 0x34281746
+          SceSysrootForDriver_35875119: 0x35875119
+          SceSysrootForDriver_377895EB: 0x377895EB
+          SceSysrootForDriver_38751FB7: 0x38751FB7
+          SceSysrootForDriver_3999F917: 0x3999F917
+          SceSysrootForDriver_39F1FD07: 0x39F1FD07
+          SceSysrootForDriver_39F9C968: 0x39F9C968
+          SceSysrootForDriver_3ACACD22: 0x3ACACD22
+          SceSysrootForDriver_3AE319DA: 0x3AE319DA
+          SceSysrootForDriver_3B19B06B: 0x3B19B06B
+          SceSysrootForDriver_3F76D531: 0x3F76D531
+          SceSysrootForDriver_400B9793: 0x400B9793
+          SceSysrootForDriver_40F28DC6: 0x40F28DC6
+          SceSysrootForDriver_421EFC96: 0x421EFC96
+          SceSysrootForDriver_42FC9FFF: 0x42FC9FFF
+          SceSysrootForDriver_44EA3197: 0x44EA3197
+          SceSysrootForDriver_47724459: 0x47724459
+          SceSysrootForDriver_47F19DD3: 0x47F19DD3
+          SceSysrootForDriver_483EF108: 0x483EF108
+          SceSysrootForDriver_49843C16: 0x49843C16
+          SceSysrootForDriver_4D98B15B: 0x4D98B15B
+          SceSysrootForDriver_51F9C118: 0x51F9C118
+          SceSysrootForDriver_525B24C5: 0x525B24C5
+          SceSysrootForDriver_5458BF6D: 0x5458BF6D
+          SceSysrootForDriver_56C4C949: 0x56C4C949
+          SceSysrootForDriver_56D85EB0: 0x56D85EB0
+          SceSysrootForDriver_571E5B79: 0x571E5B79
+          SceSysrootForDriver_579CC758: 0x579CC758
+          SceSysrootForDriver_582616EC: 0x582616EC
+          SceSysrootForDriver_591BB490: 0x591BB490
+          SceSysrootForDriver_5A4A7F7E: 0x5A4A7F7E
+          SceSysrootForDriver_5A7FFDC1: 0x5A7FFDC1
+          SceSysrootForDriver_5B106EB3: 0x5B106EB3
+          SceSysrootForDriver_5C86E49B: 0x5C86E49B
+          SceSysrootForDriver_6050A467: 0x6050A467
+          SceSysrootForDriver_6219CC14: 0x6219CC14
+          SceSysrootForDriver_631141E2: 0x631141E2
+          SceSysrootForDriver_65F3D598: 0x65F3D598
+          SceSysrootForDriver_6655F48C: 0x6655F48C
+          SceSysrootForDriver_67AAB627: 0x67AAB627
+          SceSysrootForDriver_6C036B53: 0x6C036B53
+          SceSysrootForDriver_6D44F190: 0x6D44F190
+          SceSysrootForDriver_6E0BC27C: 0x6E0BC27C
+          SceSysrootForDriver_709799BB: 0x709799BB
+          SceSysrootForDriver_70A60BBA: 0x70A60BBA
+          SceSysrootForDriver_70AD47A9: 0x70AD47A9
+          SceSysrootForDriver_71DB83A2: 0x71DB83A2
+          SceSysrootForDriver_73522F65: 0x73522F65
+          SceSysrootForDriver_778D0966: 0x778D0966
+          SceSysrootForDriver_77CF3FBD: 0x77CF3FBD
+          SceSysrootForDriver_7918D44E: 0x7918D44E
+          SceSysrootForDriver_79458ACB: 0x79458ACB
+          SceSysrootForDriver_7998F5B5: 0x7998F5B5
+          SceSysrootForDriver_7AAC4EE7: 0x7AAC4EE7
+          SceSysrootForDriver_7B4A377C: 0x7B4A377C
+          SceSysrootForDriver_7B7ED1E9: 0x7B7ED1E9
+          SceSysrootForDriver_7B7F8171: 0x7B7F8171
+          SceSysrootForDriver_7C0BE393: 0x7C0BE393
+          SceSysrootForDriver_7C2C10E2: 0x7C2C10E2
+          SceSysrootForDriver_80FBC69D: 0x80FBC69D
+          SceSysrootForDriver_82FC6405: 0x82FC6405
+          SceSysrootForDriver_8498E23F: 0x8498E23F
+          SceSysrootForDriver_84C0BE05: 0x84C0BE05
+          SceSysrootForDriver_8747D415: 0x8747D415
+          SceSysrootForDriver_89532E2F: 0x89532E2F
+          SceSysrootForDriver_8A760856: 0x8A760856
+          SceSysrootForDriver_8AA268D6: 0x8AA268D6
+          SceSysrootForDriver_8B8F1D01: 0x8B8F1D01
+          SceSysrootForDriver_8CD02748: 0x8CD02748
+          SceSysrootForDriver_930B1342: 0x930B1342
+          SceSysrootForDriver_93CD44CD: 0x93CD44CD
+          SceSysrootForDriver_9421B223: 0x9421B223
+          SceSysrootForDriver_951C7943: 0x951C7943
+          SceSysrootForDriver_97E2FB77: 0x97E2FB77
+          SceSysrootForDriver_9A486846: 0x9A486846
+          SceSysrootForDriver_9A8871F1: 0x9A8871F1
+          SceSysrootForDriver_9AF075D4: 0x9AF075D4
+          SceSysrootForDriver_9BF782CA: 0x9BF782CA
+          SceSysrootForDriver_9CDE3623: 0x9CDE3623
+          SceSysrootForDriver_9CFF80F9: 0x9CFF80F9
+          SceSysrootForDriver_9D058A32: 0x9D058A32
+          SceSysrootForDriver_9DCD0894: 0x9DCD0894
+          SceSysrootForDriver_9E96D990: 0x9E96D990
+          SceSysrootForDriver_9EC02A41: 0x9EC02A41
+          SceSysrootForDriver_A12C9950: 0xA12C9950
+          SceSysrootForDriver_A43599E9: 0xA43599E9
+          SceSysrootForDriver_A6A0A038: 0xA6A0A038
+          SceSysrootForDriver_A799F22A: 0xA799F22A
+          SceSysrootForDriver_A7A01DF0: 0xA7A01DF0
+          SceSysrootForDriver_A85FF3B2: 0xA85FF3B2
+          SceSysrootForDriver_A9510EFE: 0xA9510EFE
+          SceSysrootForDriver_AA770EF7: 0xAA770EF7
+          SceSysrootForDriver_AA8D34EE: 0xAA8D34EE
+          SceSysrootForDriver_AE7A8F1D: 0xAE7A8F1D
+          SceSysrootForDriver_B0E3E791: 0xB0E3E791
+          SceSysrootForDriver_B27B7530: 0xB27B7530
+          SceSysrootForDriver_B501E861: 0xB501E861
+          SceSysrootForDriver_BFD8F2A2: 0xBFD8F2A2
+          SceSysrootForDriver_C5EAF5F7: 0xC5EAF5F7
+          SceSysrootForDriver_C67A1FA9: 0xC67A1FA9
+          SceSysrootForDriver_C728BC61: 0xC728BC61
+          SceSysrootForDriver_C81B7E2B: 0xC81B7E2B
+          SceSysrootForDriver_C94C76FA: 0xC94C76FA
+          SceSysrootForDriver_CA497324: 0xCA497324
+          SceSysrootForDriver_CAE820B2: 0xCAE820B2
+          SceSysrootForDriver_CC7A0E63: 0xCC7A0E63
+          SceSysrootForDriver_CCB8BB5E: 0xCCB8BB5E
+          SceSysrootForDriver_CD4B84F7: 0xCD4B84F7
+          SceSysrootForDriver_CD8CD242: 0xCD8CD242
+          SceSysrootForDriver_D02281A8: 0xD02281A8
+          SceSysrootForDriver_D03741B8: 0xD03741B8
+          SceSysrootForDriver_D04C7723: 0xD04C7723
+          SceSysrootForDriver_D1E54BF4: 0xD1E54BF4
+          SceSysrootForDriver_D2423D6B: 0xD2423D6B
+          SceSysrootForDriver_D4457D4F: 0xD4457D4F
+          SceSysrootForDriver_D56A2F3E: 0xD56A2F3E
+          SceSysrootForDriver_D7207203: 0xD7207203
+          SceSysrootForDriver_D75D4F37: 0xD75D4F37
+          SceSysrootForDriver_D86BD6DC: 0xD86BD6DC
+          SceSysrootForDriver_DABD4A47: 0xDABD4A47
+          SceSysrootForDriver_DC651D22: 0xDC651D22
+          SceSysrootForDriver_DD473B05: 0xDD473B05
+          SceSysrootForDriver_E06C14FD: 0xE06C14FD
+          SceSysrootForDriver_E2515A08: 0xE2515A08
+          SceSysrootForDriver_E25D2FD5: 0xE25D2FD5
+          SceSysrootForDriver_E2E88E3E: 0xE2E88E3E
+          SceSysrootForDriver_E384DD93: 0xE384DD93
+          SceSysrootForDriver_E4EA1960: 0xE4EA1960
+          SceSysrootForDriver_E541959B: 0xE541959B
+          SceSysrootForDriver_E8EBF179: 0xE8EBF179
+          SceSysrootForDriver_E9B4221F: 0xE9B4221F
+          SceSysrootForDriver_EB19AAF6: 0xEB19AAF6
+          SceSysrootForDriver_ECADF8C3: 0xECADF8C3
+          SceSysrootForDriver_ED22CF8F: 0xED22CF8F
+          SceSysrootForDriver_ED688AEE: 0xED688AEE
+          SceSysrootForDriver_EE5D6CE9: 0xEE5D6CE9
+          SceSysrootForDriver_EE934615: 0xEE934615
+          SceSysrootForDriver_EEF091A7: 0xEEF091A7
+          SceSysrootForDriver_F0C91CD3: 0xF0C91CD3
+          SceSysrootForDriver_F2BC9E1D: 0xF2BC9E1D
+          SceSysrootForDriver_F404026C: 0xF404026C
+          SceSysrootForDriver_F4340469: 0xF4340469
+          SceSysrootForDriver_F804F761: 0xF804F761
+          SceSysrootForDriver_FF2DD7AB: 0xFF2DD7AB
+          ksceSysrootIsAuCodecIcConexant: 0x46E72428
+          ksceSysrootIsBsodReboot: 0x4373AC96
+          ksceSysrootIsExternalBootMode: 0x89D19090
+          ksceSysrootIsManufacturingMode: 0x55392965
+          ksceSysrootIsSafeMode: 0x834439A7
+          ksceSysrootIsUpdateMode: 0xB0E1FC67
+          ksceSysrootIsUsbEnumWakeup: 0x79C9AE10
+          ksceSysrootUseInternalStorage: 0x50FE3B4D
+      SceCpu:
+        nid: 0x45265161
+        kernel: false
+        functions:
+          sceKernelCpuId: 0x2704CFEE
+      SceCpuForKernel:
+        nid: 0x54BF2BAB
+        kernel: true
+        functions:
+          SceCpuForKernel_04008CF7: 0x04008CF7
+          SceCpuForKernel_1BB2BB8D: 0x1BB2BB8D
+          SceCpuForKernel_2A46E800: 0x2A46E800
+          SceCpuForKernel_337473B5: 0x337473B5
+          SceCpuForKernel_37FBFD12: 0x37FBFD12
+          SceCpuForKernel_43CC6E20: 0x43CC6E20
+          SceCpuForKernel_4553FBDE: 0x4553FBDE
+          SceCpuForKernel_470EAE1E: 0x470EAE1E
+          SceCpuForKernel_4C4C7D6B: 0x4C4C7D6B
+          SceCpuForKernel_4CD4D921: 0x4CD4D921
+          SceCpuForKernel_583F30D1: 0x583F30D1
+          SceCpuForKernel_5B6B3274: 0x5B6B3274
+          SceCpuForKernel_5F64E5ED: 0x5F64E5ED
+          SceCpuForKernel_6190A018: 0x6190A018
+          SceCpuForKernel_67343A07: 0x67343A07
+          SceCpuForKernel_6C7E7B57: 0x6C7E7B57
+          SceCpuForKernel_76EB0DD4: 0x76EB0DD4
+          SceCpuForKernel_7FB4E7AC: 0x7FB4E7AC
+          SceCpuForKernel_8510FA52: 0x8510FA52
+          SceCpuForKernel_98E91C1C: 0x98E91C1C
+          SceCpuForKernel_9A3281C0: 0x9A3281C0
+          SceCpuForKernel_9B8173F4: 0x9B8173F4
+          SceCpuForKernel_9CB82EB0: 0x9CB82EB0
+          SceCpuForKernel_9D72DD1B: 0x9D72DD1B
+          SceCpuForKernel_A5C9DBBA: 0xA5C9DBBA
+          SceCpuForKernel_AEE0B489: 0xAEE0B489
+          SceCpuForKernel_C5C1EE4E: 0xC5C1EE4E
+          SceCpuForKernel_C8E8C9E9: 0xC8E8C9E9
+          SceCpuForKernel_D0D85FF8: 0xD0D85FF8
+          SceCpuForKernel_D37AABE5: 0xD37AABE5
+          SceCpuForKernel_D8A7216C: 0xD8A7216C
+          SceCpuForKernel_F7159B55: 0xF7159B55
+          ksceKernelCpuDcacheInvalidateAll: 0x2F3BF020
+          ksceKernelCpuDcacheWritebackAll: 0x73A30DB2
+          ksceKernelCpuDcacheWritebackInvalidateAll: 0x76DAB4D0
+          ksceKernelCpuDcacheWritebackInvalidateRange: 0x6BA2E51C
+          ksceKernelCpuIcacheAndL2WritebackInvalidateRange: 0x19F17BD0
+          ksceKernelCpuIcacheInvalidateAll: 0x264DA250
+          ksceKernelCpuIcacheInvalidateRange: 0xF4C7F578
+          ksceKernelCpuUnrestrictedMemcpy: 0x8C683DEC
+      SceCpuForDriver:
+        nid: 0x40ECDB0E
+        kernel: true
+        functions:
+          SceCpuForDriver_004F09D1: 0x004F09D1
+          SceCpuForDriver_03887992: 0x03887992
+          SceCpuForDriver_043FD446: 0x043FD446
+          SceCpuForDriver_06CCFA4B: 0x06CCFA4B
+          SceCpuForDriver_0836537E: 0x0836537E
+          SceCpuForDriver_085532C8: 0x085532C8
+          SceCpuForDriver_093925BD: 0x093925BD
+          SceCpuForDriver_0EE04C03: 0x0EE04C03
+          SceCpuForDriver_0F84AFE9: 0x0F84AFE9
+          SceCpuForDriver_10EB35EB: 0x10EB35EB
+          SceCpuForDriver_18A17E07: 0x18A17E07
+          SceCpuForDriver_1B3336B0: 0x1B3336B0
+          SceCpuForDriver_1BE58599: 0x1BE58599
+          SceCpuForDriver_1E850481: 0x1E850481
+          SceCpuForDriver_1F157DC3: 0x1F157DC3
+          SceCpuForDriver_2149CD4C: 0x2149CD4C
+          SceCpuForDriver_225DF91A: 0x225DF91A
+          SceCpuForDriver_267D0B33: 0x267D0B33
+          SceCpuForDriver_26F71995: 0x26F71995
+          SceCpuForDriver_27C0B340: 0x27C0B340
+          SceCpuForDriver_29599FC8: 0x29599FC8
+          SceCpuForDriver_2A40BB93: 0x2A40BB93
+          SceCpuForDriver_2A71B03C: 0x2A71B03C
+          SceCpuForDriver_3168BC57: 0x3168BC57
+          SceCpuForDriver_32B62B1A: 0x32B62B1A
+          SceCpuForDriver_337CBDF3: 0x337CBDF3
+          SceCpuForDriver_341B6E81: 0x341B6E81
+          SceCpuForDriver_3627F4E0: 0x3627F4E0
+          SceCpuForDriver_382D1466: 0x382D1466
+          SceCpuForDriver_3E218AF7: 0x3E218AF7
+          SceCpuForDriver_3EE9B5B8: 0x3EE9B5B8
+          SceCpuForDriver_3F42B434: 0x3F42B434
+          SceCpuForDriver_4244BE65: 0x4244BE65
+          SceCpuForDriver_45153D4E: 0x45153D4E
+          SceCpuForDriver_4A820BC5: 0x4A820BC5
+          SceCpuForDriver_4AE1BCC0: 0x4AE1BCC0
+          SceCpuForDriver_4B527009: 0x4B527009
+          SceCpuForDriver_4C38CE4D: 0x4C38CE4D
+          SceCpuForDriver_4E459A03: 0x4E459A03
+          SceCpuForDriver_4F7790B4: 0x4F7790B4
+          SceCpuForDriver_515682C9: 0x515682C9
+          SceCpuForDriver_532CA3E8: 0x532CA3E8
+          SceCpuForDriver_55760309: 0x55760309
+          SceCpuForDriver_59F74E94: 0x59F74E94
+          SceCpuForDriver_5AC9D394: 0x5AC9D394
+          SceCpuForDriver_5CC62CEC: 0x5CC62CEC
+          SceCpuForDriver_5D515F1B: 0x5D515F1B
+          SceCpuForDriver_5E4D5DE1: 0x5E4D5DE1
+          SceCpuForDriver_5F6A8743: 0x5F6A8743
+          SceCpuForDriver_646003D6: 0x646003D6
+          SceCpuForDriver_692C51B3: 0x692C51B3
+          SceCpuForDriver_6B050D7C: 0x6B050D7C
+          SceCpuForDriver_6F63F56D: 0x6F63F56D
+          SceCpuForDriver_711801E6: 0x711801E6
+          SceCpuForDriver_740A0750: 0x740A0750
+          SceCpuForDriver_77E34309: 0x77E34309
+          SceCpuForDriver_78C1F148: 0x78C1F148
+          SceCpuForDriver_7B43D0D7: 0x7B43D0D7
+          SceCpuForDriver_875B094D: 0x875B094D
+          SceCpuForDriver_88BA6002: 0x88BA6002
+          SceCpuForDriver_8E538AB5: 0x8E538AB5
+          SceCpuForDriver_8E9C086D: 0x8E9C086D
+          SceCpuForDriver_9A693F5B: 0x9A693F5B
+          SceCpuForDriver_9EC91017: 0x9EC91017
+          SceCpuForDriver_A4884C4E: 0xA4884C4E
+          SceCpuForDriver_A7585370: 0xA7585370
+          SceCpuForDriver_ADD39B84: 0xADD39B84
+          SceCpuForDriver_B281D52A: 0xB281D52A
+          SceCpuForDriver_B5F8919C: 0xB5F8919C
+          SceCpuForDriver_BAF47F7B: 0xBAF47F7B
+          SceCpuForDriver_BC248C30: 0xBC248C30
+          SceCpuForDriver_BDF6F8E4: 0xBDF6F8E4
+          SceCpuForDriver_BF82DEB2: 0xBF82DEB2
+          SceCpuForDriver_C381CE8C: 0xC381CE8C
+          SceCpuForDriver_C3868071: 0xC3868071
+          SceCpuForDriver_CAC9AE80: 0xCAC9AE80
+          SceCpuForDriver_CB73D6D5: 0xCB73D6D5
+          SceCpuForDriver_CB8ABDF0: 0xCB8ABDF0
+          SceCpuForDriver_CDA96E81: 0xCDA96E81
+          SceCpuForDriver_D18E7B54: 0xD18E7B54
+          SceCpuForDriver_D2DEE625: 0xD2DEE625
+          SceCpuForDriver_D6ED0C46: 0xD6ED0C46
+          SceCpuForDriver_D8E675C0: 0xD8E675C0
+          SceCpuForDriver_DE6482C6: 0xDE6482C6
+          SceCpuForDriver_DF899E4B: 0xDF899E4B
+          SceCpuForDriver_E212ECAD: 0xE212ECAD
+          SceCpuForDriver_E36F3A46: 0xE36F3A46
+          SceCpuForDriver_E551F99B: 0xE551F99B
+          SceCpuForDriver_E813EBB2: 0xE813EBB2
+          SceCpuForDriver_EB085370: 0xEB085370
+          SceCpuForDriver_EC53D007: 0xEC53D007
+          SceCpuForDriver_F02467D1: 0xF02467D1
+          SceCpuForDriver_F5FD5676: 0xF5FD5676
+          SceCpuForDriver_F891CF2A: 0xF891CF2A
+          SceCpuForDriver_FCDCD4DE: 0xFCDCD4DE
+          ksceKernelCpuDcacheAndL2InvalidateRange: 0x02796361
+          ksceKernelCpuDcacheAndL2WritebackInvalidateRange: 0x364E68A4
+          ksceKernelCpuDcacheAndL2WritebackRange: 0x103872A5
+          ksceKernelCpuDcacheInvalidateRange: 0x8B4C26DF
+          ksceKernelCpuDcacheWritebackRange: 0x9CB9F0CE
+          ksceKernelCpuDisableInterrupts: 0x821FC0EE
+          ksceKernelCpuEnableInterrupts: 0xF5BAD43B
+          ksceKernelCpuResumeIntr: 0x7BB9D5DF
+          ksceKernelCpuSuspendIntr: 0xD32ACE9E
   SceKernelThreadMgr:
     nid: 0xF46ED7B2
     libraries:
-      SceThreadmgrForDriver:
+      SceThreadmgrForKernel:
+        nid: 0xA8CA0EFD
         kernel: true
-        nid: 0xE2C40624
         functions:
+          SceThreadmgrForKernel_000DF999: 0x000DF999
+          SceThreadmgrForKernel_02EEDF17: 0x02EEDF17
+          SceThreadmgrForKernel_091322E5: 0x091322E5
+          SceThreadmgrForKernel_09444C33: 0x09444C33
+          SceThreadmgrForKernel_09CEAAA4: 0x09CEAAA4
+          SceThreadmgrForKernel_14ADCC1F: 0x14ADCC1F
+          SceThreadmgrForKernel_150AEF74: 0x150AEF74
+          SceThreadmgrForKernel_15AAB4F9: 0x15AAB4F9
+          SceThreadmgrForKernel_17A4E56B: 0x17A4E56B
+          SceThreadmgrForKernel_1928DFBB: 0x1928DFBB
+          SceThreadmgrForKernel_2EC8E376: 0x2EC8E376
+          SceThreadmgrForKernel_315869B6: 0x315869B6
+          SceThreadmgrForKernel_333B26AD: 0x333B26AD
+          SceThreadmgrForKernel_3B4B8293: 0x3B4B8293
+          SceThreadmgrForKernel_3CD03673: 0x3CD03673
+          SceThreadmgrForKernel_41BCA03A: 0x41BCA03A
+          SceThreadmgrForKernel_41CF346A: 0x41CF346A
+          SceThreadmgrForKernel_43D13895: 0x43D13895
+          SceThreadmgrForKernel_4679280D: 0x4679280D
+          SceThreadmgrForKernel_4C3887B4: 0x4C3887B4
+          SceThreadmgrForKernel_5785D18E: 0x5785D18E
+          SceThreadmgrForKernel_5A410D2B: 0x5A410D2B
+          SceThreadmgrForKernel_5AB30D35: 0x5AB30D35
+          SceThreadmgrForKernel_6ECCDCBD: 0x6ECCDCBD
+          SceThreadmgrForKernel_72E5DA4E: 0x72E5DA4E
+          SceThreadmgrForKernel_766028E7: 0x766028E7
+          SceThreadmgrForKernel_796D3A65: 0x796D3A65
+          SceThreadmgrForKernel_82F080A8: 0x82F080A8
+          SceThreadmgrForKernel_87B3D598: 0x87B3D598
+          SceThreadmgrForKernel_88D5BC33: 0x88D5BC33
+          SceThreadmgrForKernel_8B6F201E: 0x8B6F201E
+          SceThreadmgrForKernel_8F3E9E35: 0x8F3E9E35
+          SceThreadmgrForKernel_97780FA6: 0x97780FA6
+          SceThreadmgrForKernel_9C96317A: 0x9C96317A
+          SceThreadmgrForKernel_9F5ECAD5: 0x9F5ECAD5
+          SceThreadmgrForKernel_A1939BC9: 0xA1939BC9
+          SceThreadmgrForKernel_A4127F82: 0xA4127F82
+          SceThreadmgrForKernel_AEA9213B: 0xAEA9213B
+          SceThreadmgrForKernel_AEEE955F: 0xAEEE955F
+          SceThreadmgrForKernel_BE5247A2: 0xBE5247A2
+          SceThreadmgrForKernel_C75A4609: 0xC75A4609
+          SceThreadmgrForKernel_CC1D6D9F: 0xCC1D6D9F
+          SceThreadmgrForKernel_CE99E69C: 0xCE99E69C
+          SceThreadmgrForKernel_D2BE5EFB: 0xD2BE5EFB
+          SceThreadmgrForKernel_D8117AFB: 0xD8117AFB
+          SceThreadmgrForKernel_D8B9AC8D: 0xD8B9AC8D
+          SceThreadmgrForKernel_DBE2EE32: 0xDBE2EE32
+          SceThreadmgrForKernel_E00333A6: 0xE00333A6
+          SceThreadmgrForKernel_E0833C77: 0xE0833C77
+          SceThreadmgrForKernel_E3CE20AA: 0xE3CE20AA
+          SceThreadmgrForKernel_E92C1784: 0xE92C1784
+          SceThreadmgrForKernel_F282AE42: 0xF282AE42
+          SceThreadmgrForKernel_F74B7E34: 0xF74B7E34
+          SceThreadmgrForKernel_F9BD4A0D: 0xF9BD4A0D
+          SceThreadmgrForKernel_FA53F581: 0xFA53F581
+          ksceKernelCreateMutexForKernel: 0xFBAA026E
+          ksceKernelCreateSemaForKernel: 0x30E93C31
+          ksceKernelDeleteMutexForKernel: 0x0A912340
+          ksceKernelDeleteSemaForKernel: 0x16A35E58
+          ksceKernelLockMutex_089ForKernel: 0x16AC80C5
+          ksceKernelRunWithStackForKernel: 0xE54FD746
+          ksceKernelSignalSemaForKernel: 0xD270498B
+          ksceKernelUnlockMutex_089ForKernel: 0x1E82E5D0
+          ksceKernelWaitSemaForKernel: 0x3C8B55A9
+      SceThreadmgrForDriver:
+        nid: 0xE2C40624
+        kernel: true
+        functions:
+          SceThreadmgrForDriver_02EEDF17: 0x02EEDF17
+          SceThreadmgrForDriver_032E8F73: 0x032E8F73
+          SceThreadmgrForDriver_04150799: 0x04150799
+          SceThreadmgrForDriver_04C6764B: 0x04C6764B
+          SceThreadmgrForDriver_069D8A20: 0x069D8A20
+          SceThreadmgrForDriver_09346D1A: 0x09346D1A
+          SceThreadmgrForDriver_0A4AD37A: 0x0A4AD37A
+          SceThreadmgrForDriver_0B604A3C: 0x0B604A3C
+          SceThreadmgrForDriver_0C6BCB8C: 0x0C6BCB8C
+          SceThreadmgrForDriver_0D0644DA: 0x0D0644DA
+          SceThreadmgrForDriver_0EB0ABF0: 0x0EB0ABF0
+          SceThreadmgrForDriver_10517330: 0x10517330
+          SceThreadmgrForDriver_1096042E: 0x1096042E
+          SceThreadmgrForDriver_12FC0FAB: 0x12FC0FAB
+          SceThreadmgrForDriver_1378F6EF: 0x1378F6EF
+          SceThreadmgrForDriver_14F8167C: 0x14F8167C
+          SceThreadmgrForDriver_15287EF6: 0x15287EF6
+          SceThreadmgrForDriver_154F2C2A: 0x154F2C2A
+          SceThreadmgrForDriver_19F3E92A: 0x19F3E92A
+          SceThreadmgrForDriver_1AAFA818: 0x1AAFA818
+          SceThreadmgrForDriver_207E0E18: 0x207E0E18
+          SceThreadmgrForDriver_20C228E4: 0x20C228E4
+          SceThreadmgrForDriver_2322A2F3: 0x2322A2F3
+          SceThreadmgrForDriver_25AB8F6B: 0x25AB8F6B
+          SceThreadmgrForDriver_2828F884: 0x2828F884
+          SceThreadmgrForDriver_2B60B793: 0x2B60B793
+          SceThreadmgrForDriver_2BDE3B40: 0x2BDE3B40
+          SceThreadmgrForDriver_2E95B628: 0x2E95B628
+          SceThreadmgrForDriver_2F9F75AA: 0x2F9F75AA
+          SceThreadmgrForDriver_2FC0FFF6: 0x2FC0FFF6
+          SceThreadmgrForDriver_32452017: 0x32452017
+          SceThreadmgrForDriver_332E127C: 0x332E127C
+          SceThreadmgrForDriver_33E85E9E: 0x33E85E9E
+          SceThreadmgrForDriver_357A8177: 0x357A8177
+          SceThreadmgrForDriver_360C655C: 0x360C655C
+          SceThreadmgrForDriver_3634FFE6: 0x3634FFE6
+          SceThreadmgrForDriver_36F8E58A: 0x36F8E58A
+          SceThreadmgrForDriver_374C3267: 0x374C3267
+          SceThreadmgrForDriver_37F51E91: 0x37F51E91
+          SceThreadmgrForDriver_3857C94E: 0x3857C94E
+          SceThreadmgrForDriver_385831A1: 0x385831A1
+          SceThreadmgrForDriver_3A72C6D8: 0x3A72C6D8
+          SceThreadmgrForDriver_3C297724: 0x3C297724
+          SceThreadmgrForDriver_3F5E1D56: 0x3F5E1D56
+          SceThreadmgrForDriver_419E6736: 0x419E6736
+          SceThreadmgrForDriver_44CCF310: 0x44CCF310
+          SceThreadmgrForDriver_453B764A: 0x453B764A
+          SceThreadmgrForDriver_477F7C8A: 0x477F7C8A
+          SceThreadmgrForDriver_47F26712: 0x47F26712
+          SceThreadmgrForDriver_48C06CD6: 0x48C06CD6
+          SceThreadmgrForDriver_49A0B679: 0x49A0B679
+          SceThreadmgrForDriver_4A038803: 0x4A038803
+          SceThreadmgrForDriver_4CF1BE58: 0x4CF1BE58
+          SceThreadmgrForDriver_4DE77569: 0x4DE77569
+          SceThreadmgrForDriver_5022689D: 0x5022689D
+          SceThreadmgrForDriver_5053B005: 0x5053B005
+          SceThreadmgrForDriver_5311CFB5: 0x5311CFB5
+          SceThreadmgrForDriver_54566860: 0x54566860
+          SceThreadmgrForDriver_54E1AF04: 0x54E1AF04
+          SceThreadmgrForDriver_555CA6BB: 0x555CA6BB
+          SceThreadmgrForDriver_56C18B11: 0x56C18B11
+          SceThreadmgrForDriver_5870C73A: 0x5870C73A
+          SceThreadmgrForDriver_5CDE387A: 0x5CDE387A
+          SceThreadmgrForDriver_5D8F88B1: 0x5D8F88B1
+          SceThreadmgrForDriver_612277C9: 0x612277C9
+          SceThreadmgrForDriver_64E89DE9: 0x64E89DE9
+          SceThreadmgrForDriver_6624E612: 0x6624E612
+          SceThreadmgrForDriver_6657429E: 0x6657429E
+          SceThreadmgrForDriver_67022B18: 0x67022B18
+          SceThreadmgrForDriver_67DD3BAD: 0x67DD3BAD
+          SceThreadmgrForDriver_6C2E3A49: 0x6C2E3A49
+          SceThreadmgrForDriver_6D0733A8: 0x6D0733A8
+          SceThreadmgrForDriver_6D4C1EB7: 0x6D4C1EB7
+          SceThreadmgrForDriver_70131EA5: 0x70131EA5
+          SceThreadmgrForDriver_714A107A: 0x714A107A
+          SceThreadmgrForDriver_738FF63D: 0x738FF63D
+          SceThreadmgrForDriver_741F4707: 0x741F4707
+          SceThreadmgrForDriver_767CA30C: 0x767CA30C
+          SceThreadmgrForDriver_771522C6: 0x771522C6
+          SceThreadmgrForDriver_7A4EF925: 0x7A4EF925
+          SceThreadmgrForDriver_7D12344A: 0x7D12344A
+          SceThreadmgrForDriver_7E280B69: 0x7E280B69
+          SceThreadmgrForDriver_84EB1EA4: 0x84EB1EA4
+          SceThreadmgrForDriver_85F4DC8C: 0x85F4DC8C
+          SceThreadmgrForDriver_86DAE59B: 0x86DAE59B
+          SceThreadmgrForDriver_8760C8ED: 0x8760C8ED
+          SceThreadmgrForDriver_88206D29: 0x88206D29
+          SceThreadmgrForDriver_89CA5698: 0x89CA5698
+          SceThreadmgrForDriver_8C3C1F78: 0x8C3C1F78
+          SceThreadmgrForDriver_8C48E53B: 0x8C48E53B
+          SceThreadmgrForDriver_8C8A76EF: 0x8C8A76EF
+          SceThreadmgrForDriver_90656C98: 0x90656C98
+          SceThreadmgrForDriver_91382762: 0x91382762
+          SceThreadmgrForDriver_91A8F38B: 0x91A8F38B
+          SceThreadmgrForDriver_920EA1CA: 0x920EA1CA
+          SceThreadmgrForDriver_92A3DCDD: 0x92A3DCDD
+          SceThreadmgrForDriver_995F32E1: 0x995F32E1
+          SceThreadmgrForDriver_9D6A2311: 0x9D6A2311
+          SceThreadmgrForDriver_A0B1AB21: 0xA0B1AB21
+          SceThreadmgrForDriver_A64B00F6: 0xA64B00F6
+          SceThreadmgrForDriver_A90B1E01: 0xA90B1E01
+          SceThreadmgrForDriver_AB977C72: 0xAB977C72
+          SceThreadmgrForDriver_AF302193: 0xAF302193
+          SceThreadmgrForDriver_B247EC4B: 0xB247EC4B
+          SceThreadmgrForDriver_B3453F88: 0xB3453F88
+          SceThreadmgrForDriver_B4A05763: 0xB4A05763
+          SceThreadmgrForDriver_B4CED111: 0xB4CED111
+          SceThreadmgrForDriver_B5C782A3: 0xB5C782A3
+          SceThreadmgrForDriver_B645C7EF: 0xB645C7EF
+          SceThreadmgrForDriver_B6DA4669: 0xB6DA4669
+          SceThreadmgrForDriver_B6FA8305: 0xB6FA8305
+          SceThreadmgrForDriver_B7DF3EDF: 0xB7DF3EDF
+          SceThreadmgrForDriver_B92709C4: 0xB92709C4
+          SceThreadmgrForDriver_BF631145: 0xBF631145
+          SceThreadmgrForDriver_C03799E2: 0xC03799E2
+          SceThreadmgrForDriver_C2AFFBD0: 0xC2AFFBD0
+          SceThreadmgrForDriver_C2DA6286: 0xC2DA6286
+          SceThreadmgrForDriver_C327CA7C: 0xC327CA7C
+          SceThreadmgrForDriver_C4456EC9: 0xC4456EC9
+          SceThreadmgrForDriver_C529EA32: 0xC529EA32
+          SceThreadmgrForDriver_C58DF384: 0xC58DF384
+          SceThreadmgrForDriver_C6741986: 0xC6741986
+          SceThreadmgrForDriver_C7F5FFE0: 0xC7F5FFE0
+          SceThreadmgrForDriver_C8E57BB4: 0xC8E57BB4
+          SceThreadmgrForDriver_C99DCF0D: 0xC99DCF0D
+          SceThreadmgrForDriver_CA704239: 0xCA704239
+          SceThreadmgrForDriver_CB795E13: 0xCB795E13
+          SceThreadmgrForDriver_CBA7FAAA: 0xCBA7FAAA
+          SceThreadmgrForDriver_CE09221A: 0xCE09221A
+          SceThreadmgrForDriver_CFA2FFAF: 0xCFA2FFAF
+          SceThreadmgrForDriver_D0262C55: 0xD0262C55
+          SceThreadmgrForDriver_D08C71C6: 0xD08C71C6
+          SceThreadmgrForDriver_D1FBDFA6: 0xD1FBDFA6
+          SceThreadmgrForDriver_D26BFF26: 0xD26BFF26
+          SceThreadmgrForDriver_D41F53D4: 0xD41F53D4
+          SceThreadmgrForDriver_D7455187: 0xD7455187
+          SceThreadmgrForDriver_D74F66BD: 0xD74F66BD
+          SceThreadmgrForDriver_D7AF2E58: 0xD7AF2E58
+          SceThreadmgrForDriver_D978D16F: 0xD978D16F
+          SceThreadmgrForDriver_DA1544D1: 0xDA1544D1
+          SceThreadmgrForDriver_DBB77032: 0xDBB77032
+          SceThreadmgrForDriver_DD8D9429: 0xDD8D9429
+          SceThreadmgrForDriver_E0C7BCBB: 0xE0C7BCBB
+          SceThreadmgrForDriver_E2B57231: 0xE2B57231
+          SceThreadmgrForDriver_E50E1185: 0xE50E1185
+          SceThreadmgrForDriver_E5CAD3E2: 0xE5CAD3E2
+          SceThreadmgrForDriver_E605ED7A: 0xE605ED7A
+          SceThreadmgrForDriver_E6D80698: 0xE6D80698
+          SceThreadmgrForDriver_E938FB20: 0xE938FB20
+          SceThreadmgrForDriver_E9A99C50: 0xE9A99C50
+          SceThreadmgrForDriver_E9E50096: 0xE9E50096
+          SceThreadmgrForDriver_EA211225: 0xEA211225
+          SceThreadmgrForDriver_EA7B8AEF: 0xEA7B8AEF
+          SceThreadmgrForDriver_EC8343DF: 0xEC8343DF
+          SceThreadmgrForDriver_F285C94F: 0xF285C94F
+          SceThreadmgrForDriver_F2C9DC97: 0xF2C9DC97
+          SceThreadmgrForDriver_F311808F: 0xF311808F
+          SceThreadmgrForDriver_F4C81683: 0xF4C81683
+          SceThreadmgrForDriver_F5074173: 0xF5074173
+          SceThreadmgrForDriver_F8A6013B: 0xF8A6013B
+          SceThreadmgrForDriver_F96FE0D5: 0xF96FE0D5
+          SceThreadmgrForDriver_FA54D49A: 0xFA54D49A
+          SceThreadmgrForDriver_FB3706CB: 0xFB3706CB
+          SceThreadmgrForDriver_FD6150D5: 0xFD6150D5
+          SceThreadmgrForDriver_FD87586C: 0xFD87586C
+          SceThreadmgrForDriver_FDC044AC: 0xFDC044AC
+          SceThreadmgrForDriver_FF8DA217: 0xFF8DA217
           ksceKernelCancelCallback: 0xC040EC1C
-          ksceKernelCancelMutex: 0x7204B846
+          ksceKernelCancelMutex_089: 0x7204B846
+          ksceKernelChangeActiveCpuMask: 0x001173F8
+          ksceKernelChangeCurrentThreadAttr: 0x751C9B7A
           ksceKernelChangeThreadPriority: 0x63DAB420
+          ksceKernelCheckCallback: 0xE53E41F6
+          ksceKernelCheckWaitableStatus: 0xD9BD74EB
           ksceKernelClearEvent: 0x9C335818
           ksceKernelClearEventFlag: 0x4F1DA3BE
           ksceKernelCreateCallback: 0x1C41614C
+          ksceKernelCreateCond: 0xDB6CD34A
           ksceKernelCreateEventFlag: 0x4336BAA4
           ksceKernelCreateMutex: 0xFBAA026E
           ksceKernelCreateSema: 0x30E93C31
@@ -1974,31 +3097,41 @@ modules:
           ksceKernelDelayThread: 0x4B675D05
           ksceKernelDelayThreadCB: 0x9C0180E1
           ksceKernelDeleteCallback: 0x3A7E17F6
+          ksceKernelDeleteCond: 0xAEE0D27C
           ksceKernelDeleteEventFlag: 0x71ECB352
-          ksceKernelDeleteMutex: 0xA912340
+          ksceKernelDeleteFastMutex: 0x11FE84A1
+          ksceKernelDeleteMutex: 0x0A912340
           ksceKernelDeleteSema: 0x16A35E58
           ksceKernelDeleteThread: 0xAC834F3F
           ksceKernelEnterProcess: 0x0486F239
           ksceKernelExitDeleteThread: 0x1D17DECF
           ksceKernelExitThread: 0x0C8A38E1
           ksceKernelGetCallbackCount: 0x0892D8DF
+          ksceKernelGetMutexInfo_089: 0x69B78A12
           ksceKernelGetProcessId: 0x9DCB4B7A
           ksceKernelGetSystemTimeLow: 0x47F6DE49
           ksceKernelGetSystemTimeWide: 0xF4EE4FA9
           ksceKernelGetThreadCpuAffinityMask: 0x83DC703D
           ksceKernelGetThreadCurrentPriority: 0x01414F0B
-          ksceKernelGetThreadmgrUIDClass: 0x0A20775A
+          ksceKernelGetThreadId: 0x59D06540
+          ksceKernelGetThreadInfo: 0x283807E2
           ksceKernelGetThreadStackFreeSize: 0x7B278A0B
           ksceKernelGetThreadTLSAddr: 0x66EEA46A
+          ksceKernelGetThreadmgrUIDClass: 0x0A20775A
           ksceKernelGetTimerBaseWide: 0xA6D11DD3
           ksceKernelGetTimerTimeWide: 0xC1286004
           ksceKernelInitializeFastMutex: 0xAF8E1266
-          ksceKernelLockMutex: 0x16AC80C5
+          ksceKernelLockFastMutex: 0x70627F3A
+          ksceKernelLockMutexCB_089: 0xD06F2886
+          ksceKernelLockMutex_089: 0x16AC80C5
           ksceKernelNotifyCallback: 0xC3E00919
           ksceKernelPollEventFlag: 0x76C6555B
           ksceKernelPollSema: 0x4FDDFE24
           ksceKernelPulseEvent: 0x2427C81B
+          ksceKernelReceiveMsgPipeVector: 0xDA1F256B
+          ksceKernelReceiveMsgPipeVectorCB: 0xDA5C9AC6
           ksceKernelRegisterCallbackToEvent: 0x832A7E0C
+          ksceKernelRunWithStack2: 0xA2C801A5
           ksceKernelRunWithStack: 0xE54FD746
           ksceKernelSetEvent: 0x9EA3A45C
           ksceKernelSetEventFlag: 0xD4780C3E
@@ -2007,29 +3140,128 @@ modules:
           ksceKernelSignalCondAll: 0x6EC78CD0
           ksceKernelSignalCondTo: 0x61533DA9
           ksceKernelSignalSema: 0xD270498B
-          ksceKernelStartThread: 0x21F5419B
+          ksceKernelStartThread_089: 0x21F5419B
           ksceKernelStartTimer: 0x84C4CE4D
           ksceKernelStopTimer: 0x474F214B
+          ksceKernelTryLockMutex_089: 0x270993A6
           ksceKernelTryLockReadRWLock: 0xFC2B5A50
           ksceKernelTryLockWriteRWLock: 0xA96F2E5A
-          ksceKernelUnlockMutex: 0x1E82E5D0
+          ksceKernelUnlockFastMutex: 0xDB395782
+          ksceKernelUnlockMutex_089: 0x1E82E5D0
           ksceKernelUnlockReadRWLock: 0xDE1B9EEE
           ksceKernelUnlockWriteRWLock: 0x94A73797
           ksceKernelUnregisterCallbackFromEvent: 0x2E48D81C
           ksceKernelUnregisterCallbackFromEventAll: 0x8DADBD16
           ksceKernelUnregisterThreadEventHandler: 0x2C8ED6F0
+          ksceKernelWaitCond: 0xCC7E027D
           ksceKernelWaitEventFlag: 0x0C1D3F20
           ksceKernelWaitEventFlagCB: 0x8A35F714
           ksceKernelWaitSema: 0x3C8B55A9
+          ksceKernelWaitSemaCB: 0xF55E4D86
           ksceKernelWaitThreadEnd: 0x3E20216F
           ksceKernelWaitThreadEndCB: 0x9EF4F62C
-          ksceKernelCheckWaitableStatus: 0xD9BD74EB
-          ksceKernelCheckCallback: 0xE53E41F6
       SceThreadmgr:
+        nid: 0x859A24B1
+        kernel: false
         functions:
+          __sceKernelCreateLwMutex: 0x4BB3154A
+          _sceKernelCancelEvent: 0x29483405
+          _sceKernelCancelEventFlag: 0xF76F3056
+          _sceKernelCancelEventWithSetPattern: 0x8E68E870
+          _sceKernelCancelMsgPipe: 0xCE769C83
+          _sceKernelCancelMutex: 0x1B74CB89
+          _sceKernelCancelRWLock: 0xD004EA15
+          _sceKernelCancelSema: 0x1CAF805D
+          _sceKernelCancelTimer: 0x13117B21
+          _sceKernelCreateCond: 0xCC14FA59
+          _sceKernelCreateEventFlag: 0x38AA5E8E
+          _sceKernelCreateLwCond: 0x940B9EBE
+          _sceKernelCreateMsgPipeWithLR: 0x2AAC8BFD
+          _sceKernelCreateMutex: 0x92667AE5
+          _sceKernelCreateRWLock: 0xB1877F5E
+          _sceKernelCreateSema: 0x0D76458E
+          _sceKernelCreateSema_16XX: 0xBD06F27C
+          _sceKernelCreateSimpleEvent: 0x9C187FAD
+          _sceKernelCreateTimer: 0x79BA0A6D
+          _sceKernelDeleteLwCond: 0x75FCF058
+          _sceKernelDeleteLwMutex: 0x91262C5F
+          _sceKernelExitCallback: 0x2682E6ED
+          _sceKernelGetCallbackInfo: 0x86761234
+          _sceKernelGetCondInfo: 0x05C51CE1
+          _sceKernelGetEventFlagInfo: 0x106C216F
+          _sceKernelGetEventInfo: 0xB395BBF1
+          _sceKernelGetEventPattern: 0x70358258
+          _sceKernelGetLwCondInfo: 0x6C79F2F2
+          _sceKernelGetLwCondInfoById: 0xD9E78D30
+          _sceKernelGetLwMutexInfoById: 0xFEC9E946
+          _sceKernelGetMsgPipeInfo: 0x7AE31060
+          _sceKernelGetMutexInfo: 0xE8CC3DF0
+          _sceKernelGetRWLockInfo: 0x8CE3AFC7
+          _sceKernelGetSemaInfo: 0x0402C633
+          _sceKernelGetSystemInfo: 0x80544E0C
+          _sceKernelGetSystemTime: 0xB70EBAE9
+          _sceKernelGetThreadContextForVM: 0x377094D5
+          _sceKernelGetThreadCpuAffinityMask: 0x212E6C35
+          _sceKernelGetThreadEventInfo: 0x5DE0B7E9
+          _sceKernelGetThreadExitStatus: 0xD3210C08
+          _sceKernelGetThreadInfo: 0xB373D8A1
+          _sceKernelGetThreadRunStatus: 0xC7FB5497
+          _sceKernelGetThreadTLSAddr: 0xBACA6891
+          _sceKernelGetTimerBase: 0x865DA482
+          _sceKernelGetTimerEventRemainingTime: 0x215FD24D
+          _sceKernelGetTimerInfo: 0xAC7FE4F3
+          _sceKernelGetTimerTime: 0x6F2C41BA
+          _sceKernelLockLwMutex: 0x9C572180
+          _sceKernelLockMutex: 0x7FA945AD
+          _sceKernelLockMutexCB: 0xDB9F5333
+          _sceKernelLockReadRWLock: 0x7EB9E8B5
+          _sceKernelLockReadRWLockCB: 0x5D86D763
+          _sceKernelLockWriteRWLock: 0x80191FAA
+          _sceKernelLockWriteRWLockCB: 0xDBD09B09
+          _sceKernelPMonThreadGetCounter: 0x6B9711AC
+          _sceKernelPollEvent: 0x21C7913E
+          _sceKernelPollEventFlag: 0xDAB1B1C8
+          _sceKernelPulseEventWithNotifyCallback: 0x3E49D3F1
+          _sceKernelReceiveMsgPipeVector: 0x3DD9E4AB
+          _sceKernelReceiveMsgPipeVectorCB: 0x4DBF648E
+          _sceKernelRegisterThreadEventHandler: 0xCE6B49D8
+          _sceKernelSendMsgPipeVector: 0x5E65E454
+          _sceKernelSendMsgPipeVectorCB: 0xF6D515DC
+          _sceKernelSetEventWithNotifyCallback: 0x118F646E
+          _sceKernelSetThreadContextForVM: 0xD4785C41
+          _sceKernelSetTimerEvent: 0xE2C0BFEF
+          _sceKernelSetTimerTime: 0xFF738CD9
+          _sceKernelSignalLwCond: 0xC37F6983
+          _sceKernelSignalLwCondAll: 0x07D2584A
+          _sceKernelSignalLwCondTo: 0x6F1A4A2E
+          _sceKernelStartThread: 0xC30B1745
+          _sceKernelTryReceiveMsgPipeVector: 0x03CFCF00
+          _sceKernelTrySendMsgPipeVector: 0xB3D600AB
+          _sceKernelUnlockLwMutex: 0x2ABC41DF
+          _sceKernelWaitCond: 0x040795C7
+          _sceKernelWaitCondCB: 0x452B0AB3
+          _sceKernelWaitEvent: 0x4E0EA70D
+          _sceKernelWaitEventCB: 0x7D483C33
+          _sceKernelWaitEventFlag: 0xFCE2F728
+          _sceKernelWaitEventFlagCB: 0x401E0C68
+          _sceKernelWaitException: 0x6F7C4DE6
+          _sceKernelWaitExceptionCB: 0x5E7876F2
+          _sceKernelWaitLwCond: 0x18C65756
+          _sceKernelWaitLwCondCB: 0x72DBB96B
+          _sceKernelWaitMultipleEvents: 0x200CC503
+          _sceKernelWaitMultipleEventsCB: 0x0558B7C1
+          _sceKernelWaitSema: 0x45389B6B
+          _sceKernelWaitSemaCB: 0xF8E06784
+          _sceKernelWaitSignal: 0x50407BF4
+          _sceKernelWaitSignalCB: 0xCEA3FC52
+          _sceKernelWaitThreadEnd: 0xEA5C52F5
+          _sceKernelWaitThreadEndCB: 0xFA3D4491
           sceKernelCancelCallback: 0x30741EF2
-          sceKernelChangeActiveCpuMask: 0x1173F8
+          sceKernelCancelMutex_089: 0x7204B846
+          sceKernelChangeActiveCpuMask: 0x001173F8
+          sceKernelChangeCurrentThreadAttr: 0x751C9B7A
           sceKernelChangeThreadCpuAffinityMask: 0x15129174
+          sceKernelChangeThreadPriority2: 0xC5FFCA61
           sceKernelChangeThreadPriority: 0xBD0139F2
           sceKernelChangeThreadVfpException: 0xCC18FBAE
           sceKernelCheckCallback: 0xE53E41F6
@@ -2039,14 +3271,17 @@ modules:
           sceKernelCloseCond: 0x15C690E0
           sceKernelCloseEventFlag: 0x9A68F547
           sceKernelCloseMsgPipe: 0x1305A065
-          sceKernelCloseMutex: 0x3E23AF6
+          sceKernelCloseMutex: 0x03E23AF6
+          sceKernelCloseMutex_089: 0xA35427EE
           sceKernelCloseRWLock: 0xFD5BD5C1
           sceKernelCloseSema: 0xA2D81F9E
           sceKernelCloseSimpleEvent: 0xFEF4CA53
           sceKernelCloseTimer: 0xACE60E4A
           sceKernelCreateCallback: 0xB19CF7E9
           sceKernelCreateThreadForUser: 0xC0FAF6A3
+          sceKernelDelayThread200: 0x97C4A7C4
           sceKernelDelayThread: 0x4B675D05
+          sceKernelDelayThreadCB200: 0x34938242
           sceKernelDelayThreadCB: 0x9C0180E1
           sceKernelDeleteCallback: 0xD469676B
           sceKernelDeleteCond: 0x879E6EBD
@@ -2059,19 +3294,27 @@ modules:
           sceKernelDeleteThread: 0x1BBDE3D9
           sceKernelDeleteTimer: 0xAB1E42C4
           sceKernelExitDeleteThread: 0x1D17DECF
-          sceKernelGetCallbackCount: 0x38644D5
+          sceKernelExitThread: 0x0C8A38E1
+          sceKernelGetCallbackCount: 0x038644D5
           sceKernelGetMsgPipeCreatorId: 0x70E2A6D2
+          sceKernelGetMutexInfo_089: 0x69B78A12
           sceKernelGetProcessId: 0x9DCB4B7A
+          sceKernelGetSystemTimeLow: 0x47F6DE49
           sceKernelGetSystemTimeWide: 0xF4EE4FA9
+          sceKernelGetThreadCpuAffinityMask: 0xF1AE5654
+          sceKernelGetThreadCurrentPriority: 0x01414F0B
           sceKernelGetThreadStackFreeSize: 0x4F8A3DA0
           sceKernelGetThreadmgrUIDClass: 0xC9678F7F
           sceKernelGetTimerBaseWide: 0x5DBC1960
           sceKernelGetTimerTimeWide: 0x3EFD3165
+          sceKernelLockMutexCB_089: 0xD06F2886
+          sceKernelLockMutex_089: 0x16AC80C5
           sceKernelNotifyCallback: 0xA4683592
           sceKernelOpenCond: 0x76BDA02F
           sceKernelOpenEventFlag: 0xBC19F8A1
-          sceKernelOpenMsgPipe: 0xE1CB9F6
+          sceKernelOpenMsgPipe: 0x0E1CB9F6
           sceKernelOpenMutex: 0x52E17182
+          sceKernelOpenMutex_089: 0x2928D2EC
           sceKernelOpenRWLock: 0xCE510196
           sceKernelOpenSema: 0xCBE235C7
           sceKernelOpenSimpleEvent: 0x4E1E4DF8
@@ -2079,6 +3322,7 @@ modules:
           sceKernelPollSema: 0x866EF048
           sceKernelPulseEvent: 0x8D27BAD6
           sceKernelRegisterCallbackToEvent: 0x76FB37E9
+          sceKernelResumeThreadForVM: 0x7EB55DAC
           sceKernelSendSignal: 0xD4C367B2
           sceKernelSetEvent: 0x324218CD
           sceKernelSetEventFlag: 0xEC94DFF7
@@ -2087,47 +3331,28 @@ modules:
           sceKernelSignalCondAll: 0xC2E7AC22
           sceKernelSignalCondTo: 0x1269F4EC
           sceKernelSignalSema: 0xE6B761D1
+          sceKernelStartThread_089: 0x21F5419B
           sceKernelStartTimer: 0x48091E0C
           sceKernelStopTimer: 0x869E9F20
+          sceKernelSuspendThreadForVM: 0x1FF5960D
           sceKernelTryLockMutex: 0x72FC1F54
+          sceKernelTryLockMutex_089: 0x270993A6
           sceKernelTryLockReadRWLock: 0xEFDDA456
           sceKernelTryLockWriteRWLock: 0x206CBB66
           sceKernelUnlockMutex: 0x1A372EC8
+          sceKernelUnlockMutex_089: 0x1E82E5D0
           sceKernelUnlockReadRWLock: 0x3EF91145
           sceKernelUnlockWriteRWLock: 0xB4151397
           sceKernelUnregisterCallbackFromEvent: 0x18462B11
           sceKernelUnregisterCallbackFromEventAll: 0x888A7361
-          sceKernelGetThreadTLSAddr: 0xBACA6891
-        kernel: false
-        nid: 0x859A24B1
+          sceKernelUnregisterThreadEventHandler: 0x2C8ED6F0
+          sceKernelWaitThreadEndCB_089: 0x0373C5E3
+          sceKernelWaitThreadEnd_089: 0xF3489EF4
       SceThreadmgrCoredumpTime:
         functions:
           sceKernelExitThread: 0xC8A38E1
         kernel: false
         nid: 0x5E8D0E22
-      SceCpu:
-        kernel: false
-        nid: 0x45265161
-      SceDebugLed:
-        functions:
-          sceKernelGetGPI: 0x14F582CF
-          sceKernelSetGPO: 0x78E702D3
-        kernel: false
-        nid: 0xAE004C0A
-      SceDipsw:
-        functions:
-          sceKernelCheckDipsw: 0x1C783FB2
-          sceKernelClearDipsw: 0x800EDCC1
-          sceKernelSetDipsw: 0x817053D4
-        kernel: false
-        nid: 0xB36D5922
-      SceDipswForDriver:
-        nid: 0xC9E26388
-        kernel: true
-        functions:
-          ksceKernelSetDipsw: 0x82E45FBF
-          ksceKernelCheckDipsw: 0xA98FC2FD
-          ksceKernelClearDipsw: 0xF1F3E9FE
   SceKernelModulemgr:
     nid: 0x726C6635
     libraries:
@@ -2174,52 +3399,208 @@ modules:
     nid: 0x9642948C
     libraries:
       SceIofilemgrForDriver:
+        nid: 0x40FD29C7
+        kernel: true
         functions:
+          SceIofilemgrForDriver_0D493274: 0x0D493274
+          SceIofilemgrForDriver_12F8D58E: 0x12F8D58E
+          SceIofilemgrForDriver_15C17487: 0x15C17487
+          SceIofilemgrForDriver_21D57633: 0x21D57633
+          SceIofilemgrForDriver_2EFDFA12: 0x2EFDFA12
+          SceIofilemgrForDriver_3675ECB9: 0x3675ECB9
+          SceIofilemgrForDriver_39ABDB9E: 0x39ABDB9E
+          SceIofilemgrForDriver_3A79FAC9: 0x3A79FAC9
+          SceIofilemgrForDriver_3F0FF9D5: 0x3F0FF9D5
+          SceIofilemgrForDriver_44EDCE57: 0x44EDCE57
+          SceIofilemgrForDriver_5B7E5AB8: 0x5B7E5AB8
+          SceIofilemgrForDriver_69A7E076: 0x69A7E076
+          SceIofilemgrForDriver_6B3CA9F7: 0x6B3CA9F7
+          SceIofilemgrForDriver_6BEEDDB4: 0x6BEEDDB4
+          SceIofilemgrForDriver_6D0FEDB6: 0x6D0FEDB6
+          SceIofilemgrForDriver_8F0DE34D: 0x8F0DE34D
+          SceIofilemgrForDriver_9FCDCE62: 0x9FCDCE62
+          SceIofilemgrForDriver_A1EF2648: 0xA1EF2648
+          SceIofilemgrForDriver_A39A9CA7: 0xA39A9CA7
+          SceIofilemgrForDriver_A7020B0D: 0xA7020B0D
+          SceIofilemgrForDriver_AA253B68: 0xAA253B68
+          SceIofilemgrForDriver_AC0E9AAA: 0xAC0E9AAA
+          SceIofilemgrForDriver_B499287E: 0xB499287E
+          SceIofilemgrForDriver_B987450D: 0xB987450D
+          SceIofilemgrForDriver_BBAC1751: 0xBBAC1751
+          SceIofilemgrForDriver_C20C621C: 0xC20C621C
+          SceIofilemgrForDriver_C3AE93A2: 0xC3AE93A2
+          SceIofilemgrForDriver_C468B5EF: 0xC468B5EF
+          SceIofilemgrForDriver_C722DF35: 0xC722DF35
+          SceIofilemgrForDriver_C85E33A2: 0xC85E33A2
+          SceIofilemgrForDriver_CCE94599: 0xCCE94599
+          SceIofilemgrForDriver_CDF3EF52: 0xCDF3EF52
+          SceIofilemgrForDriver_D6AB5E4B: 0xD6AB5E4B
+          SceIofilemgrForDriver_DC2D8BCE: 0xDC2D8BCE
+          SceIofilemgrForDriver_DCF75F6D: 0xDCF75F6D
+          SceIofilemgrForDriver_DD46CD63: 0xDD46CD63
+          SceIofilemgrForDriver_F4F8C59A: 0xF4F8C59A
+          ksceIoCancel: 0x6D59658D
           ksceIoChstat: 0x7D42B8DC
+          ksceIoChstatAsync: 0x7EC442BF
           ksceIoChstatByFd: 0xDF57A75F
+          ksceIoChstatByFdAsync: 0xEC974400
+          ksceIoChstatByFdThreadCB: 0x7517FE29
+          ksceIoChstatThreadCB: 0xBCE4865B
+          ksceIoChstat_2: 0x1F98BD50
           ksceIoClearErrorEvent: 0x40B933C7
           ksceIoClose: 0xF99DD8A3
+          ksceIoCloseAsync: 0x11C57CC6
+          ksceIoCloseThreadCB: 0x1AE14011
           ksceIoCreateErrorEvent: 0x3C0343DB
           ksceIoCreateMountEvent: 0x2DFA192F
+          ksceIoDclose: 0x03F6A684
           ksceIoDclose: 0x19C81DD6
+          ksceIoDcloseAsync: 0xC08F199F
           ksceIoDeleteErrorEvent: 0xC6158F8D
           ksceIoDeleteMountEvent: 0x43DB0AE4
           ksceIoDevctl: 0x16882FC4
+          ksceIoDevctlAsync: 0xA9302946
           ksceIoDopen: 0x463B25CC
+          ksceIoDopenAsync: 0x72F06BDE
           ksceIoDread: 0x20CF5FC7
+          ksceIoDreadAsync: 0x5982B0E3
+          ksceIoDread_2: 0x03051B02
           ksceIoFlock: 0x16336A0D
           ksceIoGetProcessDefaultPriorityForSystem: 0xCE397158
           ksceIoGetstat: 0x75C96D25
+          ksceIoGetstatAsync: 0x94A5304A
           ksceIoGetstatByFd: 0x462F059B
+          ksceIoGetstatByFdAsync: 0x0FEE1238
+          ksceIoGetstat_2: 0xD6503624
+          ksceIoIoctl: 0x161CD33F
+          ksceIoIoctlAsync: 0xB761E91B
+          ksceIoIoctlThreadCB: 0xC1DD4317
           ksceIoLseek: 0x62090481
+          ksceIoLseekAsync: 0x541BAABD
           ksceIoMkdir: 0x7F710B25
+          ksceIoMkdirAsync: 0x27003443
           ksceIoMount: 0xD070BC48
           ksceIoOpen: 0x75192972
+          ksceIoOpenAsync: 0x451001DE
+          ksceIoOpenThreadCB: 0x0E518FA9
+          ksceIoOpen_2: 0xC3D34965
+          ksceIoPread: 0x2A17515D
+          ksceIoPreadAsync: 0x64A46A2C
+          ksceIoPreadThreadCB: 0x0B54F9E0
+          ksceIoPwrite: 0x5F1512C8
+          ksceIoPwriteAsync: 0x202CDDE3
+          ksceIoPwriteThreadCB: 0xE5DEA6B7
           ksceIoRead: 0xE17EFC03
           ksceIoReadAsync: 0x69047C81
+          ksceIoReadThreadCB: 0x809892C1
           ksceIoRemove: 0x0D7BB3E1
+          ksceIoRemoveAsync: 0xF9D6507D
           ksceIoRename: 0xDC0C4997
+          ksceIoRenameAsync: 0xAACBC47A
           ksceIoRmdir: 0x1CC9C634
+          ksceIoRmdirAsync: 0xF5B0B36C
           ksceIoSetProcessDefaultPriorityForSystem: 0xABE65071
           ksceIoSync: 0xDDF78594
+          ksceIoSyncAsync: 0x4F9EA8B0
           ksceIoSyncByFd: 0x338DCD68
           ksceIoSyncByFdAsync: 0x041209CF
+          ksceIoSyncByFd_duplicate: 0x43170575
           ksceIoUmount: 0x20574100
           ksceIoWrite: 0x21EE91F0
           ksceIoWriteAsync: 0xA1BD13D0
-        kernel: true
-        nid: 0x40FD29C7
+          ksceIoWriteThreadCB: 0x8598ADC3
+          ksceIo_call_1914_CB: 0x9C220246
+          ksceIo_set_1914_CB: 0xCFAECF18
+          kscePfsMgrVfsMount: 0xFEEE44A9
+          kscePfsMgrVfsUmount: 0xD220539D
+          ksceVfsAddVfs: 0x673D2FCD
+          ksceVfsDeleteVfs: 0x9CBFA725
+          ksceVfsGetNewNode: 0xD60B5C63
+          ksceVfsMount: 0xB62DE9A6
+          ksceVfsNodeSetEventFlag: 0x6048F245
+          ksceVfsNodeWaitEventFlag: 0xAA45010B
+          ksceVfsNode_func10: 0x2F3F8C70
+          ksceVfsNode_func11: 0x1D551105
+          ksceVfsNode_func12: 0x00C9C2DD
+          ksceVfsNode_func12: 0xB07B307D
+          ksceVfsNode_func13: 0x1350F5C7
+          ksceVfsNode_func13: 0xF7DAC0F5
+          ksceVfsNode_func14: 0x77584C8F
+          ksceVfsNode_func15: 0x50A63ACF
+          ksceVfsNode_func16: 0x1974FA92
+          ksceVfsNode_func17: 0x36A794C7
+          ksceVfsNode_func19or5: 0xABBC80E3
+          ksceVfsNode_func1: 0x76B79BEC
+          ksceVfsNode_func20or6: 0xA53C040D
+          ksceVfsNode_func21: 0x8FB94521
+          ksceVfsNode_func22: 0x942AA61F
+          ksceVfsNode_func23: 0x0D8A806E
+          ksceVfsNode_func24: 0x9CD96406
+          ksceVfsNode_func25: 0x1DBCBB01
+          ksceVfsNode_func26: 0x082AFD7F
+          ksceVfsNode_func27: 0xF53399BC
+          ksceVfsNode_func28: 0x0F7E1718
+          ksceVfsNode_func29: 0xEEAE8B51
+          ksceVfsNode_func2: 0x9E347C7D
+          ksceVfsNode_func3: 0x40944C2E
+          ksceVfsNode_func4: 0xA5A6A55C
+          ksceVfsNode_func5or19: 0x570388A5
+          ksceVfsNode_func6or20: 0x9A68378D
+          ksceVfsNode_func7: 0xB2B13818
+          ksceVfsNode_func8: 0x333C904D
+          ksceVfsNode_func9: 0xDC1E7EE4
+          ksceVfsUmount: 0x9C7E7B76
       SceIofilemgr:
+        nid: 0xF2FF276E
+        kernel: false
         functions:
+          _sceIoChstat: 0xD2EE455F
+          _sceIoChstatAsync: 0xB4B021D9
+          _sceIoChstatByFd: 0xE0BE2A30
+          _sceIoCompleteMultiple: 0x9111D004
+          _sceIoDevctl: 0x515AC017
+          _sceIoDevctlAsync: 0x3EE3F66E
+          _sceIoDopen: 0xE6E614B5
+          _sceIoDread: 0x8713D662
+          _sceIoGetstat: 0x8E7E11F2
+          _sceIoGetstatAsync: 0xD414C89F
+          _sceIoGetstatByFd: 0xE6C53567
+          _sceIoIoctl: 0x1D2988F1
+          _sceIoIoctlAsync: 0xE00DC256
+          _sceIoLseek: 0xA604764A
+          _sceIoLseekAsync: 0x2300858E
+          _sceIoMkdir: 0x8F1ACC32
+          _sceIoMkdirAsync: 0xF5C58B21
+          _sceIoOpen: 0xCC67B6FD
+          _sceIoOpenAsync: 0x09CD0FC8
+          _sceIoPread: 0x539FD5C4
+          _sceIoPreadAsync: 0xBCF5684D
+          _sceIoPwrite: 0x9654094B
+          _sceIoPwriteAsync: 0xB2D0B2F4
+          _sceIoRemove: 0x78955C65
+          _sceIoRemoveAsync: 0x5FFA47E2
+          _sceIoRename: 0x4912F748
+          _sceIoRenameAsync: 0x81794921
+          _sceIoRmdir: 0xFFFB4D76
+          _sceIoRmdirAsync: 0x13DC3244
+          _sceIoSync: 0x5DD867F7
+          _sceIoSyncAsync: 0x86DB0C0E
           sceIoCancel: 0xCEF48835
+          sceIoChstatByFdAsync: 0xA9F89275
           sceIoClose: 0xC70B8886
           sceIoCloseAsync: 0x8EA3616A
           sceIoComplete: 0xD1C49D2F
           sceIoDclose: 0x422A221A
+          sceIoDcloseAsync: 0xDC2D7D38
+          sceIoDopenAsync: 0xC49C312F
+          sceIoDreadAsync: 0xF59F37B0
           sceIoFlockForSystem: 0x3E98E422
           sceIoGetPriority: 0xF2A472A1
-          sceIoGetProcessDefaultPriority: 0xDC4F1BB
+          sceIoGetPriorityForSystem: 0xEF5432ED
+          sceIoGetProcessDefaultPriority: 0x0DC4F1BB
           sceIoGetThreadDefaultPriority: 0xA176CD03
+          sceIoGetThreadDefaultPriorityForSystem: 0xFCBCEAED
+          sceIoGetstatByFdAsync: 0x5167AC1E
           sceIoLseek32: 0x49252B9B
           sceIoRead: 0xFDB32293
           sceIoReadAsync: 0x773EBD45
@@ -2232,13 +3613,28 @@ modules:
           sceIoSyncByFdAsync: 0x7E1367CB
           sceIoWrite: 0x34EFD876
           sceIoWriteAsync: 0xE0D63D2A
-        kernel: false
-        nid: 0xF2FF276E
   SceProcessmgr:
     nid: 0x8B8A6263
     libraries:
       SceProcessmgr:
+        nid: 0x2DD91812
+        kernel: false
         functions:
+          _sceKernelExitProcessForUserB: 0xC053DC6B
+          _sceKernelGetTimer5Reg: 0x2F73D72F
+          _sceKernelRegisterLibkernelAddresses: 0x56C2E8FF
+          ceKernelGetRemoteProcessTime: 0xE6E9FCA3
+          sceKernelCDialogSessionClose: 0xDB4CC1D0
+          sceKernelCDialogSetLeaseLimit: 0xEC8DDAAD
+          sceKernelCallAbortHandler: 0xEB6E50BB
+          sceKernelGetCurrentProcess: 0xCD248267
+          sceKernelGetExtraTty: 0x2D635A00
+          sceKernelGetProcessName: 0x10C52C95
+          sceKernelGetProcessParam: 0x2BE3E066
+          sceKernelGetProcessTimeCore: 0xD37A8437
+          sceKernelGetProcessTimeLowCore: 0xF5D0D4C6
+          sceKernelGetProcessTimeWideCore: 0x89DA0967
+          sceKernelGetProcessTitleId: 0x03A48771
           sceKernelGetStderr: 0xFA5E3ADA
           sceKernelGetStdin: 0xC1727F59
           sceKernelGetStdout: 0xE5AA625C
@@ -2249,44 +3645,196 @@ modules:
           sceKernelLibcGmtime_r: 0xBCA437CD
           sceKernelLibcLocaltime_r: 0x94F041ED
           sceKernelLibcMktime: 0x890BDC39
-          sceKernelLibcTime: 0x39BE45
+          sceKernelLibcTime: 0x0039BE45
           sceKernelPowerLock: 0x7AA73378
           sceKernelPowerTick: 0x2252890C
           sceKernelPowerUnlock: 0x466C0CBD
           sceKernelRegisterProcessTerminationCallback: 0x5EC77870
           sceKernelUnregisterProcessTerminationCallback: 0x973A4527
-        kernel: false
-        nid: 0x2DD91812
-      SceProcessmgrForKernel:
+      SceProcessmgrForDriver:
+        nid: 0x746EC971
         kernel: true
-        nid: 0x7A69DE86
         functions:
+          SceProcessmgrForDriver_00B1CA0F: 0x00B1CA0F
+          SceProcessmgrForDriver_0CC5B30C: 0x0CC5B30C
+          SceProcessmgrForDriver_11BEFBBE: 0x11BEFBBE
+          SceProcessmgrForDriver_1C70501E: 0x1C70501E
+          SceProcessmgrForDriver_1D0F3185: 0x1D0F3185
+          SceProcessmgrForDriver_21A6F0EC: 0x21A6F0EC
+          SceProcessmgrForDriver_24FA97A5: 0x24FA97A5
+          SceProcessmgrForDriver_2CEB1C7A: 0x2CEB1C7A
+          SceProcessmgrForDriver_33B3D026: 0x33B3D026
+          SceProcessmgrForDriver_3B33FFBA: 0x3B33FFBA
+          SceProcessmgrForDriver_4140D633: 0x4140D633
+          SceProcessmgrForDriver_46221964: 0x46221964
+          SceProcessmgrForDriver_5468892A: 0x5468892A
+          SceProcessmgrForDriver_54D469E2: 0x54D469E2
+          SceProcessmgrForDriver_594319C7: 0x594319C7
+          SceProcessmgrForDriver_5BDA978F: 0x5BDA978F
+          SceProcessmgrForDriver_5E882B60: 0x5E882B60
+          SceProcessmgrForDriver_61B9B6FA: 0x61B9B6FA
+          SceProcessmgrForDriver_6599E5D9: 0x6599E5D9
+          SceProcessmgrForDriver_65B120B8: 0x65B120B8
+          SceProcessmgrForDriver_879153D9: 0x879153D9
+          SceProcessmgrForDriver_8A85FA28: 0x8A85FA28
+          SceProcessmgrForDriver_8CB01675: 0x8CB01675
+          SceProcessmgrForDriver_9C28EA9A: 0x9C28EA9A
+          SceProcessmgrForDriver_A1CF74FA: 0xA1CF74FA
+          SceProcessmgrForDriver_B1C3EFCA: 0xB1C3EFCA
+          SceProcessmgrForDriver_B559410A: 0xB559410A
+          SceProcessmgrForDriver_B80DBD53: 0xB80DBD53
+          SceProcessmgrForDriver_BA0A06A4: 0xBA0A06A4
+          SceProcessmgrForDriver_C5CF15ED: 0xC5CF15ED
+          SceProcessmgrForDriver_C715591F: 0xC715591F
+          SceProcessmgrForDriver_D141C076: 0xD141C076
+          SceProcessmgrForDriver_DD0A58D1: 0xDD0A58D1
+          SceProcessmgrForDriver_E1A67C86: 0xE1A67C86
+          SceProcessmgrForDriver_E8005AFC: 0xE8005AFC
+          SceProcessmgrForDriver_FC2A424E: 0xFC2A424E
+          ksceKernelCreateProcessLocalStorage: 0x3801D7D6
+          ksceKernelGetPidProcessLocalStorageAddr: 0xAF80F39C
+          ksceKernelGetProcessInfo: 0x0AFF3EAE
+          ksceKernelGetProcessLocalStorageAddr: 0xEE694840
+          ksceKernelGetProcessTimeCore: 0xEC283166
+          ksceKernelGetProcessTimeLowCore: 0x02179E12
+          ksceKernelGetProcessTimeWideCore: 0x82D94BE9
+          ksceKernelGetRemoteProcessTime: 0xC074EB31
+          ksceKernelIsCDialogAvailable: 0x2F6020B7
+          ksceKernelIsGameBudget: 0xF7A8BB25
+      SceProcessmgrForKernel:
+        nid: 0x7A69DE86
+        kernel: true
+        functions:
+          SceProcessmgrForKernel_029378AC: 0x029378AC
+          SceProcessmgrForKernel_05F74BAF: 0x05F74BAF
+          SceProcessmgrForKernel_080CDC59: 0x080CDC59
+          SceProcessmgrForKernel_0A5A2CF1: 0x0A5A2CF1
+          SceProcessmgrForKernel_0A60B40A: 0x0A60B40A
+          SceProcessmgrForKernel_0EE2658E: 0x0EE2658E
+          SceProcessmgrForKernel_1423FA86: 0x1423FA86
+          SceProcessmgrForKernel_15A93CD2: 0x15A93CD2
+          SceProcessmgrForKernel_20174234: 0x20174234
+          SceProcessmgrForKernel_234A80B6: 0x234A80B6
+          SceProcessmgrForKernel_2ABFB6C1: 0x2ABFB6C1
+          SceProcessmgrForKernel_31834C49: 0x31834C49
+          SceProcessmgrForKernel_34FA9645: 0x34FA9645
+          SceProcessmgrForKernel_36728B16: 0x36728B16
+          SceProcessmgrForKernel_381818A1: 0x381818A1
+          SceProcessmgrForKernel_38FB7BCA: 0x38FB7BCA
+          SceProcessmgrForKernel_3C4D2889: 0x3C4D2889
+          SceProcessmgrForKernel_3C5E2F08: 0x3C5E2F08
+          SceProcessmgrForKernel_41815DF2: 0x41815DF2
+          SceProcessmgrForKernel_54D7B16A: 0x54D7B16A
+          SceProcessmgrForKernel_59FA3216: 0x59FA3216
+          SceProcessmgrForKernel_5AC72C5A: 0x5AC72C5A
+          SceProcessmgrForKernel_62D048D2: 0x62D048D2
+          SceProcessmgrForKernel_6A7FF80A: 0x6A7FF80A
+          SceProcessmgrForKernel_6AECE4CD: 0x6AECE4CD
+          SceProcessmgrForKernel_71CF71FD: 0x71CF71FD
+          SceProcessmgrForKernel_76C89783: 0x76C89783
+          SceProcessmgrForKernel_7D8D7885: 0x7D8D7885
+          SceProcessmgrForKernel_8729DE79: 0x8729DE79
+          SceProcessmgrForKernel_89A0A910: 0x89A0A910
+          SceProcessmgrForKernel_8F320D2B: 0x8F320D2B
+          SceProcessmgrForKernel_90C27779: 0x90C27779
+          SceProcessmgrForKernel_915AB8D6: 0x915AB8D6
+          SceProcessmgrForKernel_9321D0E5: 0x9321D0E5
+          SceProcessmgrForKernel_95F9ED94: 0x95F9ED94
+          SceProcessmgrForKernel_A1071106: 0xA1071106
+          SceProcessmgrForKernel_A9C20202: 0xA9C20202
+          SceProcessmgrForKernel_ACBAAB10: 0xACBAAB10
+          SceProcessmgrForKernel_B13E3C7B: 0xB13E3C7B
+          SceProcessmgrForKernel_B75FB970: 0xB75FB970
+          SceProcessmgrForKernel_B7C91F6C: 0xB7C91F6C
+          SceProcessmgrForKernel_C031BFE0: 0xC031BFE0
+          SceProcessmgrForKernel_C1C91BB2: 0xC1C91BB2
+          SceProcessmgrForKernel_C55BF6C3: 0xC55BF6C3
+          SceProcessmgrForKernel_C6820972: 0xC6820972
+          SceProcessmgrForKernel_C77C2085: 0xC77C2085
+          SceProcessmgrForKernel_C7E75A8C: 0xC7E75A8C
+          SceProcessmgrForKernel_CCB4289B: 0xCCB4289B
+          SceProcessmgrForKernel_CF83C23B: 0xCF83C23B
+          SceProcessmgrForKernel_D17D6110: 0xD17D6110
+          SceProcessmgrForKernel_E0A9C9C4: 0xE0A9C9C4
+          SceProcessmgrForKernel_E5A60577: 0xE5A60577
+          SceProcessmgrForKernel_E7174A8D: 0xE7174A8D
+          SceProcessmgrForKernel_F3C4A83B: 0xF3C4A83B
+          SceProcessmgrForKernel_F7FFECF3: 0xF7FFECF3
+          ksceKernelExitProcessForUser: 0x4CA7DC42
           ksceKernelGetProcessAuthid: 0xE4C83B0D
           ksceKernelGetProcessKernelBuf: 0xB9E68092
-      SceProcessmgrForDriver:
-        kernel: true
-        nid: 0x746EC971
-        functions:
-          ksceKernelGetProcessTimeLowCore: 0x02179E12
-          ksceKernelGetProcessInfo: 0x0AFF3EAE
-          ksceKernelIsCDialogAvailable: 0x2F6020B7
-          ksceKernelCreateProcessLocalStorage: 0x3801D7D6
-          ksceKernelGetProcessTimeWideCore: 0x82D94BE9
-          ksceKernelGetPidProcessLocalStorageAddr: 0xAF80F39C
-          ksceKernelGetRemoteProcessTime: 0xC074EB31
-          ksceKernelGetProcessTimeCore: 0xEC283166
-          ksceKernelGetProcessLocalStorageAddr: 0xEE694840
-          ksceKernelIsGameBudget: 0xF7A8BB25
+          ksceKernelLibcGettimeofday: 0xDE8B8B5E
+          ksceKernelLibcTime: 0x9E38C556
   SceLibKernel:
     nid: 0xF9C9C52F
     libraries:
       SceLibKernel:
+        nid: 0xCAE9ACE6
+        kernel: false
         functions:
-          SceKernelStackChkGuard: 0x4458BCF3
+          SceLibKernel_01E00CBF: 0x01E00CBF
+          SceLibKernel_023EAA62: 0x023EAA62
+          SceLibKernel_0A4DF821: 0x0A4DF821
+          SceLibKernel_104D802F: 0x104D802F
+          SceLibKernel_11E263A5: 0x11E263A5
+          SceLibKernel_12C7CD2B: 0x12C7CD2B
+          SceLibKernel_1693032E: 0x1693032E
+          SceLibKernel_17C0CEF4: 0x17C0CEF4
+          SceLibKernel_1F4DF829: 0x1F4DF829
+          SceLibKernel_20E2D4B7: 0x20E2D4B7
+          SceLibKernel_211BEDE8: 0x211BEDE8
+          SceLibKernel_22C9595E: 0x22C9595E
+          SceLibKernel_27E6DEDE: 0x27E6DEDE
+          SceLibKernel_297AA2AE: 0x297AA2AE
+          SceLibKernel_2E05B2DC: 0x2E05B2DC
+          SceLibKernel_2E3B02A1: 0x2E3B02A1
+          SceLibKernel_35D20E49: 0x35D20E49
+          SceLibKernel_37F4ED04: 0x37F4ED04
+          SceLibKernel_3B595E1D: 0x3B595E1D
+          SceLibKernel_499EA781: 0x499EA781
+          SceLibKernel_4AC7EFC9: 0x4AC7EFC9
+          SceLibKernel_56A59D4F: 0x56A59D4F
+          SceLibKernel_58DDAC4F: 0x58DDAC4F
+          SceLibKernel_5F9F0D61: 0x5F9F0D61
+          SceLibKernel_622A81E6: 0x622A81E6
+          SceLibKernel_6314CAA3: 0x6314CAA3
+          SceLibKernel_65126005: 0x65126005
+          SceLibKernel_6C7365C4: 0x6C7365C4
+          SceLibKernel_6D8C0F13: 0x6D8C0F13
+          SceLibKernel_6F9C4CC1: 0x6F9C4CC1
+          SceLibKernel_70867F93: 0x70867F93
+          SceLibKernel_774AE3CB: 0x774AE3CB
+          SceLibKernel_84C75DC3: 0x84C75DC3
+          SceLibKernel_88E72157: 0x88E72157
+          SceLibKernel_8AF15B5F: 0x8AF15B5F
+          SceLibKernel_91FA6614: 0x91FA6614
+          SceLibKernel_93A6570E: 0x93A6570E
+          SceLibKernel_9557D15C: 0x9557D15C
+          SceLibKernel_9B28E1AF: 0x9B28E1AF
+          SceLibKernel_9EF798C1: 0x9EF798C1
+          SceLibKernel_9F793F84: 0x9F793F84
+          SceLibKernel_A7819967: 0xA7819967
+          SceLibKernel_A9002567: 0xA9002567
+          SceLibKernel_AB4B5485: 0xAB4B5485
+          SceLibKernel_AC57B6A4: 0xAC57B6A4
+          SceLibKernel_BEF71602: 0xBEF71602
+          SceLibKernel_C362ECD6: 0xC362ECD6
+          SceLibKernel_C8082804: 0xC8082804
+          SceLibKernel_D7E10BB1: 0xD7E10BB1
+          SceLibKernel_DC277B4D: 0xDC277B4D
+          SceLibKernel_DEAD6277: 0xDEAD6277
+          SceLibKernel_E088B0D0: 0xE088B0D0
+          SceLibKernel_E2984A54: 0xE2984A54
+          SceLibKernel_E48476FE: 0xE48476FE
+          SceLibKernel_E633BAD1: 0xE633BAD1
+          SceLibKernel_EB02F15D: 0xEB02F15D
+          SceLibKernel_EB6DA895: 0xEB6DA895
+          SceLibKernel_EE2D40F7: 0xEE2D40F7
+          SceLibKernel_EFD76235: 0xEFD76235
+          SceLibKernel_F7027E6A: 0xF7027E6A
           __sce_aeabi_idiv0: 0x4373B548
           __sce_aeabi_ldiv0: 0xFB235848
           __stack_chk_fail: 0x37691BF8
-          __stack_chk_guard: 0x93B8AA67
           _sceKernelCreateLwMutex: 0xB84EF718
           sceClibAbort: 0x2F2C6046
           sceClibDprintf: 0x4340EF77
@@ -2296,7 +3844,6 @@ modules:
           sceClibMemcmpConstTime: 0x100091AF
           sceClibMemcpy: 0x14E9DBD7
           sceClibMemcpyChk: 0x1F94EF45
-          sceClibMemcpy_safe: 0x2E3B02A1
           sceClibMemmove: 0x736753C8
           sceClibMemmoveChk: 0xA18068FC
           sceClibMemset: 0x632980D7
@@ -2316,7 +3863,7 @@ modules:
           sceClibPrintf: 0xFA26BC62
           sceClibSnprintf: 0x8CBA03D5
           sceClibSnprintfChk: 0xC2E1A945
-          sceClibStrcatChk: 0xF28A495
+          sceClibStrcatChk: 0x0F28A495
           sceClibStrchr: 0x614076B7
           sceClibStrcmp: 0xA2FB4D9D
           sceClibStrcpyChk: 0xB9B6B05A
@@ -2341,22 +3888,39 @@ modules:
           sceClibVsnprintf: 0xFA6BE467
           sceClibVsnprintfChk: 0xB628786B
           sceIoChstat: 0x29482F7F
+          sceIoChstatAsync: 0x9739A5E2
           sceIoChstatByFd: 0x6E903AB2
-          sceIoDevctl: 0x4B30CB2
+          sceIoClose: 0xF5C6F098
+          sceIoCompleteMultiple: 0xA792C404
+          sceIoDevctl: 0x04B30CB2
+          sceIoDevctlAsync: 0x950F78EB
           sceIoDopen: 0xA9283DD0
           sceIoDread: 0x9C8B6624
           sceIoGetstat: 0xBCA5B623
+          sceIoGetstatAsync: 0x82B20B41
           sceIoGetstatByFd: 0x57F8CD25
           sceIoIoctl: 0x54ABACFA
+          sceIoIoctlAsync: 0x099C54B9
           sceIoLseek: 0x99BA173E
+          sceIoLseekAsync: 0xCAC5D672
           sceIoMkdir: 0x9670D39F
+          sceIoMkdirAsync: 0x8E5FCBB1
           sceIoOpen: 0x6C60AC61
+          sceIoOpenAsync: 0x6A7EA9FD
           sceIoPread: 0x52315AD7
+          sceIoPreadAsync: 0xA010141E
           sceIoPwrite: 0x8FFFF5A8
+          sceIoPwriteAsync: 0xED25BEEF
+          sceIoRead: 0x713523E1
           sceIoRemove: 0xE20ED0F3
+          sceIoRemoveAsync: 0x446A60AC
           sceIoRename: 0xF737E369
+          sceIoRenameAsync: 0xEE9857CD
           sceIoRmdir: 0xE9F91EC8
+          sceIoRmdirAsync: 0x9694D00F
           sceIoSync: 0x98ACED6D
+          sceIoSyncAsync: 0xF7C7FBFE
+          sceIoWrite: 0x11FED231
           sceKernelAtomicAddAndGet16: 0x495C52EC
           sceKernelAtomicAddAndGet32: 0x2E84A93B
           sceKernelAtomicAddAndGet64: 0xB6CE9B9A
@@ -2390,11 +3954,11 @@ modules:
           sceKernelAtomicGetAndAdd64: 0x63DAF37D
           sceKernelAtomicGetAndAdd8: 0x27A2AAFA
           sceKernelAtomicGetAndAnd16: 0x7A0CB056
-          sceKernelAtomicGetAndAnd32: 0x8266595
+          sceKernelAtomicGetAndAnd32: 0x08266595
           sceKernelAtomicGetAndAnd64: 0x4828BC43
           sceKernelAtomicGetAndAnd8: 0x53DCA02B
           sceKernelAtomicGetAndClear16: 0x57CD7E7D
-          sceKernelAtomicGetAndClear32: 0x226A017
+          sceKernelAtomicGetAndClear32: 0x0226A017
           sceKernelAtomicGetAndClear64: 0x436AA0B5
           sceKernelAtomicGetAndClear8: 0xA10873A4
           sceKernelAtomicGetAndOr16: 0x31E49E73
@@ -2422,7 +3986,7 @@ modules:
           sceKernelAtomicSet64: 0xC8A4339C
           sceKernelAtomicSet8: 0xE960FDA2
           sceKernelAtomicSubAndGet16: 0xC26BBBB1
-          sceKernelAtomicSubAndGet32: 0x1C9CD92
+          sceKernelAtomicSubAndGet32: 0x01C9CD92
           sceKernelAtomicSubAndGet64: 0x9BB4A94B
           sceKernelAtomicSubAndGet8: 0x99E1796E
           sceKernelAtomicXorAndGet16: 0x6F524195
@@ -2448,7 +4012,7 @@ modules:
           sceKernelCreateEventFlag: 0x8516D040
           sceKernelCreateLwCond: 0x48C7EAE6
           sceKernelCreateLwMutex: 0xDA6EC8EF
-          sceKernelCreateMsgPipe: 0xA10C1C8
+          sceKernelCreateMsgPipe: 0x0A10C1C8
           sceKernelCreateMutex: 0xED53334A
           sceKernelCreateRWLock: 0x8667951D
           sceKernelCreateSema: 0x1BD67366
@@ -2476,14 +4040,14 @@ modules:
           sceKernelGetProcessTime: 0x4C4672BF
           sceKernelGetProcessTimeLow: 0xE9F973B1
           sceKernelGetProcessTimeWide: 0xB110C123
-          sceKernelGetRWLockInfo: 0x79A573B
+          sceKernelGetRWLockInfo: 0x079A573B
           sceKernelGetSemaInfo: 0x595D3FA6
           sceKernelGetSystemInfo: 0xE0241FAA
           sceKernelGetTLSAddr: 0xB295EB61
           sceKernelGetThreadCpuAffinityMask: 0x8C57AC2A
           sceKernelGetThreadCurrentPriority: 0xC53A9848
           sceKernelGetThreadExitStatus: 0xD5DC26C4
-          sceKernelGetThreadId: 0xFB972F9
+          sceKernelGetThreadId: 0x0FB972F9
           sceKernelGetThreadInfo: 0x8D9C5461
           sceKernelGetThreadRunStatus: 0xD6B01013
           sceKernelGetTimerBase: 0x1F59E04D
@@ -2510,7 +4074,7 @@ modules:
           sceKernelReceiveMsgPipeCB: 0x33AF829B
           sceKernelReceiveMsgPipeVector: 0x9F899087
           sceKernelReceiveMsgPipeVectorCB: 0xBE5B3E27
-          sceKernelSendMsgPipe: 0xCA71EA2
+          sceKernelSendMsgPipe: 0x0CA71EA2
           sceKernelSendMsgPipeCB: 0xA5CA74AC
           sceKernelSendMsgPipeVector: 0x94D506F7
           sceKernelSendMsgPipeVectorCB: 0x9C6F7F79
@@ -2542,20 +4106,84 @@ modules:
           sceKernelWaitLwCondCB: 0x8FA54B07
           sceKernelWaitMultipleEvents: 0x10586418
           sceKernelWaitMultipleEventsCB: 0x4263DBC9
-          sceKernelWaitSema: 0xC7B834B
+          sceKernelWaitSema: 0x0C7B834B
           sceKernelWaitSemaCB: 0x174692B4
           sceKernelWaitSignal: 0xADCA94E5
           sceKernelWaitSignalCB: 0x24460BB3
           sceKernelWaitThreadEnd: 0xDDB395A9
           sceKernelWaitThreadEndCB: 0xC54941ED
           sceSblACMgrIsGameProgram: 0x963F4A99
+      SceLibGcc:
+        nid: 0x567AF9A6
         kernel: false
-        nid: 0xCAE9ACE6
+        functions:
+          SceLibGcc_0DFF2B2C: 0x0DFF2B2C
+          SceLibGcc_12472ADD: 0x12472ADD
+          SceLibGcc_29C2EB11: 0x29C2EB11
+          SceLibGcc_4BB45B70: 0x4BB45B70
+          SceLibGcc_6214B80C: 0x6214B80C
+          SceLibGcc_74274866: 0x74274866
+          SceLibGcc_7772C028: 0x7772C028
+          SceLibGcc_7DFC519A: 0x7DFC519A
+          SceLibGcc_83A4F46F: 0x83A4F46F
+          SceLibGcc_8A5F29D8: 0x8A5F29D8
+          SceLibGcc_8D4953C7: 0x8D4953C7
+          SceLibGcc_A22B2436: 0xA22B2436
+          SceLibGcc_AC15DBA5: 0xAC15DBA5
+          SceLibGcc_B1CD7AC2: 0xB1CD7AC2
+          SceLibGcc_BAC00FF7: 0xBAC00FF7
+          SceLibGcc_CD43FEDC: 0xCD43FEDC
+          SceLibGcc_DA5097CE: 0xDA5097CE
+          SceLibGcc_DAB28374: 0xDAB28374
+          SceLibGcc_DBE840D6: 0xDBE840D6
+          SceLibGcc_F16E32FC: 0xF16E32FC
+      SceLibSsp:
+        nid: 0x8FA98EF1
+        kernel: false
+        functions:
+          SceLibSsp_39AD080B: 0x39AD080B
+      SceRtabi:
+        nid: 0xA941943F
+        kernel: false
+        functions:
+          SceRtabi_0D4F0635: 0x0D4F0635
+          SceRtabi_141BC4CE: 0x141BC4CE
+          SceRtabi_21FF67B9: 0x21FF67B9
+          SceRtabi_317B3774: 0x317B3774
+          SceRtabi_38D62D60: 0x38D62D60
+          SceRtabi_5024AB91: 0x5024AB91
+          SceRtabi_609CA961: 0x609CA961
+          SceRtabi_67104054: 0x67104054
+          SceRtabi_6BB838EF: 0x6BB838EF
+          SceRtabi_6CBB0E84: 0x6CBB0E84
+          SceRtabi_A5DB3A86: 0xA5DB3A86
+          SceRtabi_AA1F1B50: 0xAA1F1B50
+          SceRtabi_C33391D1: 0xC33391D1
+          SceRtabi_CBDA815C: 0xCBDA815C
+          SceRtabi_CDF7708E: 0xCDF7708E
+          SceRtabi_FB311F87: 0xFB311F87
+      SceKernelForVM:
+        nid: 0xA2B3EA8F
+        kernel: false
+        functions:
+          SceKernelForVM_010BB885: 0x010BB885
+          SceKernelForVM_70F3F49D: 0x70F3F49D
+          SceKernelForVM_F5F8F795: 0xF5F8F795
       SceLibRng:
+        nid: 0xF9AC7CF8
+        kernel: false
         functions:
           sceKernelGetRandomNumber: 0xB2700165
+      SceKernelForMono:
+        nid: 0x5FEEA076
         kernel: false
-        nid: 0xF9AC7CF8
+        functions:
+          SceKernelForMono_1BECC64C: 0x1BECC64C
+          SceKernelForMono_38839DA2: 0x38839DA2
+          SceKernelForMono_92A0964D: 0x92A0964D
+          SceKernelForMono_9A6D085B: 0x9A6D085B
+          SceKernelForMono_AD210F16: 0xAD210F16
+          SceKernelForMono_E513151F: 0xE513151F
   SceLibMonoBridge:
     nid: 0x53
     libraries:
@@ -3657,34 +5285,15 @@ modules:
   SceNpDrm:
     nid: 0xE7E2CE05
     libraries:
-      SceNpDrmPackage:
-        functions:
-          _sceNpDrmPackageCheck: 0xA1D885FA
-          _sceNpDrmPackageDecrypt: 0xD6F05ACC
-          _sceNpDrmPackageInstallFinished: 0x6896EAF2
-          _sceNpDrmPackageInstallStarted: 0xCEC18DA4
-          _sceNpDrmPackageTransform: 0x0567DCA1
-          _sceNpDrmPackageUninstallFinished: 0x23A28861
-          _sceNpDrmPackageUninstallStarted: 0x4901C3E6
-          sceNpDrmPackageInstallOngoing: 0xED0471FE
-          sceNpDrmPackageIsGameExist: 0xB9337914
-          sceNpDrmPackageUninstallOngoing: 0xF1FF6193
-        kernel: false
-        nid: 0x88514DB2
-      SceNpDrm:
-        functions:
-          _sceNpDrmCheckActData: 0xFEEBCD62
-          _sceNpDrmCheckDrmReset: 0x4458812B
-          _sceNpDrmGetFixedRifName: 0xE935B0FC
-          _sceNpDrmGetRifInfo: 0xE8343660
-          _sceNpDrmGetRifName: 0xB8C5DA7C
-          _sceNpDrmGetRifNameForInstall: 0xD312424D
-          _sceNpDrmPresetRifProvisionalFlag: 0x2523F57F
-          _sceNpDrmRemoveActData: 0x507D06A6
-        kernel: false
-        nid: 0xF2799B1B
       SceNpDrmForDriver:
+        nid: 0xD84DC44A
+        kernel: true
         functions:
+          SceNpDrmForDriver_get_act_data: 0xD91C3BCE
+          SceNpDrmForDriver_reset_act_dat: 0x077926F5
+          SceNpDrmForDriver_set_act_data: 0x742EBAF4
+          SceNpDrmForDriver_verify_rif: 0xFE7B17B6
+          SceNpDrmForDriver_verify_rif_full: 0xFF63672D
           ksceNpDrmCheckActData: 0x9265B350
           ksceNpDrmEbootSigConvert: 0xA29B75F9
           ksceNpDrmEbootSigGenMultiDisc: 0x39A7A666
@@ -3698,14 +5307,66 @@ modules:
           ksceNpDrmGetRifNameForInstall: 0x17573133
           ksceNpDrmGetRifPspKey: 0xDACB71F4
           ksceNpDrmGetRifVitaKey: 0x723322B5
+          ksceNpDrmIsLooseAccountBind: 0xFC84CA1A
+          ksceNpDrmPackageSetGameExist: 0x3BFD2850
           ksceNpDrmPresetRifProvisionalFlag: 0xC070FE89
           ksceNpDrmPspEbootSigGen: 0xEF387FC4
           ksceNpDrmPspEbootVerify: 0xB6CA3A2C
           ksceNpDrmRemoveActData: 0x8B85A509
           ksceNpDrmUpdateAccountId: 0x116FC0D6
           ksceNpDrmUpdateDebugSettings: 0xA91C7443
+      SceNpDrm:
+        nid: 0xF2799B1B
+        kernel: false
+        functions:
+          _sceNpDrmCheckActData: 0xFEEBCD62
+          _sceNpDrmCheckDrmReset: 0x4458812B
+          _sceNpDrmGetFixedRifName: 0xE935B0FC
+          _sceNpDrmGetRifInfo: 0xE8343660
+          _sceNpDrmGetRifName: 0xB8C5DA7C
+          _sceNpDrmGetRifNameForInstall: 0xD312424D
+          _sceNpDrmPresetRifProvisionalFlag: 0x2523F57F
+          _sceNpDrmRemoveActData: 0x507D06A6
+      ScePsmDrmForDriver:
+        nid: 0x9F4924F2
         kernel: true
-        nid: 0xD84DC44A
+        functions:
+          ScePsmDrmForDriver_4CD5375C: 0x4CD5375C
+          ScePsmDrmForDriver_791198CE: 0x791198CE
+          ScePsmDrmForDriver_B09003A7: 0xB09003A7
+          ScePsmDrmForDriver_get_info: 0x984F9017
+          ScePsmDrmForDriver_get_info_2: 0x8C8CFD01
+          ScePsmDrmForDriver_set_psm_act_data: 0xCB73E9D3
+      ScePsmDrm:
+        nid: 0x3F2B0888
+        kernel: false
+        functions:
+          ScePsmDrm_0E193CBB: 0x0E193CBB
+          ScePsmDrm_3E881391: 0x3E881391
+          ScePsmDrm_A89653B3: 0xA89653B3
+          ScePsmDrm_get_info: 0x207A2C53
+          ScePsmDrm_get_info_2: 0xE31A6220
+          ScePsmDrm_get_rif_name: 0x0D6470DA
+      SceNpDrmPackage:
+        nid: 0x88514DB2
+        kernel: false
+        functions:
+          _sceNpDrmPackageCheck: 0xA1D885FA
+          _sceNpDrmPackageDecrypt: 0xD6F05ACC
+          _sceNpDrmPackageInstallFinished: 0x6896EAF2
+          _sceNpDrmPackageInstallStarted: 0xCEC18DA4
+          _sceNpDrmPackageTransform: 0x0567DCA1
+          _sceNpDrmPackageUninstallFinished: 0x23A28861
+          _sceNpDrmPackageUninstallStarted: 0x4901C3E6
+          _sceNpDrmSaveDataFormatFinished: 0xC75A775B
+          _sceNpDrmSaveDataFormatStarted: 0x97BB85BD
+          _sceNpDrmSaveDataInstallFinished: 0x640C1724
+          _sceNpDrmSaveDataInstallStarted: 0x4665E75A
+          sceNpDrmPackageInstallOngoing: 0xED0471FE
+          sceNpDrmPackageIsGameExist: 0xB9337914
+          sceNpDrmPackageUninstallOngoing: 0xF1FF6193
+          sceNpDrmSaveDataFormatOngoing: 0x200D2DE4
+          sceNpDrmSaveDataInstallOngoing: 0xA5E0F38C
   SceNpManager:
     nid: 0x2D4B5F41
     libraries:
@@ -4102,33 +5763,39 @@ modules:
     nid: 0x5EAE6AEC
     libraries:
       ScePower:
+        nid: 0x1082DA7F
+        kernel: false
         functions:
           scePowerBatteryUpdateInfo: 0x27F3292C
           scePowerCancelRequest: 0xDB62C9CF
           scePowerGetArmClockFrequency: 0xABC6F88F
           scePowerGetBatteryChargingStatus: 0xB4432BC8
-          scePowerGetBatteryCycleCount: 0x8A54B9
+          scePowerGetBatteryCycleCount: 0x008A54B9
           scePowerGetBatteryElec: 0x862AE1A6
           scePowerGetBatteryFullCapacity: 0xFD18A0FF
           scePowerGetBatteryLifePercent: 0x2085D15D
           scePowerGetBatteryLifeTime: 0x8EFB3FA2
           scePowerGetBatteryRemainCapacity: 0x94F5A53F
+          scePowerGetBatteryRemainLevel: 0xEA3E3715
+          scePowerGetBatteryRemainMaxLevel: 0x1DB00F10
           scePowerGetBatterySOH: 0xA88A2B65
           scePowerGetBatteryTemp: 0x28E12023
           scePowerGetBatteryVolt: 0x483CE86B
           scePowerGetBusClockFrequency: 0x478FE6F5
           scePowerGetCaseTemp: 0x525592E4
           scePowerGetGpuClockFrequency: 0x1B04A1D6
-          scePowerGetGpuXbarClockFrequency: 0xA750DEE
+          scePowerGetGpuXbarClockFrequency: 0x0A750DEE
           scePowerGetUsingWireless: 0xD541FF03
           scePowerIsBatteryCharging: 0x1E490401
-          scePowerIsBatteryExist: 0xAFD0D8B
+          scePowerIsBatteryExist: 0x0AFD0D8B
           scePowerIsLowBattery: 0xD3075926
+          scePowerIsLowBatteryInhibitUpdateDownload: 0xE3E45636
+          scePowerIsLowBatteryInhibitUpdateReboot: 0x9AA05A48
           scePowerIsPowerOnline: 0x87440F5E
           scePowerIsRequest: 0x7FA406DD
           scePowerIsSuspendRequired: 0x78A1A796
-          scePowerRegisterCallback: 0x4B7766E
-          scePowerRequestColdReset: 0x442D852
+          scePowerRegisterCallback: 0x04B7766E
+          scePowerRequestColdReset: 0x0442D852
           scePowerRequestDisplayOff: 0x160EB506
           scePowerRequestDisplayOn: 0x3EA75C88
           scePowerRequestStandby: 0x2B7C7CF4
@@ -4141,59 +5808,122 @@ modules:
           scePowerSetIdleTimerCount: 0xB11EF149
           scePowerSetUsingWireless: 0x4D695C1F
           scePowerUnregisterCallback: 0xDFA8BAF8
-        kernel: false
-        nid: 0x1082DA7F
       ScePowerForDriver:
+        nid: 0x1590166F
+        kernel: true
         functions:
-          kscePowerGetResumeCount: 0x0074EF9B
-          kscePowerRegisterCallback: 0x04B7766E
-          kscePowerIsBatteryExist: 0x0AFD0D8B
-          kscePowerIsBatteryCharging: 0x1E490401
-          kscePowerGetBatteryLifePercent: 0x2085D15D
-          kscePowerWlanDeactivate: 0x23BB0A60
-          kscePowerSetGpuClockFrequency: 0x264C24FC
+          ScePowerForDriver_0074EF9B: 0x0074EF9B
+          ScePowerForDriver_02DB1035: 0x02DB1035
+          ScePowerForDriver_06AF03DB: 0x06AF03DB
+          ScePowerForDriver_0856FD0A: 0x0856FD0A
+          ScePowerForDriver_08951418: 0x08951418
+          ScePowerForDriver_0C6973B8: 0x0C6973B8
+          ScePowerForDriver_0CD21B1F: 0x0CD21B1F
+          ScePowerForDriver_0D56C601: 0x0D56C601
+          ScePowerForDriver_0D80B917: 0x0D80B917
+          ScePowerForDriver_0E333BEC: 0x0E333BEC
+          ScePowerForDriver_0E58FCDF: 0x0E58FCDF
+          ScePowerForDriver_165CE085: 0x165CE085
+          ScePowerForDriver_166922EC: 0x166922EC
+          ScePowerForDriver_1BA2FCAE: 0x1BA2FCAE
+          ScePowerForDriver_20A33D58: 0x20A33D58
+          ScePowerForDriver_23BB0A60: 0x23BB0A60
+          ScePowerForDriver_264C24FC: 0x264C24FC
+          ScePowerForDriver_2777A517: 0x2777A517
+          ScePowerForDriver_2784A6BD: 0x2784A6BD
+          ScePowerForDriver_2B51FE2F: 0x2B51FE2F
+          ScePowerForDriver_2E9000F7: 0x2E9000F7
+          ScePowerForDriver_38415146: 0x38415146
+          ScePowerForDriver_394DE492: 0x394DE492
+          ScePowerForDriver_3951AF53: 0x3951AF53
+          ScePowerForDriver_4159E0D9: 0x4159E0D9
+          ScePowerForDriver_43D5CE1D: 0x43D5CE1D
+          ScePowerForDriver_475BCC82: 0x475BCC82
+          ScePowerForDriver_4A69163A: 0x4A69163A
+          ScePowerForDriver_5210A6FE: 0x5210A6FE
+          ScePowerForDriver_621BD8FD: 0x621BD8FD
+          ScePowerForDriver_627A89C6: 0x627A89C6
+          ScePowerForDriver_62C5406C: 0x62C5406C
+          ScePowerForDriver_642E0AF2: 0x642E0AF2
+          ScePowerForDriver_64641E6A: 0x64641E6A
+          ScePowerForDriver_660D5AB4: 0x660D5AB4
+          ScePowerForDriver_661D670D: 0x661D670D
+          ScePowerForDriver_668F01D4: 0x668F01D4
+          ScePowerForDriver_675A84ED: 0x675A84ED
+          ScePowerForDriver_6BC26FC7: 0x6BC26FC7
+          ScePowerForDriver_6D2CA84B: 0x6D2CA84B
+          ScePowerForDriver_711C68DF: 0x711C68DF
+          ScePowerForDriver_733F973B: 0x733F973B
+          ScePowerForDriver_77027B6B: 0x77027B6B
+          ScePowerForDriver_86CB5218: 0x86CB5218
+          ScePowerForDriver_8921A7A0: 0x8921A7A0
+          ScePowerForDriver_8C0D2051: 0x8C0D2051
+          ScePowerForDriver_8D18F728: 0x8D18F728
+          ScePowerForDriver_90285886: 0x90285886
+          ScePowerForDriver_991BDEAF: 0x991BDEAF
+          ScePowerForDriver_9F26222A: 0x9F26222A
+          ScePowerForDriver_A6FF5997: 0xA6FF5997
+          ScePowerForDriver_A902CDDF: 0xA902CDDF
+          ScePowerForDriver_ACC857A4: 0xACC857A4
+          ScePowerForDriver_B104EFE2: 0xB104EFE2
+          ScePowerForDriver_B24263F0: 0xB24263F0
+          ScePowerForDriver_C1853BA7: 0xC1853BA7
+          ScePowerForDriver_C62B6164: 0xC62B6164
+          ScePowerForDriver_C63DACD5: 0xC63DACD5
+          ScePowerForDriver_C715F4F0: 0xC715F4F0
+          ScePowerForDriver_C743E392: 0xC743E392
+          ScePowerForDriver_CBCC11CC: 0xCBCC11CC
+          ScePowerForDriver_CF8F0529: 0xCF8F0529
+          ScePowerForDriver_D516D446: 0xD516D446
+          ScePowerForDriver_D8759B55: 0xD8759B55
+          ScePowerForDriver_DD3D4DAC: 0xDD3D4DAC
+          ScePowerForDriver_E4E3C316: 0xE4E3C316
+          ScePowerForDriver_E5573571: 0xE5573571
+          ScePowerForDriver_EDC13FE5: 0xEDC13FE5
+          ScePowerForDriver_EFD3C963: 0xEFD3C963
+          ScePowerForDriver_F1E14EA9: 0xF1E14EA9
+          ScePowerForDriver_F535D928: 0xF535D928
+          ScePowerForDriver_FB5C3C75: 0xFB5C3C75
+          ScePowerForDriver_FE35B73D: 0xFE35B73D
+          ScePowerForDriver_FFC84E69: 0xFFC84E69
           kscePowerBatteryUpdateInfo: 0x27F3292C
-          kscePowerGetBatteryTemp: 0x28E12023
-          kscePowerEncodeUBattery: 0x3951AF53
-          kscePowerGetBusClockFrequency: 0x478FE6F5
-          kscePowerGetBatteryVolt: 0x483CE86B
-          kscePowerGetCaseTemp: 0x525592E4
-          kscePowerWlanActivate: 0x6D2CA84B
-          kscePowerSetArmClockFrequency: 0x74DB5AE5
-          kscePowerSetGpuXbarClockFrequency: 0xA7739DBE
-          kscePowerGetGpuXbarClockFrequency: 0x0A750DEE
-          kscePowerIsRequest: 0x7FA406DD
-          kcePowerGetBatteryElec: 0x862AE1A6
-          kscePowerIsPowerOnline: 0x87440F5E
+          kscePowerCancelRequest: 0xDB62C9CF
+          kscePowerGetArmClockFrequency: 0xABC6F88F
+          kscePowerGetBatteryChargingStatus: 0xB4432BC8
+          kscePowerGetBatteryCycleCount: 0x008A54B9
+          kscePowerGetBatteryElec: 0x862AE1A6
+          kscePowerGetBatteryFullCapacity: 0xFD18A0FF
+          kscePowerGetBatteryLifePercent: 0x2085D15D
           kscePowerGetBatteryLifeTime: 0x8EFB3FA2
           kscePowerGetBatteryRemainCapacity: 0x94F5A53F
-          kscePowerGetBatteryChargingStatus: 0xB4432BC8
-          kscePowerSetBusClockFrequency: 0xB8D7B3FB
+          kscePowerGetBatteryRemainLevel: 0xEA3E3715
+          kscePowerGetBatteryRemainMaxLevel: 0x1DB00F10
+          kscePowerGetBatterySOH: 0xA88A2B65
+          kscePowerGetBatteryTemp: 0x28E12023
+          kscePowerGetBatteryVolt: 0x483CE86B
+          kscePowerGetBusClockFrequency: 0x478FE6F5
+          kscePowerGetCaseTemp: 0x525592E4
+          kscePowerGetGpuXbarClockFrequency: 0x0A750DEE
+          kscePowerIsBatteryCharging: 0x1E490401
+          kscePowerIsBatteryExist: 0x0AFD0D8B
           kscePowerIsLowBattery: 0xD3075926
-          kscePowerCancelRequest: 0xDB62C9CF
-          kscePowerUnregisterCallback: 0xDFA8BAF8
-          kscePowerGetIdleTimer: 0xEDC13FE5
-          kscePowerTick: 0xEFD3C963
-          kscePowerGetWakeupFactor: 0x9F26222A
+          kscePowerIsPowerOnline: 0x87440F5E
+          kscePowerIsRequest: 0x7FA406DD
+          kscePowerIsSuspendRequired: 0x78A1A796
+          kscePowerRegisterCallback: 0x04B7766E
           kscePowerRequestColdReset: 0x0442D852
           kscePowerRequestDisplayOff: 0x160EB506
           kscePowerRequestDisplayOn: 0x3EA75C88
-          kscePowerRequestHibernate: 0x08951418
           kscePowerRequestSoftReset: 0x2875994B
           kscePowerRequestStandby: 0x2B7C7CF4
           kscePowerRequestSuspend: 0xAC32C9CC
-          kscePowerSetBatteryFakeStatus: 0x0C6973B8
-          kscePowerSetIdleCallback: 0x1BA2FCAE
-          kscePowerSetMipsClockFrequency: 0xFFC84E69
-          kscePowerSetPowerSwMode: 0xC1853BA7
-          kscePowerGetPowerSwMode: 0x165CE085
-          kscePowerSetPsButtonPushTime: 0xCF8F0529
-          kscePowerSetStandbyButtonPushTime: 0x675A84ED
-        kernel: true
-        nid: 0x1590166F
+          kscePowerSetArmClockFrequency: 0x74DB5AE5
+          kscePowerSetBusClockFrequency: 0xB8D7B3FB
+          kscePowerSetGpuXbarClockFrequency: 0xA7739DBE
+          kscePowerUnregisterCallback: 0xDFA8BAF8
       SceLedForDriver:
-        kernel: true
         nid: 0x282C1323
+        kernel: true
         functions:
           ksceLedSetMode: 0xEA24BE03
   ScePspnetAdhoc:
@@ -4325,39 +6055,15 @@ modules:
   SceRegistryMgr:
     nid: 0x761F343C
     libraries:
-      SceRegMgr:
-        functions:
-          sceRegMgrAddRegistryCallback: 0xA86F0A71
-          sceRegMgrDbBackup: 0xB68B5422
-          sceRegMgrDbRestore: 0xA87D2562
-          sceRegMgrGetInitVals: 0x3A9DE7C5
-          sceRegMgrGetKeyBin: 0xB98D646
-          sceRegMgrGetKeyInt: 0x16DDF3DC
-          sceRegMgrGetKeyStr: 0xE188382F
-          sceRegMgrGetKeys: 0x5B161504
-          sceRegMgrGetKeysInfo: 0x58421DD1
-          sceRegMgrGetRegVersion: 0x74A0FB10
-          sceRegMgrIsBlueScreen: 0x282027B7
-          sceRegMgrRegisterCallback: 0x82A4464D
-          sceRegMgrRegisterDrvErrCallback: 0xDDB02D7F
-          sceRegMgrResetRegistryLv: 0x2B5F3E20
-          sceRegMgrSetKeys: 0x34E550DA
-          sceRegMgrSetKeyBin: 0x566A1793
-          sceRegMgrSetKeyInt: 0xD72EA399
-          sceRegMgrSetKeyStr: 0x41D320C5
-          sceRegMgrStartCallback: 0xCE84FE2F
-          sceRegMgrStopCallback: 0x6A8E2FB4
-          sceRegMgrUnregisterCallback: 0xD7BD3607
-          sceRegMgrUnregisterDrvErrCallback: 0xD9E6B7BD
-        kernel: false
-        nid: 0xC436F916
       SceRegMgrForDriver:
+        nid: 0xB2223AEB
+        kernel: true
         functions:
           ksceRegMgrAddRegistryCallback: 0xA86F0A71
           ksceRegMgrDbBackup: 0xB68B5422
           ksceRegMgrDbRestore: 0xA87D2562
           ksceRegMgrGetInitVals: 0x3A9DE7C5
-          ksceRegMgrGetKeyBin: 0xB98D646
+          ksceRegMgrGetKeyBin: 0x0B98D646
           ksceRegMgrGetKeyInt: 0x16DDF3DC
           ksceRegMgrGetKeyStr: 0xE188382F
           ksceRegMgrGetKeys: 0x5B161504
@@ -4367,10 +6073,10 @@ modules:
           ksceRegMgrRegisterCallback: 0x82A4464D
           ksceRegMgrRegisterDrvErrCallback: 0xDDB02D7F
           ksceRegMgrResetRegistryLv: 0x2B5F3E20
-          ksceRegMgrSetKeys: 0x34E550DA
           ksceRegMgrSetKeyBin: 0x566A1793
           ksceRegMgrSetKeyInt: 0xD72EA399
           ksceRegMgrSetKeyStr: 0x41D320C5
+          ksceRegMgrSetKeys: 0x34E550DA
           ksceRegMgrStartCallback: 0xCE84FE2F
           ksceRegMgrStopCallback: 0x6A8E2FB4
           ksceRegMgrSystemParamGetBin: 0x7FFE2CDF
@@ -4378,19 +6084,64 @@ modules:
           ksceRegMgrSystemParamGetStr: 0x877ADB3F
           ksceRegMgrUnregisterCallback: 0xD7BD3607
           ksceRegMgrUnregisterDrvErrCallback: 0xD9E6B7BD
+      SceRegMgrServiceForDriver:
+        nid: 0x12431F66
         kernel: true
-        nid: 0xB2223AEB
-      SceRegMgrForGame:
         functions:
+          ksceRegMgrSrvCnvRegionInt: 0x7683FC84
+          ksceRegMgrSrvCnvRegionPsCode: 0x94D008D2
+          ksceRegMgrSrvCnvRegionStr: 0x15B4A5C5
+          ksceRegMgrSrvGetRegion: 0xBEC3F77A
+          ksceRegMgrSrvGetRegionStr: 0xBC3FE639
+      SceRegMgr:
+        nid: 0xC436F916
+        kernel: false
+        functions:
+          sceRegMgrAddRegistryCallback: 0xA86F0A71
+          sceRegMgrDbBackup: 0xB68B5422
+          sceRegMgrDbRestore: 0xA87D2562
+          sceRegMgrGetInitVals: 0x3A9DE7C5
+          sceRegMgrGetKeyBin: 0x0B98D646
+          sceRegMgrGetKeyInt: 0x16DDF3DC
+          sceRegMgrGetKeyStr: 0xE188382F
+          sceRegMgrGetKeys: 0x5B161504
+          sceRegMgrGetKeysInfo: 0x58421DD1
+          sceRegMgrGetRegVersion: 0x74A0FB10
+          sceRegMgrIsBlueScreen: 0x282027B7
+          sceRegMgrRegisterCallback: 0x82A4464D
+          sceRegMgrRegisterDrvErrCallback: 0xDDB02D7F
+          sceRegMgrResetRegistryLv: 0x2B5F3E20
+          sceRegMgrSetKeyBin: 0x566A1793
+          sceRegMgrSetKeyInt: 0xD72EA399
+          sceRegMgrSetKeyStr: 0x41D320C5
+          sceRegMgrSetKeys: 0x34E550DA
+          sceRegMgrStartCallback: 0xCE84FE2F
+          sceRegMgrStopCallback: 0x6A8E2FB4
+          sceRegMgrUnregisterCallback: 0xD7BD3607
+          sceRegMgrUnregisterDrvErrCallback: 0xD9E6B7BD
+      SceRegMgrService:
+        nid: 0x23A10D9B
+        kernel: false
+        functions:
+          sceRegMgrSrvCnvRegionInt: 0x7683FC84
+          sceRegMgrSrvCnvRegionPsCode: 0x94D008D2
+          sceRegMgrSrvCnvRegionStr: 0x15B4A5C5
+          sceRegMgrSrvGetRegion: 0xBEC3F77A
+          sceRegMgrSrvGetRegionStr: 0xBC3FE639
+      SceRegMgrForGame:
+        nid: 0x0B351269
+        kernel: false
+        functions:
+          sceRegMgrSystemIsBlueScreen: 0x169A0D1D
           sceRegMgrSystemParamGetBin: 0x7FFE2CDF
           sceRegMgrSystemParamGetInt: 0x347C1BDB
           sceRegMgrSystemParamGetStr: 0x877ADB3F
           sceRegMgrSystemParamSetBin: 0xD5A73557
           sceRegMgrSystemParamSetInt: 0xC8F73311
           sceRegMgrSystemParamSetStr: 0xCB3246E3
-        kernel: false
-        nid: 0x0B351269
       SceRegMgrForSDK:
+        nid: 0x67E45817
+        kernel: false
         functions:
           sceRegMgrUtilityGetBin: 0xEFCFA182
           sceRegMgrUtilityGetInt: 0x8154D696
@@ -4398,26 +6149,36 @@ modules:
           sceRegMgrUtilitySetBin: 0x7304DC12
           sceRegMgrUtilitySetInt: 0xB370A2CF
           sceRegMgrUtilitySetStr: 0x4898C1E2
+      SceRegMgrForDebugger:
+        nid: 0xCC88EAB1
         kernel: false
-        nid: 0x67E45817
-      SceRegMgrService:
         functions:
-          sceRegMgrSrvCnvRegionInt: 0x7683FC84
-          sceRegMgrSrvCnvRegionPsCode: 0x94D008D2
-          sceRegMgrSrvCnvRegionStr: 0x15B4A5C5
-          sceRegMgrSrvGetRegion: 0xBEC3F77A
-          sceRegMgrSrvGetRegionStr: 0xBC3FE639
+          SceRegMgrForDebugger_46AC0CCB: 0x46AC0CCB
+          SceRegMgrForDebugger_53970232: 0x53970232
+          SceRegMgrForDebugger_810D2F09: 0x810D2F09
+          SceRegMgrForDebugger_8AE5757E: 0x8AE5757E
+          SceRegMgrForDebugger_8E798E47: 0x8E798E47
+          SceRegMgrForDebugger_B9A0BB77: 0xB9A0BB77
+          SceRegMgrForDebugger_C588D3E7: 0xC588D3E7
+          SceRegMgrForDebugger_C64C67A8: 0xC64C67A8
+          SceRegMgrForDebugger_D668ABD2: 0xD668ABD2
+      SceRegMgrForTool:
+        nid: 0x1F121C9E
         kernel: false
-        nid: 0x23A10D9B
-      SceRegMgrServiceForDriver:
         functions:
-          ksceRegMgrSrvCnvRegionInt: 0x7683FC84
-          ksceRegMgrSrvCnvRegionPsCode: 0x94D008D2
-          ksceRegMgrSrvCnvRegionStr: 0x15B4A5C5
-          ksceRegMgrSrvGetRegion: 0xBEC3F77A
-          ksceRegMgrSrvGetRegionStr: 0xBC3FE639
-        kernel: true
-        nid: 0x12431F66
+          SceRegMgrForTool_0B623D0B: 0x0B623D0B
+          SceRegMgrForTool_0CFA929B: 0x0CFA929B
+          SceRegMgrForTool_2A76051A: 0x2A76051A
+          SceRegMgrForTool_2D415472: 0x2D415472
+          SceRegMgrForTool_3AAB71EF: 0x3AAB71EF
+          SceRegMgrForTool_4EDF87F9: 0x4EDF87F9
+          SceRegMgrForTool_6276E7D8: 0x6276E7D8
+          SceRegMgrForTool_6808B7AD: 0x6808B7AD
+          SceRegMgrForTool_7B30AC2C: 0x7B30AC2C
+          SceRegMgrForTool_B441660B: 0xB441660B
+          SceRegMgrForTool_C689E36C: 0xC689E36C
+          SceRegMgrForTool_E6E81558: 0xE6E81558
+          SceRegMgrForTool_F55E6E4F: 0xF55E6E4F
   SceRtc:
     nid: 0x1E923AD1
     libraries:
@@ -5336,9 +7097,12 @@ modules:
     nid: 0xA2BE1892
     libraries:
       SceVshBridge:
+        nid: 0x35C5ACD4
+        kernel: false
         functions:
           _vshAppMgrAcInstGetAcdirParam: 0x1E91B5F5
           _vshAppMgrBgdlSetQueueStatus: 0xE842333E
+          _vshAppMgrCheckPfsMounted: 0x771E2612
           _vshAppMgrCloudDataCreateHeader: 0x29E83224
           _vshAppMgrCloudDataDstCreateMount: 0x8C4B556F
           _vshAppMgrCloudDataGetMcId: 0xEFCBC92C
@@ -5346,8 +7110,14 @@ modules:
           _vshAppMgrCloudDataSetupKey: 0x4DD6CA46
           _vshAppMgrCloudDataSrcMount: 0x9C480D61
           _vshAppMgrCloudDataVerifyHeader: 0x2715097A
+          _vshAppMgrFakeSaveDataCreateMount: 0x7C2975D7
           _vshAppMgrIsExclusiveProcessRunning: 0x853F63CA
+          _vshAppMgrLocalBackupGetOfflineId: 0xD433C0A9
+          _vshAppMgrLocalBackupVerifyOfflineHeader: 0x96BDC2BF
           _vshAppMgrRegisterPath: 0x179965E7
+          _vshAppMgrSaveDataLocalBackupTargetGetList: 0x1A35977D
+          _vshAppMgrSaveDataLocalBackupTargetRemoveItem: 0xBE084F03
+          _vshAppMgrSaveDataNotifyBackupFinished: 0xCE34242F
           _vshAppMgrSystemParamDateTimeSetConf: 0xBA0385A2
           _vshAppMgrUpdateRifInfo: 0xC9C5AB28
           _vshCoredumpCafCreateIv: 0x2D989282
@@ -5356,7 +7126,9 @@ modules:
           _vshCoredumpCafSegmentFinal: 0x396BBBEF
           _vshCoredumpCafSegmentInit: 0x88444AB8
           _vshCoredumpCafSegmentTransform: 0x435AC680
-          _vshCoredumpCreateDump: 0x2ABCAF7
+          _vshCoredumpCreateDump: 0x02ABCAF7
+          _vshDisplayGetActualViewportConf: 0x9039BF0B
+          _vshDisplaySetViewportConf: 0xEDC6652A
           _vshEventLogPut: 0x87E21AFF
           _vshIdStorageCreateAtomicLeaves: 0xDD50C65F
           _vshIoChstat: 0xE2A2B139
@@ -5366,7 +7138,7 @@ modules:
           _vshKernelGetCompiledSdkVersionByPid: 0x74311638
           _vshKernelSearchModuleByName: 0x232F0EEE
           _vshKernelShutdownSystem: 0x933425F1
-          _vshLedSetMode: 0x4F5FC78
+          _vshLedSetMode: 0x04F5FC78
           _vshNpDrmEbootSigConvert: 0x201871C6
           _vshNpDrmEbootSigGenMultiDisc: 0xAC6C6FCA
           _vshNpDrmEbootSigGenPs1: 0xF2CE6E93
@@ -5385,31 +7157,32 @@ modules:
           _vshRtcSetCurrentSecureTick: 0xC350E6CF
           _vshRtcSetCurrentTick: 0xC4DDAC72
           _vshRtcSetSecureAlarmTick: 0xC49D8699
+          _vshSDfCtlSetBootParameter: 0xD4DE24E2
           _vshSblAimgrGetConsoleId: 0xF183726E
-          _vshSblAimgrGetPscode: 0x1AF2CFC9
           _vshSblAimgrGetPscode2: 0x71B2ADE6
+          _vshSblAimgrGetPscode: 0x1AF2CFC9
           _vshSblAimgrGetSMI: 0x28C4D6D6
           _vshSblAimgrGetVisibleId: 0xB693DA6E
           _vshSblAuthMgrVerifySpsfo: 0xBA7BDD18
           _vshSblGcAuthMgrMlnpsnlAuth1: 0xD643667D
           _vshSblGcAuthMgrMlnpsnlAuth2: 0x96E89920
-          _vshSblGetSystemSwVersion: 0xF529915
+          _vshSblGetSystemSwVersion: 0x0F529915
           _vshSblSsCreatePassPhrase: 0x4079CD88
           _vshSblSsDecryptWithPortability: 0x99506729
           _vshSblSsEncryptWithPortability: 0x3F6DF5F3
           _vshSblSsGenerateAppKey: 0x82F2FBA8
           _vshSblSsGetNvsData: 0x9DFA6D33
           _vshSblSsSetNvsData: 0xC176D19F
-          _vshSDfCtlSetBootParameter: 0xD4DE24E2
-          _vshSysconCtrlManualChargeMode: 0x7B43EFB
-          _vshSysconGetHardwareInfo: 0x21000193
+          _vshSysconCtrlManualChargeMode: 0x07B43EFB
           _vshSysconGetHardwareInfo2: 0xD7A3D69C
+          _vshSysconGetHardwareInfo: 0x21000193
           _vshSysconGetManualChargeMode: 0x3CCFAEF4
           _vshSysconGetManufacturesStatus: 0x484DE68A
           _vshSysconGetTemperatureLog: 0x1D80FCB8
           _vshSysconGetUsbDetStatus: 0x863AD3C2
           _vshSysconLogReadData: 0x33A4F9DA
           _vshTouchSetTouchEmulationData: 0x77AA1E8B
+          shSblQafMgrIsAllowControlIduAutoUpdate: 0x51CE4C9A
           vshAppMgrCheckContentInstallPeriod: 0x8657814C
           vshAppMgrCloudDataClearMcId: 0xE42605BB
           vshAppMgrDebugSettingNotifyUpdate: 0xA82E2E98
@@ -5430,13 +7203,16 @@ modules:
           vshCtrlSetVibrationSetting: 0x59F24C78
           vshCtrlUnregisterNotifyCallBack: 0x64DB80C8
           vshDisplayRegisterFrameBufCallback: 0x9038C55C
+          vshDisplaySetInvertColors: 0x27DFAD31
           vshHdmiCecCmdForcedPollingMsg: 0xD53E02C5
+          vshHdmiDisableCec: 0xBDCF9D86
+          vshHdmiEnableCec: 0x0FD12633
           vshIdStorageCreateLeaf: 0x8E0E0C7D
           vshIdStorageDeleteLeaf: 0x51855867
           vshIdStorageFlush: 0x32691EA3
           vshIdStorageFormat: 0x1AB26527
           vshIdStorageGetFreeLeaves: 0x1A64C088
-          vshIdStorageGetLeafSize: 0x5A07BFD
+          vshIdStorageGetLeafSize: 0x05A07BFD
           vshIdStorageIsDirty: 0x5EBE2E01
           vshIdStorageIsFormatted: 0x26115B5A
           vshIdStorageIsReadOnly: 0xCD926259
@@ -5447,8 +7223,8 @@ modules:
           vshIdStorageUpdate: 0x9693D645
           vshIdStorageWriteLeaf: 0xE5083DB6
           vshIoClearErrorEvent: 0xD950A054
-          vshIoCreateErrorEvent: 0xD2A63DD
-          vshIoCreateMountEvent: 0x25AD398
+          vshIoCreateErrorEvent: 0x0D2A63DD
+          vshIoCreateMountEvent: 0x025AD398
           vshIoDeleteErrorEvent: 0x86EBB9FD
           vshIoDeleteMountEvent: 0x57F63369
           vshIoFlock: 0xDAB83424
@@ -5456,9 +7232,13 @@ modules:
           vshIoSetProcessDefaultPriorityForSystem: 0xF581621D
           vshIoUmount: 0x35BC26AC
           vshKernelCheckModelCapability: 0x9B38EAEC
+          vshKernelDisableAutoClockDown: 0x0A18C46C
+          vshKernelEnableAutoClockDown: 0x29459DD2
           vshKernelSendSysEvent: 0x71D9DB5C
           vshMemoryCardEnableSlowMode: 0xECE08D1D
           vshMemoryCardGetCardInsertState: 0x1ED13AD6
+          vshMotionNoiseFilterIsAvailable: 0x334E9FD3
+          vshMsifGetMsInfo: 0x349AA70B
           vshNpDrmIsLooseAccountBind: 0x333875AB
           vshNpDrmUpdateAccountId: 0xCB46FAB0
           vshNpDrmUpdateDebugSettings: 0x89D89CAC
@@ -5486,7 +7266,6 @@ modules:
           vshSblAimgrIsTool: 0x3BBD5935
           vshSblAimgrIsVITA: 0xE9168697
           vshSblPmMgrSetSdModeOff: 0x2E7A3AF7
-          vshSblQafMgrIsAllowControlIduAutoUpdate: 0x51CE4C9A
           vshSblQafMgrIsAllowDtcpIpReset: 0xD0C8D4EC
           vshSblQafMgrIsAllowFakeACInstall: 0x565E0504
           vshSblQafMgrIsAllowKeepCoreFile: 0xA458FACE
@@ -5503,18 +7282,21 @@ modules:
           vshSblQafMgrIsAllowShowTitleUpgradeInfo: 0x314BFD78
           vshSblQafMgrIsAllowSystemAppDebug: 0x31AACDD2
           vshSblSsIsDevelopmentMode: 0x641890D8
-          vshSblUtMgrHasComTestFlag: 0x6AD7CBB
+          vshSblUtMgrHasComTestFlag: 0x06AD7CBB
+          vshSblUtMgrHasNpTestFlag: 0xAD95CBE8
           vshSblUtMgrHasStoreFlag: 0x4A004B05
+          vshSdGetCardInfo: 0xE99DBAB2
           vshSysconBeginConfigstorageTransaction: 0x972B68A2
           vshSysconClearTemperatureLog: 0x83DDCF27
           vshSysconCommitConfigstorageTransaction: 0x2931A602
           vshSysconEnableHibernateIO: 0xF2CF8BD3
-          vshSysconEndConfigstorageTransaction: 0x5DFCAEE
+          vshSysconEndConfigstorageTransaction: 0x05DFCAEE
+          vshSysconGetBatteryCalibData: 0xF4F2F841
           vshSysconGetLogInfo: 0x723FDFD9
           vshSysconHasWWAN: 0xCEC8B917
           vshSysconIduModeClear: 0x3C8BE31F
           vshSysconIduModeSet: 0x4A2F495A
-          vshSysconIsDownLoaderMode: 0xA4ADA2
+          vshSysconIsDownLoaderMode: 0x00A4ADA2
           vshSysconIsIduMode: 0xE493EFF4
           vshSysconIsMCEmuCapable: 0x32D0951D
           vshSysconIsShowMode: 0xFF244636
@@ -5524,8 +7306,15 @@ modules:
           vshSysconShowModeClear: 0xD7E71C94
           vshSysconShowModeSet: 0x5E2A8BBD
           vshSysconVerifyConfigstorageScript: 0xE1E2BAD0
+      SceDrmBridge:
+        nid: 0xFF4CD67F
         kernel: false
-        nid: 0x35C5ACD4
+        functions:
+          SceDrmBridge_1BBB62E9: 0x1BBB62E9
+          SceDrmBridge_6D483DFC: 0x6D483DFC
+          SceDrmBridge_B81B597A: 0xB81B597A
+          SceDrmBridge_E04F767B: 0xE04F767B
+          SceDrmBridge_FFB164E2: 0xFFB164E2
   SceStdio:
     nid: 0x771A73C0
     libraries:
@@ -5539,24 +7328,207 @@ modules:
   SceSblSsMgr:
     nid: 0x4E913538
     libraries:
-      SceSblSsMgrForDriver:
+      SceSblSsMgrForKernel:
+        nid: 0x74580D9F
         kernel: true
-        nid: 0x61E9428D
         functions:
+          SceSblSsMgrForKernel_516ECC08: 0x516ECC08
+          SceSblSsMgrForKernel_83D254FF: 0x83D254FF
+          SceSblSsMgrForKernel_C2EC8F5A: 0xC2EC8F5A
+          SceSblSsMgrForKernel_E29E161C: 0xE29E161C
+          SceSblSsMgrForKernel_E2DD0378: 0xE2DD0378
+      SceSblSsMgrForDriver:
+        nid: 0x61E9428D
+        kernel: true
+        functions:
+          SceSblSsMgrForDriver_01BE0374: 0x01BE0374
+          SceSblSsMgrForDriver_04843835: 0x04843835
+          SceSblSsMgrForDriver_05B38698: 0x05B38698
+          SceSblSsMgrForDriver_0F7D28AF: 0x0F7D28AF
+          SceSblSsMgrForDriver_121FA69F: 0x121FA69F
+          SceSblSsMgrForDriver_1901CB5E: 0x1901CB5E
+          SceSblSsMgrForDriver_197ACF6F: 0x197ACF6F
+          SceSblSsMgrForDriver_1B14658D: 0x1B14658D
+          SceSblSsMgrForDriver_21EC51F6: 0x21EC51F6
+          SceSblSsMgrForDriver_249ADB07: 0x249ADB07
+          SceSblSsMgrForDriver_37DD5CBF: 0x37DD5CBF
+          SceSblSsMgrForDriver_6704D985: 0x6704D985
+          SceSblSsMgrForDriver_711C057A: 0x711C057A
+          SceSblSsMgrForDriver_79F38554: 0x79F38554
+          SceSblSsMgrForDriver_7C978BE7: 0x7C978BE7
+          SceSblSsMgrForDriver_7D46768C: 0x7D46768C
+          SceSblSsMgrForDriver_82B5DCEF: 0x82B5DCEF
+          SceSblSsMgrForDriver_83B058F5: 0x83B058F5
+          SceSblSsMgrForDriver_8B4700CB: 0x8B4700CB
+          SceSblSsMgrForDriver_8EAFB18A: 0x8EAFB18A
+          SceSblSsMgrForDriver_926BCCF0: 0x926BCCF0
+          SceSblSsMgrForDriver_92E37656: 0x92E37656
+          SceSblSsMgrForDriver_934DB6B5: 0x934DB6B5
+          SceSblSsMgrForDriver_9641374E: 0x9641374E
+          SceSblSsMgrForDriver_9A9676D0: 0x9A9676D0
+          SceSblSsMgrForDriver_B8B298FD: 0xB8B298FD
+          SceSblSsMgrForDriver_C38D0CEA: 0xC38D0CEA
+          SceSblSsMgrForDriver_C517770D: 0xC517770D
+          SceSblSsMgrForDriver_CD98CC92: 0xCD98CC92
+          SceSblSsMgrForDriver_E0B13BA7: 0xE0B13BA7
+          SceSblSsMgrForDriver_E0DC2587: 0xE0DC2587
+          SceSblSsMgrForDriver_E6E1AD15: 0xE6E1AD15
+          SceSblSsMgrForDriver_EA6ACB6D: 0xEA6ACB6D
+          SceSblSsMgrForDriver_EB3AF9B5: 0xEB3AF9B5
+          SceSblSsMgrForDriver_FDD6D5DE: 0xFDD6D5DE
           ksceKernelGetRandomNumber: 0x4F9BFBE5
+          ksceSblSsMgrGetConsoleId: 0xFC6CDD68
+          ksceSblSsMgrGetOpenPsId: 0xA5B5D269
+          ksceSblSsMgrGenerate40_0x4: 0x4DD1B2E5
+          ksceSblSsMgrGenerate40_0xA: 0xAC57F4F0
+      SceSblQafMgr:
+        nid: 0x756B7E89
+        kernel: false
+        functions:
+          sceSblQafManagerDeleteQafTokenForUser: 0xD542583F
+          sceSblQafManagerGetQafNameForUser: 0x0F7EA8C2
+          sceSblQafManagerIsAllowKernelDebugForUser: 0x11D30766
+          sceSblQafManagerSetQafTokenForUser: 0x56A16392
+          sceSblQafMgrDeleteQafToken2: 0x62E30BF4
+          sceSblQafMgrGetQafName: 0xF0CA8766
+          sceSblQafMgrGetQafToken2: 0xDFBA8569
+          sceSblQafMgrGetQafToken: 0xB6BAE81D
+          sceSblQafMgrIsAllowAllDebugMenuDisplay: 0x66843305
+          sceSblQafMgrIsAllowForceUpdate: 0x63F29BA0
+          sceSblQafMgrIsAllowLimitedDebugMenuDisplay: 0xC456212D
+          sceSblQafMgrIsAllowMinimumDebugMenuDisplay: 0xA156BBD2
+          sceSblQafMgrIsAllowNonQAPup: 0xB5621615
+          sceSblQafMgrIsAllowNpFullTest: 0x72168C6E
+          sceSblQafMgrIsAllowNpTest: 0xA9EBCBAC
+          sceSblQafMgrIsAllowRemoteSysmoduleLoad: 0xF45AA706
+          sceSblQafMgrIsAllowScreenShotAlways: 0xD22A8731
+          sceSblQafMgrSetQafToken2: 0xF4B5C8A5
+      SceSblRng:
+        nid: 0x1843F124
+        kernel: false
+        functions:
+          _sceKernelGetRandomNumber: 0xC37E818C
+      SceSblDmac5Mgr:
+        nid: 0x437366A2
+        kernel: false
+        functions:
+          sceSblDmac5EncDec: 0xD0B1F759
+          sceSblDmac5EncDecKeyGen: 0x5BF4F924
+          sceSblDmac5HashTransform: 0x09EBC6EF
+          sceSblDmac5HmacKeyGen: 0xCCE57D33
+      SceSblAimgr:
+        nid: 0xD473F968
+        kernel: false
+        functions:
+          _sceKernelGetOpenPsId: 0x6E283E2E
   SceSblACMgr:
     nid: 0x7474D6F9
     libraries:
-      SceSblACMgrForDriver:
+      SceSblACMgrForKernel:
+        nid: 0x11F9B314
         kernel: true
-        nid: 0x9AD8E213
         functions:
+          SceSblACMgrForKernel_02422F1F: 0x02422F1F
+          SceSblACMgrForKernel_04C0ED3F: 0x04C0ED3F
+          SceSblACMgrForKernel_05FDC646: 0x05FDC646
+          SceSblACMgrForKernel_06BE9F0F: 0x06BE9F0F
+          SceSblACMgrForKernel_0E489631: 0x0E489631
+          SceSblACMgrForKernel_11C9158B: 0x11C9158B
+          SceSblACMgrForKernel_165C3C7A: 0x165C3C7A
+          SceSblACMgrForKernel_1948E9DB: 0x1948E9DB
+          SceSblACMgrForKernel_1B160234: 0x1B160234
+          SceSblACMgrForKernel_2AE6CF27: 0x2AE6CF27
+          SceSblACMgrForKernel_30575458: 0x30575458
+          SceSblACMgrForKernel_31C23B66: 0x31C23B66
+          SceSblACMgrForKernel_3388F595: 0x3388F595
+          SceSblACMgrForKernel_356B9139: 0x356B9139
+          SceSblACMgrForKernel_384D20FD: 0x384D20FD
+          SceSblACMgrForKernel_3F99279F: 0x3F99279F
+          SceSblACMgrForKernel_410357AF: 0x410357AF
+          SceSblACMgrForKernel_47B67F72: 0x47B67F72
+          SceSblACMgrForKernel_48F4D5EE: 0x48F4D5EE
+          SceSblACMgrForKernel_49509A83: 0x49509A83
+          SceSblACMgrForKernel_4C4B7D6B: 0x4C4B7D6B
+          SceSblACMgrForKernel_570D6AD3: 0x570D6AD3
+          SceSblACMgrForKernel_5AC59172: 0x5AC59172
+          SceSblACMgrForKernel_5E6BA11C: 0x5E6BA11C
+          SceSblACMgrForKernel_7529E364: 0x7529E364
+          SceSblACMgrForKernel_75AAF981: 0x75AAF981
+          SceSblACMgrForKernel_7C2AF978: 0x7C2AF978
+          SceSblACMgrForKernel_7F294A09: 0x7F294A09
+          SceSblACMgrForKernel_8241AB5C: 0x8241AB5C
+          SceSblACMgrForKernel_930CD037: 0x930CD037
+          SceSblACMgrForKernel_96403142: 0x96403142
+          SceSblACMgrForKernel_966B3738: 0x966B3738
+          SceSblACMgrForKernel_98B28671: 0x98B28671
+          SceSblACMgrForKernel_9EDAF856: 0x9EDAF856
+          SceSblACMgrForKernel_A50FDA27: 0xA50FDA27
+          SceSblACMgrForKernel_A7C3001D: 0xA7C3001D
+          SceSblACMgrForKernel_AF6F208E: 0xAF6F208E
+          SceSblACMgrForKernel_BBA13D9C: 0xBBA13D9C
+          SceSblACMgrForKernel_C90A9216: 0xC90A9216
+          SceSblACMgrForKernel_CCDBB74D: 0xCCDBB74D
+          SceSblACMgrForKernel_D442962E: 0xD442962E
+          SceSblACMgrForKernel_DC49E160: 0xDC49E160
+          SceSblACMgrForKernel_E273ED8C: 0xE273ED8C
+          SceSblACMgrForKernel_F5AD56E4: 0xF5AD56E4
+          SceSblACMgrForKernel_F9FEF5F0: 0xF9FEF5F0
+          SceSblACMgrForKernel_FB2AC5B4: 0xFB2AC5B4
+          SceSblACMgrForKernel_FBA1A256: 0xFBA1A256
+      SceSblACMgrForDriver:
+        nid: 0x9AD8E213
+        kernel: true
+        functions:
+          SceSblACMgrForDriver_0139FC20: 0x0139FC20
+          SceSblACMgrForDriver_0606B87E: 0x0606B87E
+          SceSblACMgrForDriver_062CAEB2: 0x062CAEB2
+          SceSblACMgrForDriver_091F7247: 0x091F7247
+          SceSblACMgrForDriver_0924896F: 0x0924896F
+          SceSblACMgrForDriver_0948F41C: 0x0948F41C
+          SceSblACMgrForDriver_0B6E6CD7: 0x0B6E6CD7
+          SceSblACMgrForDriver_2A29453C: 0x2A29453C
+          SceSblACMgrForDriver_2E992B02: 0x2E992B02
+          SceSblACMgrForDriver_3B356B98: 0x3B356B98
+          SceSblACMgrForDriver_426A4E8C: 0x426A4E8C
+          SceSblACMgrForDriver_4322F188: 0x4322F188
+          SceSblACMgrForDriver_456DA7AC: 0x456DA7AC
+          SceSblACMgrForDriver_48CFCEA2: 0x48CFCEA2
+          SceSblACMgrForDriver_4CBD6156: 0x4CBD6156
+          SceSblACMgrForDriver_4DB7F512: 0x4DB7F512
+          SceSblACMgrForDriver_5C4BC352: 0x5C4BC352
+          SceSblACMgrForDriver_5F9AF49C: 0x5F9AF49C
+          SceSblACMgrForDriver_6210D745: 0x6210D745
+          SceSblACMgrForDriver_6D8A88B7: 0x6D8A88B7
+          SceSblACMgrForDriver_84604EED: 0x84604EED
+          SceSblACMgrForDriver_8A54DF3A: 0x8A54DF3A
+          SceSblACMgrForDriver_962CD237: 0x962CD237
+          SceSblACMgrForDriver_96AF69BD: 0x96AF69BD
+          SceSblACMgrForDriver_991FDC15: 0x991FDC15
+          SceSblACMgrForDriver_A27E47A7: 0xA27E47A7
+          SceSblACMgrForDriver_A67E8E5B: 0xA67E8E5B
+          SceSblACMgrForDriver_A92CD636: 0xA92CD636
+          SceSblACMgrForDriver_AD717E7A: 0xAD717E7A
+          SceSblACMgrForDriver_AE1AF154: 0xAE1AF154
+          SceSblACMgrForDriver_B12CEAA8: 0xB12CEAA8
+          SceSblACMgrForDriver_B836CF13: 0xB836CF13
+          SceSblACMgrForDriver_BE5667C5: 0xBE5667C5
+          SceSblACMgrForDriver_C98D82EE: 0xC98D82EE
+          SceSblACMgrForDriver_D0E11C89: 0xD0E11C89
+          SceSblACMgrForDriver_D7AD8471: 0xD7AD8471
+          SceSblACMgrForDriver_E79C7A8D: 0xE79C7A8D
+          SceSblACMgrForDriver_F5AE24AC: 0xF5AE24AC
+          SceSblACMgrForDriver_FF7125DE: 0xFF7125DE
           ksceSblACMgrHasCapability: 0xC2D1F2FC
-          ksceSblACMgrIsShell: 0x8612B243
+          ksceSblACMgrIsDevelopmentMode: 0xE87D1777
           ksceSblACMgrIsGameProgram: 0x1298C647
           ksceSblACMgrIsNonGameProgram: 0x6C5AB07F
-          ksceSblACMgrIsDevelopmentMode: 0xE87D1777
           ksceSblACMgrIsPspEmu: 0xFD00C72A
+          ksceSblACMgrIsShell: 0x8612B243
+      SceSblACMgr:
+        nid: 0xF069F219
+        kernel: false
+        functions:
+          _sceSblACMgrIsGameProgram: 0x3C17A7F7
   SceSblUpdateMgr:
      nid: 0x528F6BF5
      libraries:
@@ -5680,19 +7652,35 @@ modules:
     nid: 0x770E22E0
     libraries:
       ScePromoterUtil:
-        kernel: false
         nid: 0x31F237B6
+        kernel: false
         functions:
-          scePromoterUtilityInit: 0x93451536
-          scePromoterUtilityExit: 0xC95D24A6
+          ScePromoterUtil_1F5EA997: 0x1F5EA997
+          ScePromoterUtil_30A36AAF: 0x30A36AAF
+          ScePromoterUtil_59A6CDAE: 0x59A6CDAE
+          ScePromoterUtil_59DA665E: 0x59DA665E
+          ScePromoterUtil_5FF5CACF: 0x5FF5CACF
+          ScePromoterUtil_6A547384: 0x6A547384
+          ScePromoterUtil_739BC292: 0x739BC292
+          ScePromoterUtil_82E69783: 0x82E69783
+          ScePromoterUtil_8494C742: 0x8494C742
+          ScePromoterUtil_999AD6CE: 0x999AD6CE
+          ScePromoterUtil_B27DA268: 0xB27DA268
+          ScePromoterUtil_D4E87DCB: 0xD4E87DCB
+          ScePromoterUtil_FDCCBE33: 0xFDCCBE33
+          ScePromoterUtil_heartbeat: 0x395739DF
+          scePromoterUtilityCheckExist: 0x0D76CD38
+          scePromoterUtilityCheckExist: 0xBA9871E5
           scePromoterUtilityDeletePkg: 0x7D46752F
-          scePromoterUtilityUpdateLiveArea: 0x17D73ECA
+          scePromoterUtilityExit: 0xC95D24A6
+          scePromoterUtilityGetResult: 0x49B473F0
+          scePromoterUtilityGetState: 0xABEC74D2
+          scePromoterUtilityInit: 0x93451536
           scePromoterUtilityPromoteBackup: 0x4B37808F
           scePromoterUtilityPromotePkg: 0x716C81F4
           scePromoterUtilityPromotePkgWithRif: 0x86641BC6
-          scePromoterUtilityGetState: 0xABEC74D2
-          scePromoterUtilityGetResult: 0x49B473F0
-          scePromoterUtilityCheckExist: 0xBA9871E5
+          scePromoterUtilityRemoveSavedata: 0xCB0A59B0
+          scePromoterUtilityUpdateLiveArea: 0x17D73ECA
   SceMtpIfDriver:
     nid: 0xEA885947
     libraries:
@@ -5809,14 +7797,25 @@ modules:
     nid: 0x1773372D
     libraries:
       SceSblAuthMgrForKernel:
-        kernel: true
         nid: 0x7ABF5135
-        functions:
-          ksceSblAuthMgrClearDmac5Key: 0xF2BB723E
-          ksceSblAuthMgrSetDmac5Key: 0x122ACDEA
-      SceSblAuthMgrForDriver:
         kernel: true
+        functions:
+          SceSblAuthMgrForKernel_026ACBAD: 0x026ACBAD
+          SceSblAuthMgrForKernel_2A83A012: 0x2A83A012
+          SceSblAuthMgrForKernel_89CCDA2C: 0x89CCDA2C
+          SceSblAuthMgrForKernel_A9CD2A09: 0xA9CD2A09
+          SceSblAuthMgrForKernel_ABAB8466: 0xABAB8466
+          SceSblAuthMgrForKernel_BC422443: 0xBC422443
+          SceSblAuthMgrForKernel_F3411881: 0xF3411881
+          sceSblAuthMgrClearDmac5Key: 0xF2BB723E
+          sceSblAuthMgrSetDmac5Key: 0x122ACDEA
+      SceSblAuthMgrForDriver:
         nid: 0x4EB2B1BB
+        kernel: true
+        functions:
+          SceSblAuthMgrForDriver_24C4CE64: 0x24C4CE64
+          sceSblAuthMgrDecBindData: 0x41DAEA12
+          sceSblAuthMgrGetEKc: 0x868B9E9A
   SceMotionDev:
     nid: 0x466A97BD
     libraries:
@@ -5967,3 +7966,596 @@ modules:
           sceLsdbGetParentalLevel: 0x226B12F7
           sceLsdbGetSelfPath: 0xD6B57313
           sceLsdbGetStyle: 0xDEC358E4
+  SceAvcodec:
+    nid: 0xDD0E433A
+    libraries:
+      SceAvcodecForDriver:
+        nid: 0x66845469
+        kernel: true
+        functions:
+          SceAvcodecForDriver_01387A93: 0x01387A93
+          SceAvcodecForDriver_04080710: 0x04080710
+          SceAvcodecForDriver_04F734CC: 0x04F734CC
+          SceAvcodecForDriver_0CC84413: 0x0CC84413
+          SceAvcodecForDriver_12DAE04A: 0x12DAE04A
+          SceAvcodecForDriver_13C530E4: 0x13C530E4
+          SceAvcodecForDriver_16B501C9: 0x16B501C9
+          SceAvcodecForDriver_1A584DB7: 0x1A584DB7
+          SceAvcodecForDriver_1BE9F5A4: 0x1BE9F5A4
+          SceAvcodecForDriver_20892154: 0x20892154
+          SceAvcodecForDriver_20C83C00: 0x20C83C00
+          SceAvcodecForDriver_229AB2CF: 0x229AB2CF
+          SceAvcodecForDriver_22D7B653: 0x22D7B653
+          SceAvcodecForDriver_2641888C: 0x2641888C
+          SceAvcodecForDriver_27211864: 0x27211864
+          SceAvcodecForDriver_2895CB6D: 0x2895CB6D
+          SceAvcodecForDriver_2A0AF392: 0x2A0AF392
+          SceAvcodecForDriver_2C7A9841: 0x2C7A9841
+          SceAvcodecForDriver_2C8271BA: 0x2C8271BA
+          SceAvcodecForDriver_301CCA25: 0x301CCA25
+          SceAvcodecForDriver_32DEE3C5: 0x32DEE3C5
+          SceAvcodecForDriver_361238E2: 0x361238E2
+          SceAvcodecForDriver_3CB7661A: 0x3CB7661A
+          SceAvcodecForDriver_3F146942: 0x3F146942
+          SceAvcodecForDriver_427914D5: 0x427914D5
+          SceAvcodecForDriver_43985AA8: 0x43985AA8
+          SceAvcodecForDriver_43A9CD35: 0x43A9CD35
+          SceAvcodecForDriver_468949D7: 0x468949D7
+          SceAvcodecForDriver_47D8E150: 0x47D8E150
+          SceAvcodecForDriver_48247A20: 0x48247A20
+          SceAvcodecForDriver_48DECA56: 0x48DECA56
+          SceAvcodecForDriver_4AE6B437: 0x4AE6B437
+          SceAvcodecForDriver_4DB66E3A: 0x4DB66E3A
+          SceAvcodecForDriver_4DD3826D: 0x4DD3826D
+          SceAvcodecForDriver_4F11F915: 0x4F11F915
+          SceAvcodecForDriver_536C8296: 0x536C8296
+          SceAvcodecForDriver_58835DCB: 0x58835DCB
+          SceAvcodecForDriver_58F1E353: 0x58F1E353
+          SceAvcodecForDriver_5C3434FB: 0x5C3434FB
+          SceAvcodecForDriver_663B3195: 0x663B3195
+          SceAvcodecForDriver_6DC39EDC: 0x6DC39EDC
+          SceAvcodecForDriver_6E250A5F: 0x6E250A5F
+          SceAvcodecForDriver_6F1CF77F: 0x6F1CF77F
+          SceAvcodecForDriver_71C37694: 0x71C37694
+          SceAvcodecForDriver_73401748: 0x73401748
+          SceAvcodecForDriver_7385FB51: 0x7385FB51
+          SceAvcodecForDriver_77529FD2: 0x77529FD2
+          SceAvcodecForDriver_78BA8E98: 0x78BA8E98
+          SceAvcodecForDriver_7DC13C29: 0x7DC13C29
+          SceAvcodecForDriver_7E8CC4E5: 0x7E8CC4E5
+          SceAvcodecForDriver_80F63723: 0x80F63723
+          SceAvcodecForDriver_823E187E: 0x823E187E
+          SceAvcodecForDriver_864FC454: 0x864FC454
+          SceAvcodecForDriver_866B49BF: 0x866B49BF
+          SceAvcodecForDriver_86AD5A4F: 0x86AD5A4F
+          SceAvcodecForDriver_86B1ACC5: 0x86B1ACC5
+          SceAvcodecForDriver_90F394E6: 0x90F394E6
+          SceAvcodecForDriver_91B27CF3: 0x91B27CF3
+          SceAvcodecForDriver_91E94B76: 0x91E94B76
+          SceAvcodecForDriver_95E8AFCA: 0x95E8AFCA
+          SceAvcodecForDriver_A0E63278: 0xA0E63278
+          SceAvcodecForDriver_A2085B6B: 0xA2085B6B
+          SceAvcodecForDriver_A6CAE217: 0xA6CAE217
+          SceAvcodecForDriver_B2A51EB0: 0xB2A51EB0
+          SceAvcodecForDriver_B6882013: 0xB6882013
+          SceAvcodecForDriver_B77B5BFC: 0xB77B5BFC
+          SceAvcodecForDriver_B8A9632A: 0xB8A9632A
+          SceAvcodecForDriver_BC244D21: 0xBC244D21
+          SceAvcodecForDriver_BC55D10F: 0xBC55D10F
+          SceAvcodecForDriver_BCB769EB: 0xBCB769EB
+          SceAvcodecForDriver_BF3835E2: 0xBF3835E2
+          SceAvcodecForDriver_C114C499: 0xC114C499
+          SceAvcodecForDriver_C363B31A: 0xC363B31A
+          SceAvcodecForDriver_C518A109: 0xC518A109
+          SceAvcodecForDriver_C5C10C8B: 0xC5C10C8B
+          SceAvcodecForDriver_C5E720E2: 0xC5E720E2
+          SceAvcodecForDriver_C8366BB8: 0xC8366BB8
+          SceAvcodecForDriver_C84AFFC4: 0xC84AFFC4
+          SceAvcodecForDriver_C93DA0C7: 0xC93DA0C7
+          SceAvcodecForDriver_C99242F5: 0xC99242F5
+          SceAvcodecForDriver_C9EF7057: 0xC9EF7057
+          SceAvcodecForDriver_CD7FE8D0: 0xCD7FE8D0
+          SceAvcodecForDriver_D0647B74: 0xD0647B74
+          SceAvcodecForDriver_D2ACCE22: 0xD2ACCE22
+          SceAvcodecForDriver_D46B8463: 0xD46B8463
+          SceAvcodecForDriver_D5A34236: 0xD5A34236
+          SceAvcodecForDriver_D7CD7F82: 0xD7CD7F82
+          SceAvcodecForDriver_D9FCDF3E: 0xD9FCDF3E
+          SceAvcodecForDriver_DE515BFF: 0xDE515BFF
+          SceAvcodecForDriver_DFC0AAC6: 0xDFC0AAC6
+          SceAvcodecForDriver_E0232BFE: 0xE0232BFE
+          SceAvcodecForDriver_E355CAAE: 0xE355CAAE
+          SceAvcodecForDriver_E4F668C5: 0xE4F668C5
+          SceAvcodecForDriver_E782E735: 0xE782E735
+          SceAvcodecForDriver_E7E14DE4: 0xE7E14DE4
+          SceAvcodecForDriver_EA07A3B7: 0xEA07A3B7
+          SceAvcodecForDriver_EAAE7737: 0xEAAE7737
+          SceAvcodecForDriver_EAEB16D5: 0xEAEB16D5
+          SceAvcodecForDriver_F305E3B3: 0xF305E3B3
+          SceAvcodecForDriver_F67F93DC: 0xF67F93DC
+          SceAvcodecForDriver_F714DB9A: 0xF714DB9A
+          SceAvcodecForDriver_F8BCBE20: 0xF8BCBE20
+          SceAvcodecForDriver_F9E271DE: 0xF9E271DE
+          SceAvcodecForDriver_FACCD284: 0xFACCD284
+          SceAvcodecForDriver_FD805BF1: 0xFD805BF1
+      SceAvcodec:
+        nid: 0xA166C96E
+        kernel: false
+        functions:
+          _sceAudiodecClearContext: 0x914CC7A7
+          _sceAudiodecCreateDecoder: 0x38FE5C91
+          _sceAudiodecCreateDecoderExternal: 0x82710FAE
+          _sceAudiodecCreateDecoderResident: 0x56CE556D
+          _sceAudiodecDecode: 0x7F5DD597
+          _sceAudiodecDecodeNFrames: 0x215CFCC1
+          _sceAudiodecDecodeNStreams: 0x5168491A
+          _sceAudiodecDeleteDecoder: 0x5C548173
+          _sceAudiodecDeleteDecoderExternal: 0x7AA7D478
+          _sceAudiodecDeleteDecoderResident: 0xE147D80C
+          _sceAudiodecGetContextSize: 0x74A9FA86
+          _sceAudiodecGetInternalError: 0x0CD84136
+          _sceAudiodecInitLibrary: 0x780A3ED6
+          _sceAudiodecPartlyDecode: 0xCE1AB19A
+          _sceAudiodecTermLibrary: 0x4A9CDA20
+          _sceAudioencClearContext: 0xAC47088A
+          _sceAudioencCreateEncoder: 0x9E4796C4
+          _sceAudioencCreateEncoderExternal: 0x835F98F8
+          _sceAudioencCreateEncoderResident: 0x04ED53EC
+          _sceAudioencDeleteEncoder: 0x83873882
+          _sceAudioencDeleteEncoderExternal: 0x34E1BA94
+          _sceAudioencDeleteEncoderResident: 0xCFC633F6
+          _sceAudioencEncode: 0xBFCF8F3F
+          _sceAudioencEncodeNFrames: 0x9CCB2033
+          _sceAudioencGetContextSize: 0x14C85301
+          _sceAudioencGetInternalError: 0x8874B8A7
+          _sceAudioencGetOptInfo: 0x09E763CD
+          _sceAudioencInitLibrary: 0x373AB413
+          _sceAudioencTermLibrary: 0x263BA366
+          _sceAvcdecCreateDecoder: 0x95EF1A0C
+          _sceAvcdecCreateDecoderInternal: 0xED853085
+          _sceAvcdecCreateDecoderNongameapp: 0x4099935D
+          _sceAvcdecCsc: 0xD301B276
+          _sceAvcdecCscInternal: 0x4859779A
+          _sceAvcdecDecode: 0xCDB74E5D
+          _sceAvcdecDecodeAuInternal: 0x1FA806E5
+          _sceAvcdecDecodeAuNalAuInternal: 0xF757BE5E
+          _sceAvcdecDecodeAuNalAuNongameapp: 0x9DEBBA02
+          _sceAvcdecDecodeAuNongameapp: 0x5F1B6299
+          _sceAvcdecDecodeAvailableSize: 0x9D576E7E
+          _sceAvcdecDecodeFlush: 0x80C78430
+          _sceAvcdecDecodeGetPictureInternal: 0xFEE91426
+          _sceAvcdecDecodeGetPictureNongameapp: 0x4A061F8C
+          _sceAvcdecDecodeGetPictureWithWorkPictureInternal: 0xCF0F24FE
+          _sceAvcdecDecodeNalAu: 0x5D9FD6DB
+          _sceAvcdecDecodeNalAuWithWorkPicture: 0xB6AD7638
+          _sceAvcdecDecodeSetTrickModeNongameapp: 0x32057062
+          _sceAvcdecDecodeSetUserDataSei1FieldMemSizeNongameapp: 0x1DBA40CB
+          _sceAvcdecDecodeStop: 0xD390D6E9
+          _sceAvcdecDecodeStopWithWorkPicture: 0x7C44A3CE
+          _sceAvcdecDecodeWithWorkPicture: 0xB20EBBBF
+          _sceAvcdecDeleteDecoder: 0x1FAD5C13
+          _sceAvcdecGetSeiPictureTimingInternal: 0x1C0F4C2F
+          _sceAvcdecGetSeiUserDataNongameapp: 0xAC1A4B84
+          _sceAvcdecQueryDecoderMemSize: 0x0B47EBC1
+          _sceAvcdecQueryDecoderMemSizeInternal: 0x008CFFE6
+          _sceAvcdecQueryDecoderMemSizeNongameapp: 0x6C290F95
+          _sceAvcdecRegisterCallbackInternal: 0x6B216E40
+          _sceAvcdecRegisterCallbackNongameapp: 0x18144D32
+          _sceAvcdecSetDecodeMode: 0x6931F869
+          _sceAvcdecSetDecodeModeInternal: 0x7D2E4694
+          _sceAvcdecSetInterlacedStreamMode: 0x439B6468
+          _sceAvcdecSetLowDelayModeNongameapp: 0x6B5D2664
+          _sceAvcdecSetRecoveryPointSEIMode: 0xA8A0DBA6
+          _sceAvcdecUnregisterCallbackInternal: 0x6327330C
+          _sceAvcdecUnregisterCallbackNongameapp: 0x03040F4A
+          _sceAvcdecUnregisterCallbackWithCbidInternal: 0x2C86BF22
+          _sceAvcdecUnregisterCallbackWithCbidNongameapp: 0xC152BBF0
+          _sceAvcencCreateEncoder: 0x7DBE3302
+          _sceAvcencCreateEncoderBasic: 0x83DE207F
+          _sceAvcencCreateEncoderInternal: 0x81A63707
+          _sceAvcencCsc: 0xC23957F9
+          _sceAvcencDeleteEncoder: 0x3313DAC9
+          _sceAvcencEncode: 0xC03BA7BA
+          _sceAvcencEncodeFlush: 0x8F3EF1D5
+          _sceAvcencEncodeStop: 0x7360B1E6
+          _sceAvcencGetNalUnit: 0x58B0CC46
+          _sceAvcencQueryEncoderMemSize: 0xDEA87D04
+          _sceAvcencQueryEncoderMemSizeBasic: 0x5A604BA1
+          _sceAvcencQueryEncoderMemSizeInternal: 0x43D4E94B
+          _sceAvcencSetAvailablePreset: 0x34E914A7
+          _sceAvcencSetEncoderParameter: 0x9ED5188E
+          _sceJpegCreateSplitDecoder: 0x20E2D9D5
+          _sceJpegCsc: 0x72811C19
+          _sceJpegDecodeMJpeg: 0xCB7F8A69
+          _sceJpegDecodeMJpegYCbCr: 0x925F0A72
+          _sceJpegDeleteSplitDecoder: 0x45F71883
+          _sceJpegEncoderCsc: 0xE035FA28
+          _sceJpegEncoderEncode: 0x77F1F2A2
+          _sceJpegEncoderEnd: 0xACC6B9F1
+          _sceJpegEncoderGetContextSize: 0x2A9B196E
+          _sceJpegEncoderInit: 0xA12E3D80
+          _sceJpegEncoderInitWithParam: 0x22124B1B
+          _sceJpegEncoderSetCompressionRatio: 0x271734D5
+          _sceJpegEncoderSetHeaderMode: 0x3472D7E8
+          _sceJpegEncoderSetOutputAddr: 0x7970C81B
+          _sceJpegEncoderSetValidRegion: 0x24239139
+          _sceJpegFinishMJpeg: 0x64419DEA
+          _sceJpegGetOutputInfo: 0x6F6DAF2B
+          _sceJpegInitMJpeg: 0x12740EA3
+          _sceJpegInitMJpegWithParam: 0x7BA8FDDE
+          _sceJpegMJpegCsc: 0x7E2E515F
+          _sceJpegSplitDecodeMJpeg: 0xA0CB5CF8
+          _sceM4vdecCreateDecoder: 0xBBFF3491
+          _sceM4vdecCreateDecoderInternal: 0xBB1687CD
+          _sceM4vdecCsc: 0x7D227358
+          _sceM4vdecDecode: 0x36861BB9
+          _sceM4vdecDecodeAvailableSize: 0x58CC2B59
+          _sceM4vdecDecodeFlush: 0x1D88FBEC
+          _sceM4vdecDecodeStop: 0xCF1844E7
+          _sceM4vdecDecodeStopWithWorkPicture: 0x50AA1253
+          _sceM4vdecDecodeWithWorkPicture: 0x15F9533D
+          _sceM4vdecDeleteDecoder: 0x355B448E
+          _sceM4vdecQueryDecoderMemSize: 0x704A70E8
+          _sceM4vdecQueryDecoderMemSizeInternal: 0xD9F1331D
+          _sceVideodecInitLibrary: 0xAE511B32
+          _sceVideodecInitLibraryInternal: 0x2CFE9AF0
+          _sceVideodecInitLibraryNongameapp: 0x3070B3ED
+          _sceVideodecInitLibraryWithUnmapMem: 0x3A8F0E2B
+          _sceVideodecInitLibraryWithUnmapMemInternal: 0xE4003992
+          _sceVideodecInitLibraryWithUnmapMemNongameapp: 0xE816BAE7
+          _sceVideodecQueryInstanceNongameapp: 0x309BBB68
+          _sceVideodecQueryMemSize: 0xAF9BDDA7
+          _sceVideodecQueryMemSizeInternal: 0x654A5F92
+          _sceVideodecQueryMemSizeNongameapp: 0x8B52F56A
+          _sceVideodecSetConfig: 0x89324E23
+          _sceVideodecSetConfigInternal: 0xD43EEFD8
+          _sceVideodecTermLibrary: 0x07B26B00
+          _sceVideoencInitLibrary: 0xEEAC1039
+          _sceVideoencInitLibraryInternal: 0x1CF4523E
+          _sceVideoencInitLibraryWithUnmapMem: 0x67127921
+          _sceVideoencInitLibraryWithUnmapMemInternal: 0x19ACF593
+          _sceVideoencQueryMemSize: 0xC4EBFDF5
+          _sceVideoencQueryMemSizeInternal: 0xEE5B74B7
+          _sceVideoencTermLibrary: 0xFF652EAE
+  SceOled:
+    nid: 0xE49D6C00
+    libraries:
+      SceOledForDriver:
+        nid: 0x60C7478A
+        kernel: true
+        functions:
+          SceOledForDriver_26F9EEA8: 0x26F9EEA8
+          SceOledForDriver_2F0C4B67: 0x2F0C4B67
+          SceOledForDriver_3C990F53: 0x3C990F53
+          SceOledForDriver_3E6AE8A2: 0x3E6AE8A2
+          SceOledForDriver_4891257F: 0x4891257F
+          SceOledForDriver_4C7836C7: 0x4C7836C7
+          SceOledForDriver_4F8A1D4A: 0x4F8A1D4A
+          SceOledForDriver_5AF31932: 0x5AF31932
+          SceOledForDriver_6B1E0B52: 0x6B1E0B52
+          SceOledForDriver_9F4ABDDC: 0x9F4ABDDC
+          SceOledForDriver_AD6C7FB8: 0xAD6C7FB8
+          SceOledForDriver_BC84602E: 0xBC84602E
+          SceOledForDriver_BF5C5624: 0xBF5C5624
+          SceOledForDriver_C9D5987C: 0xC9D5987C
+          SceOledForDriver_DABBD9D3: 0xDABBD9D3
+          SceOledForDriver_DDB1412B: 0xDDB1412B
+          SceOledForDriver_E30604CC: 0xE30604CC
+          SceOledForDriver_ED2D6F19: 0xED2D6F19
+          ksceOledGetBrightness: 0x43EF811A
+          ksceOledSetBrightness: 0xF9624C47
+          ksceOledWaitReady: 0x0CC6BCB4
+  SceSblGcAuthMgr:
+    nid: 0xDB1A9016
+    libraries:
+      SceSblGcAuthMgrDrmBBForDriver:
+        nid: 0x1926B182
+        kernel: true
+        functions:
+          SceSblGcAuthMgrDrmBBForDriver_050DC6DF: 0x050DC6DF
+          SceSblGcAuthMgrDrmBBForDriver_22FD5D23: 0x22FD5D23
+          SceSblGcAuthMgrDrmBBForDriver_30A0B441: 0x30A0B441
+          SceSblGcAuthMgrDrmBBForDriver_3C25F9FA: 0x3C25F9FA
+          SceSblGcAuthMgrDrmBBForDriver_48D7784E: 0x48D7784E
+          SceSblGcAuthMgrDrmBBForDriver_4B506BE7: 0x4B506BE7
+          SceSblGcAuthMgrDrmBBForDriver_4C5DE1AA: 0x4C5DE1AA
+          SceSblGcAuthMgrDrmBBForDriver_4CEA150C: 0x4CEA150C
+          SceSblGcAuthMgrDrmBBForDriver_4FE89ADB: 0x4FE89ADB
+          SceSblGcAuthMgrDrmBBForDriver_500F5157: 0x500F5157
+          SceSblGcAuthMgrDrmBBForDriver_535B87BC: 0x535B87BC
+          SceSblGcAuthMgrDrmBBForDriver_6E6D2B89: 0x6E6D2B89
+          SceSblGcAuthMgrDrmBBForDriver_6EF3C9DB: 0x6EF3C9DB
+          SceSblGcAuthMgrDrmBBForDriver_7F98E4E2: 0x7F98E4E2
+          SceSblGcAuthMgrDrmBBForDriver_812B2B5C: 0x812B2B5C
+          SceSblGcAuthMgrDrmBBForDriver_B13577E2: 0xB13577E2
+          SceSblGcAuthMgrDrmBBForDriver_BB451E83: 0xBB451E83
+          SceSblGcAuthMgrDrmBBForDriver_BB70DDC0: 0xBB70DDC0
+          SceSblGcAuthMgrDrmBBForDriver_C0F37F18: 0xC0F37F18
+          SceSblGcAuthMgrDrmBBForDriver_E950BE32: 0xE950BE32
+      SceSblGcAuthMgrGcAuthForDriver:
+        nid: 0xC6627F5E
+        kernel: true
+        functions:
+          cmd56_handshake: 0x68781760
+      SceSblGcAuthMgrMlnpsnlForDriver:
+        nid: 0x29ED0109
+        kernel: true
+        functions:
+          SceSblGcAuthMgrMlnpsnlForDriver_296ABD68: 0x296ABD68
+          SceSblGcAuthMgrMlnpsnlForDriver_DABC01F5: 0xDABC01F5
+      SceSblGcAuthMgrPkgForDriver:
+        nid: 0x082FBA7D
+        kernel: true
+        functions:
+          SceSblGcAuthMgrPkgForDriver_E459A9A8: 0xE459A9A8
+      SceSblGcAuthMgrPsmactForDriver:
+        nid: 0x1C53F37D
+        kernel: true
+        functions:
+          get_act_data: 0x39222A58
+      SceSblGcAuthMgrSclkForDriver:
+        nid: 0xF24F760D
+        kernel: true
+        functions:
+          SceSblGcAuthMgrSclkForDriver_11D5570B: 0x11D5570B
+          SceSblGcAuthMgrSclkForDriver_F723A9BA: 0xF723A9BA
+      SceSblGcAuthMgrMsSaveBBForDriver:
+        nid: 0x5032E8D4
+        kernel: true
+        functions:
+          SceSblGcAuthMgrMsSaveBBForDriver_3C185A67: 0x3C185A67
+          SceSblGcAuthMgrMsSaveBBForDriver_4A249828: 0x4A249828
+          SceSblGcAuthMgrMsSaveBBForDriver_79A9BE44: 0x79A9BE44
+          SceSblGcAuthMgrMsSaveBBForDriver_805C860B: 0x805C860B
+          SceSblGcAuthMgrMsSaveBBForDriver_8E6626A0: 0x8E6626A0
+          SceSblGcAuthMgrMsSaveBBForDriver_F66D5F76: 0xF66D5F76
+      SceSblGcAuthMgr:
+        nid: 0x7B13BCF7
+        kernel: false
+        functions:
+          _sceSblGcAuthMgrAdhocBB160Auth1: 0x5E56F845
+          _sceSblGcAuthMgrAdhocBB160Auth2: 0xD2218A6E
+          _sceSblGcAuthMgrAdhocBB160Auth3: 0xD1777A14
+          _sceSblGcAuthMgrAdhocBB160Auth4: 0x7F33DE86
+          _sceSblGcAuthMgrAdhocBB160Auth5: 0xD84C2E0C
+          _sceSblGcAuthMgrAdhocBB160BroadCastDecrypt: 0x2193A7CB
+          _sceSblGcAuthMgrAdhocBB160BroadCastEncrypt: 0x6125C3D9
+          _sceSblGcAuthMgrAdhocBB160GetKeys: 0x09E1E270
+          _sceSblGcAuthMgrAdhocBB160Init: 0xE4AA1BB2
+          _sceSblGcAuthMgrAdhocBB160Shutdown: 0x076ADAB3
+          _sceSblGcAuthMgrAdhocBB160UniCastDecrypt: 0xD79A1B31
+          _sceSblGcAuthMgrAdhocBB160UniCastEncrypt: 0x08C4EE5F
+          _sceSblGcAuthMgrAdhocBB224Auth1: 0x307FD67C
+          _sceSblGcAuthMgrAdhocBB224Auth2: 0x788C0517
+          _sceSblGcAuthMgrAdhocBB224Auth3: 0xD3F95259
+          _sceSblGcAuthMgrAdhocBB224Auth4: 0x5CCC216C
+          _sceSblGcAuthMgrAdhocBB224Auth5: 0x459F5503
+          _sceSblGcAuthMgrAdhocBB224GetKeys: 0xC236FB28
+          _sceSblGcAuthMgrAdhocBB224Init: 0x5AB126A7
+          _sceSblGcAuthMgrAdhocBB224Shutdown: 0x8ECEACF9
+          _sceSblGcAuthMgrGetMediaIdType01: 0x0AC64154
+          _sceSblGcAuthMgrMsSaveBBCipherFinal: 0x18EAAD73
+          _sceSblGcAuthMgrMsSaveBBCipherInit: 0x064BA38A
+          _sceSblGcAuthMgrMsSaveBBCipherUpdate: 0xF6FECCE0
+          _sceSblGcAuthMgrMsSaveBBMacFinal: 0xFDDDD1D4
+          _sceSblGcAuthMgrMsSaveBBMacInit: 0x3A92780D
+          _sceSblGcAuthMgrMsSaveBBMacUpdate: 0x716C0C3B
+          _sceSblGcAuthMgrPcactActivation: 0x032E7CEA
+          _sceSblGcAuthMgrPcactGetChallenge: 0x98153286
+          _sceSblGcAuthMgrPkgVry: 0x3E168BC4
+          _sceSblGcAuthMgrPsmactCreateC1: 0x3BD8B007
+          _sceSblGcAuthMgrPsmactVerifyR1: 0x2B604356
+          _sceSblGcAuthMgrSclkGetData1: 0x8A3AF1E8
+          _sceSblGcAuthMgrSclkSetData2: 0x837D0FB6
+  SceSblPostSsMgr:
+    nid: 0xB6C941F2
+    libraries:
+      SceSblPostSsMgrForDriver:
+        functions:
+          SceSblPostSsMgrForDriver_0298382B: 0x0298382B
+          SceSblPostSsMgrForDriver_07BAD056: 0x07BAD056
+          SceSblPostSsMgrForDriver_08525D8D: 0x08525D8D
+          SceSblPostSsMgrForDriver_128FB35A: 0x128FB35A
+          SceSblPostSsMgrForDriver_15F37282: 0x15F37282
+          SceSblPostSsMgrForDriver_1923D80D: 0x1923D80D
+          SceSblPostSsMgrForDriver_19B63D65: 0x19B63D65
+          SceSblPostSsMgrForDriver_1FF699DD: 0x1FF699DD
+          SceSblPostSsMgrForDriver_22599675: 0x22599675
+          SceSblPostSsMgrForDriver_2646DE64: 0x2646DE64
+          SceSblPostSsMgrForDriver_2BF04B8E: 0x2BF04B8E
+          SceSblPostSsMgrForDriver_2C463AF1: 0x2C463AF1
+          SceSblPostSsMgrForDriver_33275F95: 0x33275F95
+          SceSblPostSsMgrForDriver_3DB69911: 0x3DB69911
+          SceSblPostSsMgrForDriver_3F9BDEDF: 0x3F9BDEDF
+          SceSblPostSsMgrForDriver_4100B9E9: 0x4100B9E9
+          SceSblPostSsMgrForDriver_42474C8B: 0x42474C8B
+          SceSblPostSsMgrForDriver_4663C195: 0x4663C195
+          SceSblPostSsMgrForDriver_4FF2682F: 0x4FF2682F
+          SceSblPostSsMgrForDriver_686B9461: 0x686B9461
+          SceSblPostSsMgrForDriver_739C981E: 0x739C981E
+          SceSblPostSsMgrForDriver_7ACCAA50: 0x7ACCAA50
+          SceSblPostSsMgrForDriver_942010A0: 0x942010A0
+          SceSblPostSsMgrForDriver_9B49C249: 0x9B49C249
+          SceSblPostSsMgrForDriver_9D1D8EE5: 0x9D1D8EE5
+          SceSblPostSsMgrForDriver_9D2E2D39: 0x9D2E2D39
+          SceSblPostSsMgrForDriver_9FD835B0: 0x9FD835B0
+          SceSblPostSsMgrForDriver_ABDD68CD: 0xABDD68CD
+          SceSblPostSsMgrForDriver_AD3B0078: 0xAD3B0078
+          SceSblPostSsMgrForDriver_ADF92824: 0xADF92824
+          SceSblPostSsMgrForDriver_BDF18922: 0xBDF18922
+          SceSblPostSsMgrForDriver_C2E58CE3: 0xC2E58CE3
+          SceSblPostSsMgrForDriver_C6684F7E: 0xC6684F7E
+          SceSblPostSsMgrForDriver_C93C0A0D: 0xC93C0A0D
+          SceSblPostSsMgrForDriver_C977601E: 0xC977601E
+          SceSblPostSsMgrForDriver_CB5436BD: 0xCB5436BD
+          SceSblPostSsMgrForDriver_CC5AA5A5: 0xCC5AA5A5
+          SceSblPostSsMgrForDriver_D8A2D465: 0xD8A2D465
+          SceSblPostSsMgrForDriver_DC68EE5C: 0xDC68EE5C
+          SceSblPostSsMgrForDriver_DDA6FA6D: 0xDDA6FA6D
+          SceSblPostSsMgrForDriver_DE5150FE: 0xDE5150FE
+          SceSblPostSsMgrForDriver_F7F1015B: 0xF7F1015B
+          SceSblPostSsMgrForDriver_F86F1452: 0xF86F1452
+          SceSblPostSsMgrForDriver_FE92A318: 0xFE92A318
+        nid: 0x2254E1B2
+        kernel: true
+      SceZlibForDriver:
+        functions:
+          SceZlibForDriver_00561385: 0x00561385
+          SceZlibForDriver_05F712FE: 0x05F712FE
+          SceZlibForDriver_0BDDF66A: 0x0BDDF66A
+          SceZlibForDriver_0FA805A3: 0x0FA805A3
+          SceZlibForDriver_134E91EA: 0x134E91EA
+          SceZlibForDriver_1C344E27: 0x1C344E27
+          SceZlibForDriver_1E135CC1: 0x1E135CC1
+          SceZlibForDriver_20A122F8: 0x20A122F8
+          SceZlibForDriver_211D25F5: 0x211D25F5
+          SceZlibForDriver_21A03034: 0x21A03034
+          SceZlibForDriver_25F28DA7: 0x25F28DA7
+          SceZlibForDriver_3252D28C: 0x3252D28C
+          SceZlibForDriver_3370B9AD: 0x3370B9AD
+          SceZlibForDriver_35E0108C: 0x35E0108C
+          SceZlibForDriver_3B4466F4: 0x3B4466F4
+          SceZlibForDriver_3F33F55F: 0x3F33F55F
+          SceZlibForDriver_408311E8: 0x408311E8
+          SceZlibForDriver_44DA19D2: 0x44DA19D2
+          SceZlibForDriver_4C27A382: 0x4C27A382
+          SceZlibForDriver_4CB63BCD: 0x4CB63BCD
+          SceZlibForDriver_4EE6C080: 0x4EE6C080
+          SceZlibForDriver_517BC5F7: 0x517BC5F7
+          SceZlibForDriver_520CAA7F: 0x520CAA7F
+          SceZlibForDriver_5377643A: 0x5377643A
+          SceZlibForDriver_5492B3F2: 0x5492B3F2
+          SceZlibForDriver_5A0078D6: 0x5A0078D6
+          SceZlibForDriver_5B718E55: 0x5B718E55
+          SceZlibForDriver_67A085C4: 0x67A085C4
+          SceZlibForDriver_68CFEA45: 0x68CFEA45
+          SceZlibForDriver_6ED5B677: 0x6ED5B677
+          SceZlibForDriver_7048F14C: 0x7048F14C
+          SceZlibForDriver_723495A5: 0x723495A5
+          SceZlibForDriver_7993ADAB: 0x7993ADAB
+          SceZlibForDriver_7B16DBD6: 0x7B16DBD6
+          SceZlibForDriver_7C40CC39: 0x7C40CC39
+          SceZlibForDriver_7E823337: 0x7E823337
+          SceZlibForDriver_81D0667B: 0x81D0667B
+          SceZlibForDriver_82167CD9: 0x82167CD9
+          SceZlibForDriver_834CC4A2: 0x834CC4A2
+          SceZlibForDriver_86FF6C8B: 0x86FF6C8B
+          SceZlibForDriver_89A13883: 0x89A13883
+          SceZlibForDriver_89B30588: 0x89B30588
+          SceZlibForDriver_9030BAE4: 0x9030BAE4
+          SceZlibForDriver_904AA7AE: 0x904AA7AE
+          SceZlibForDriver_93168F72: 0x93168F72
+          SceZlibForDriver_938F34FA: 0x938F34FA
+          SceZlibForDriver_98619620: 0x98619620
+          SceZlibForDriver_A1E7E8B3: 0xA1E7E8B3
+          SceZlibForDriver_A5D70E95: 0xA5D70E95
+          SceZlibForDriver_AC2F8437: 0xAC2F8437
+          SceZlibForDriver_AD23EEBB: 0xAD23EEBB
+          SceZlibForDriver_B03E109B: 0xB03E109B
+          SceZlibForDriver_BC022D38: 0xBC022D38
+          SceZlibForDriver_BE5CE88A: 0xBE5CE88A
+          SceZlibForDriver_D4A85178: 0xD4A85178
+          SceZlibForDriver_D9BDC778: 0xD9BDC778
+          SceZlibForDriver_E0CE06C0: 0xE0CE06C0
+          SceZlibForDriver_E2DF5A8B: 0xE2DF5A8B
+          SceZlibForDriver_E323828B: 0xE323828B
+          SceZlibForDriver_E4F34A68: 0xE4F34A68
+          SceZlibForDriver_E6EB524C: 0xE6EB524C
+          SceZlibForDriver_E859D60F: 0xE859D60F
+          SceZlibForDriver_E94663DD: 0xE94663DD
+          SceZlibForDriver_EEC6D267: 0xEEC6D267
+          SceZlibForDriver_F2D8FC1A: 0xF2D8FC1A
+        nid: 0xE241534E
+        kernel: true
+      SceSblPmMgr:
+        functions:
+          sceSblPmMgrAuthEtoI: 0xBD38B141
+          sceSblPmMgrGetCurrentMode: 0xDA4EDEBF
+          sceSblPmMgrGetProductModeForUser: 0x46EA9FDB
+          sceSblPmMgrGetProductModeFromNVS: 0x49CE0DDF
+          sceSblPmMgrSetProductModeOffForUser: 0x41FE8A37
+        nid: 0xA9CE5795
+        kernel: false
+      SceSblRtcMgr:
+        functions:
+          sceSblRtcMgrGetCpRtcLogical: 0xDD44D726
+          sceSblRtcMgrGetCpRtcPhysicalForUser: 0x1614302B
+          sceSblRtcMgrGetCpSerialId: 0xE162A827
+          sceSblRtcMgrSetCpActivationKey: 0x298AE544
+          sceSblRtcMgrSetCpRtcLogical: 0x9DFB118B
+          sceSblRtcMgrSetCpRtcPhysicalAndKey: 0x3C0EEC69
+          sceSblRtcMgrSetCpRtcPhysicalForUser: 0xA990BC44
+        nid: 0x44C5F209
+        kernel: false
+      SceSblLicMgr:
+        functions:
+          sceSblLicMgrActivateDevkit: 0xEB21DD39
+          sceSblLicMgrActivateFromFs: 0x6E56EA0A
+          sceSblLicMgrClearActivationData: 0x9B749D1D
+          sceSblLicMgrGetActivationKey: 0x2A437187
+          sceSblLicMgrGetExpireDate: 0xE9FA0FE5
+          sceSblLicMgrGetIssueNo: 0x0E0691A1
+          sceSblLicMgrGetLicenseStatus: 0x0EA6A30C
+          sceSblLicMgrGetUsageTimeLimit: 0x774EBBA2
+        nid: 0x62083C72
+        kernel: false
+      SceSblUtMgr:
+        functions:
+          SceSblUtMgr_04CA1311: 0x04CA1311
+          SceSblUtMgr_1CD57182: 0x1CD57182
+          SceSblUtMgr_BDE74645: 0xBDE74645
+          SceSblUtMgr_CFCB1355: 0xCFCB1355
+          SceSblUtMgr_D2836E0D: 0xD2836E0D
+        nid: 0x000DF81A
+        kernel: false
+      SceSblFwLoaderForDriver:
+        functions:
+          SceSblFwLoaderForDriver_91C73A54: 0x91C73A54
+          SceSblFwLoaderForDriver_A6278D27: 0xA6278D27
+          SceSblFwLoaderForDriver_BB59FC7A: 0xBB59FC7A
+        nid: 0x6FE424E4
+        kernel: true
+  SceSblSsSmComm:
+    nid: 0xBB4B5D92
+    libraries:
+      SceSblSmCommForKernel:
+        nid: 0xCD3C89B6
+        kernel: true
+        functions:
+          ksceSblSmCommCallFunc: 0xDB9FC204
+          ksceSblSmCommStartSm1: 0x039C73B1
+          ksceSblSmCommStartSm2: 0x7863A0CC
+          ksceSblSmCommStopSm: 0x0631F8ED
+  SceUlobjMgr:
+    nid: 0xAC99A848
+    libraries:
+      SceUlobjMgr:
+        nid: 0xDB18BB68
+        kernel: false
+        functions:
+          _sceUlobjMgrRegisterLibultProtocolRevision: 0x50F2F2AA
+          _sceUlobjMgrStartSupportingUserlevelObject: 0x08769991
+          _sceUlobjMgrStopSupportingUserlevelObject: 0xEF09284B
+      SceUlobjMgrForDriver:
+        nid: 0xD6A45C93
+        kernel: true
+        functions:
+          SceUlobjMgrForDriver_0C29AFEC: 0x0C29AFEC
+          SceUlobjMgrForDriver_332F2E58: 0x332F2E58
+          SceUlobjMgrForDriver_362C9488: 0x362C9488
+          SceUlobjMgrForDriver_3685D4FB: 0x3685D4FB
+          SceUlobjMgrForDriver_3D6E2EF3: 0x3D6E2EF3
+          SceUlobjMgrForDriver_525A9BDB: 0x525A9BDB
+          SceUlobjMgrForDriver_5D7A7925: 0x5D7A7925
+          SceUlobjMgrForDriver_6BCB4568: 0x6BCB4568
+          SceUlobjMgrForDriver_6D2C8928: 0x6D2C8928
+          SceUlobjMgrForDriver_6F868221: 0x6F868221
+          SceUlobjMgrForDriver_74B9199C: 0x74B9199C
+          SceUlobjMgrForDriver_8E200387: 0x8E200387
+          SceUlobjMgrForDriver_A48A5B3C: 0xA48A5B3C
+          SceUlobjMgrForDriver_A90A564C: 0xA90A564C
+          SceUlobjMgrForDriver_ADAAA961: 0xADAAA961
+          SceUlobjMgrForDriver_B978DB70: 0xB978DB70
+          SceUlobjMgrForDriver_BB11EB2F: 0xBB11EB2F
+          SceUlobjMgrForDriver_CDAD91AD: 0xCDAD91AD
+          SceUlobjMgrForDriver_FFC8C811: 0xFFC8C811

--- a/db.yml
+++ b/db.yml
@@ -1737,12 +1737,6 @@ modules:
   SceSysmem:
     nid: 0x3380B323
     libraries:
-      SceSysmemForKernel:
-        nid: 0x63A519E5
-        kernel: true
-        functions:
-          ksceKernelCreateUidObj: 0xDF0288D7
-          ksceKernelRxMemcpyKernelToUserForPid: 0x30931572
       SceSysmemForDriver:
         nid: 0x6F25E18A
         kernel: true
@@ -1786,6 +1780,12 @@ modules:
           ksceKernelUidRelease: 0x149885C4
           ksceKernelUidRetain: 0x0F5C84B7
           ksceKernelUnmapMemBlock: 0xFFCD9B60
+      SceSysmemForKernel:
+        nid: 0x63A519E5
+        kernel: true
+        functions:
+          ksceKernelCreateUidObj: 0xDF0288D7
+          ksceKernelRxMemcpyKernelToUserForPid: 0x30931572
       SceSysmem:
         nid: 0x37FE725A
         kernel: false


### PR DESCRIPTION
Thanks to TheFloW, devnoname, Xerpi, Motoharu, Yifan Lu for their tools.

I have merged official SCE userland functions while kernel functions come from the WIKI.
I have checked that all NIDs were 3.60, and from which module and libraries they are.
I made no typo (I checked with a comparizon tool, function after function).

Here are the noticeable changes for compatibility :
in SceKernelThreadmgr library :
sceKernelGetThreadTLSAddr becomes _sceKernelGetThreadTLSAddr
sceKernelStartThread becomes sceKernelStartThread_089 ---------> Cancelled for compatibility
sceKernelLockMutex becomes sceKernelLockMutex_089
sceKernelUnlockMutex becomes sceKernelUnlockMutex_089
sceKernelCancelMutex becomes sceKernelCancelMutex_089

in SceKernelThreadmgrForDriver library :
ksceKernelStartThread becomes ksceKernelStartThread_089 ---------> Cancelled for compatibility
ksceKernelLockMutex becomes ksceKernelLockMutex_089
ksceKernelUnlockMutex becomes ksceKernelUnlockMutex_089
ksceKernelCancelMutex becomes ksceKernelCancelMutex_089

in SceSysrootForKernel library :
BEFORE :
ksceKernelGetSysrootBuffer: 0x3E455842
AFTER :
ksceKernelGetSysbase: 0x3E455842
ksceKernelGetSysrootBuffer: 0x9DB56D1F

in SceSysmemForDriver library :
ksceKernelSwitchVmaForPid: 0x6F2ACDAE has been removed because NID is not in unsecure-world
ksceKernelRoMemcpyKernelToUserForPid: 0x571D2739 has been removed because NID is not in unsecure-world

in SceCpuForKernel
ksceKernelCpuSaveContext: 0x211B89DA has been removed because NID is not in unsecure-world
ksceKernelCpuRestoreContext: 0xA4F0FB9 has been removed because NID is not in unsecure-world