### PR TITLE
Remove all NID mismatched definitions

### DIFF
--- a/include/psp2/gxt.h
+++ b/include/psp2/gxt.h
@@ -43,64 +43,12 @@ typedef struct SceGxtTextureInfo {
 } SceGxtTextureInfo;
 
 /**
- * Checks if a pointer is a valid GXT file.
- *
- * @param	gxt	pointer to the GXT data
- *
- * @retval	SCE_OK
- * @retval	SCE_GXT_ERROR_INVALID_VALUE Magic or version invalid
- */
-SceGxtErrorCode sceGxtCheckData(const void *gxt);
-
-/**
  * Gets the start address of the texture data.
  *
  * @param	gxt	pointer to the GXT data
  * @return A pointer to the start of the texture data
  */
 const void *sceGxtGetDataAddress(const void *gxt);
-
-/**
- * Gets the size of the texture data.
- *
- * @param	gxt	pointer to the GXT data
- * @return The size of the texture data in bytes
- */
-uint32_t sceGxtGetDataSize(const void *gxt);
-
-/**
- * Gets the header size of a GXT file.
- *
- * @param	gxt	pointer to the GXT data
- * @return The size of the header in bytes
- */
-uint32_t sceGxtGetHeaderSize(const void *gxt);
-
-/**
- * Gets the texture count in a GXT file.
- *
- * @param	gxt	pointer to the GXT data
- * @return The number of textures.
- */
-uint32_t sceGxtGetTextureCount(const void *gxt);
-
-/**
- * Sets the palette of a given texture.
- *
- * @param	texture		pointer to the texture
- * @param	gxt 		pointer to the GXT data
- * @param	textureData 	pointer to the start of texture data
- * @param	paletteIndex 	palette index
- *
- * @retval	SCE_OK
- * @retval	SCE_GXT_ERROR_INVALID_ALIGNMENT
- * @retval	SCE_GXT_ERROR_INVALID_VALUE
- * @retval	SCE_GXT_ERROR_INVALID_POINTER
- */
-SceGxtErrorCode sceGxtSetPalette(SceGxmTexture *texture,
-				const void *gxt,
-				const void *textureData,
-				uint32_t paletteIndex);
 
 #ifdef __cplusplus
 }

--- a/include/psp2/io/fcntl.h
+++ b/include/psp2/io/fcntl.h
@@ -241,17 +241,6 @@ int sceIoLseekAsync(SceUID fd, SceOff offset, int whence);
 int sceIoLseek32(SceUID fd, int offset, int whence);
 
 /**
- * Reposition read/write file descriptor offset (32bit mode, asynchronous)
- *
- * @param fd - Opened file descriptor with which to seek
- * @param offset - Relative offset from the start position given by whence
- * @param whence - One of ::SceIoSeekMode.
- *
- * @return < 0 on error.
- */
-int sceIoLseek32Async(SceUID fd, int offset, int whence);
-
-/**
  * Remove directory entry
  *
  * @param file - Path to the file to remove
@@ -286,47 +275,6 @@ int sceIoSync(const char *device, unsigned int unk);
 int sceIoSyncByFd(SceUID fd);
 
 /**
-  * Wait for asynchronous completion.
-  *
-  * @param fd - The file descriptor which is current performing an asynchronous action.
-  * @param res - The result of the async action.
-  *
-  * @return < 0 on error.
-  */
-int sceIoWaitAsync(SceUID fd, SceInt64 *res);
-
-/**
-  * Wait for asynchronous completion (with callbacks).
-  *
-  * @param fd - The file descriptor which is current performing an asynchronous action.
-  * @param res - The result of the async action.
-  *
-  * @return < 0 on error.
-  */
-int sceIoWaitAsyncCB(SceUID fd, SceInt64 *res);
-
-/**
-  * Poll for asynchronous completion.
-  *
-  * @param fd - The file descriptor which is current performing an asynchronous action.
-  * @param res - The result of the async action.
-  *
-  * @return < 0 on error.
-  */
-int sceIoPollAsync(SceUID fd, SceInt64 *res);
-
-/**
-  * Get the asynchronous completion status.
-  *
-  * @param fd - The file descriptor which is current performing an asynchronous action.
-  * @param poll - If 0 then waits for the status, otherwise it polls the fd.
-  * @param res - The result of the async action.
-  *
-  * @return < 0 on error.
-  */
-int sceIoGetAsyncStat(SceUID fd, int poll, SceInt64 *res);
-
-/**
   * Cancel an asynchronous operation on a file descriptor.
   *
   * @param fd - The file descriptor to perform cancel on.
@@ -334,36 +282,6 @@ int sceIoGetAsyncStat(SceUID fd, int poll, SceInt64 *res);
   * @return < 0 on error.
   */
 int sceIoCancel(SceUID fd);
-
-/**
-  * Get the device type of the currently opened file descriptor.
-  *
-  * @param fd - The opened file descriptor.
-  *
-  * @return < 0 on error, otherwise one of ::SceIoDevType.
-  */
-int sceIoGetDevType(SceUID fd);
-
-/**
-  * Change the priority of the asynchronous thread.
-  *
-  * @param fd - The opened fd on which the priority should be changed.
-  * @param pri - The priority of the thread.
-  *
-  * @return < 0 on error.
-  */
-int sceIoChangeAsyncPriority(SceUID fd, int pri);
-
-/**
-  * Sets a callback for the asynchronous action.
-  *
-  * @param fd - The filedescriptor currently performing an asynchronous action.
-  * @param cb - The UID of the callback created with ::sceKernelCreateCallback
-  * @param argp - Pointer to an argument to pass to the callback.
-  *
-  * @return < 0 on error.
-  */
-int sceIoSetAsyncCallback(SceUID fd, SceUID cb, void *argp);
 
 #ifdef __cplusplus
 }

--- a/include/psp2/kernel/threadmgr.h
+++ b/include/psp2/kernel/threadmgr.h
@@ -231,15 +231,6 @@ int sceKernelChangeCurrentThreadAttr(int unknown, SceUInt attr);
 int sceKernelChangeThreadPriority(SceUID thid, int priority);
 
 /**
- * Release a thread in the wait state.
- *
- * @param thid - The UID of the thread.
- *
- * @return 0 on success, < 0 on error
- */
-int sceKernelReleaseWaitThread(SceUID thid);
-
-/**
   * Get the current thread Id
   *
   * @return The thread id of the calling thread.

--- a/include/psp2/net/http.h
+++ b/include/psp2/net/http.h
@@ -304,13 +304,6 @@ int sceHttpReadData(int reqId, void *data, unsigned int size);
 int sceHttpAddRequestHeader(int id, const char *name, const char *value, unsigned int mode);
 int sceHttpRemoveRequestHeader(int id, const char *name);
 
-int sceHttpSetProxy(int id, int enableProxyFlag, int mode, const char *newProxyHost, unsigned short newProxyPort);
-int sceHttpGetProxy(int id, int *enabeProxyFlag, int *mode, char *proxy_host, unsigned int len, unsigned short *proxy_port);
-int sceHttpEnableKeepAlive(int id);
-int sceHttpDisableKeepAlive(int id);
-int sceHttpEnableHttp0_9(int id);
-int sceHttpDisableHttp0_9(int id);
-
 int sceHttpParseResponseHeader(const char *header, unsigned int headerLen, const char *fieldStr, const char **fieldValue, unsigned int *valueLen);
 int sceHttpParseStatusLine(const char *statusLine, unsigned int lineLen, int *httpMajorVer, int *httpMinorVer, int *responseCode, const char **reasonPhrase, unsigned int *phraseLen);
 
@@ -323,7 +316,6 @@ int sceHttpCreateRequest(int connId, int method, const char *path, unsigned long
 int sceHttpCreateRequestWithURL(int connId, int method, const char *url, unsigned long long int contentLength);
 int sceHttpDeleteRequest(int reqId);
 int sceHttpSetResponseHeaderMaxSize(int id, unsigned int headerSize);
-int sceHttpSetRecvBlockSize(int id, unsigned int blockSize);
 int sceHttpSetRequestContentLength(int id, unsigned long long int contentLength);
 
 // uri

--- a/include/psp2kern/bt.h
+++ b/include/psp2kern/bt.h
@@ -312,7 +312,6 @@ int ksceBtHfpGetCurrentPhoneNumber(int r0, int r1, int r2, int r3);
 int ksceBtHfpRequest(int r0, int r1, int r2, int r3);
 int ksceBtHidGetReportDescriptor(unsigned int mac0, unsigned int mac1, void *buffer, unsigned int size);
 int ksceBtHidTransfer(unsigned int mac0, unsigned int mac1, SceBtHidRequest *request);
-int ksceBtPairingOOB(int r0, int r1, int r2, int r3);
 int ksceBtPushBip(int r0, int r1, int r2, int r3);
 int ksceBtPushOpp(int r0, int r1, int r2, int r3);
 int ksceBtReadEvent(SceBtEvent *events, int num_events);

--- a/include/psp2kern/io/fcntl.h
+++ b/include/psp2kern/io/fcntl.h
@@ -75,16 +75,6 @@ typedef enum SceIoDevType {
 SceUID ksceIoOpen(const char *file, int flags, SceMode mode);
 
 /**
- * Open or create a file for reading or writing (asynchronous)
- *
- * @param file - Pointer to a string holding the name of the file to open
- * @param flags - Libc styled flags that are or'ed together
- * @param mode - File access mode (One or more ::SceIoMode).
- * @return A non-negative integer is a valid fd, anything else an error
- */
-SceUID ksceIoOpenAsync(const char *file, int flags, SceMode mode);
-
-/**
  * Delete a descriptor
  *
  * @code
@@ -95,14 +85,6 @@ SceUID ksceIoOpenAsync(const char *file, int flags, SceMode mode);
  * @return < 0 on error
  */
 int ksceIoClose(SceUID fd);
-
-/**
- * Delete a descriptor (asynchronous)
- *
- * @param fd - File descriptor to close
- * @return < 0 on error
- */
-int ksceIoCloseAsync(SceUID fd);
 
 /**
  * Read input
@@ -137,23 +119,6 @@ int ksceIoRead(SceUID fd, void *data, SceSize size);
 int ksceIoReadAsync(SceUID fd, void *data, SceSize size);
 
 /**
- * Read input at offset
- *
- * @par Example:
- * @code
- * bytes_read = ksceIoPread(fd, data, 100, 0x1000);
- * @endcode
- *
- * @param fd - Opened file descriptor to read from
- * @param data - Pointer to the buffer where the read data will be placed
- * @param size - Size of the read in bytes
- * @param offset - Offset to read
- *
- * @return < 0 on error.
- */
-int ksceIoPread(SceUID fd, void *data, SceSize size, SceOff offset);
-
-/**
  * Write output
  *
  * @par Example:
@@ -181,23 +146,6 @@ int ksceIoWrite(SceUID fd, const void *data, SceSize size);
 int ksceIoWriteAsync(SceUID fd, const void *data, SceSize size);
 
 /**
- * Write output at offset
- *
- * @par Example:
- * @code
- * bytes_written = ksceIoPwrite(fd, data, 100, 0x1000);
- * @endcode
- *
- * @param fd - Opened file descriptor to write to
- * @param data - Pointer to the data to write
- * @param size - Size of data to write
- * @param offset - Offset to write
- *
- * @return The number of bytes written
- */
-int ksceIoPwrite(SceUID fd, const void *data, SceSize size, SceOff offset);
-
-/**
  * Reposition read/write file descriptor offset
  *
  * @par Example:
@@ -212,44 +160,6 @@ int ksceIoPwrite(SceUID fd, const void *data, SceSize size, SceOff offset);
  * @return The position in the file after the seek.
  */
 SceOff ksceIoLseek(SceUID fd, SceOff offset, int whence);
-
-/**
- * Reposition read/write file descriptor offset (asynchronous)
- *
- * @param fd - Opened file descriptor with which to seek
- * @param offset - Relative offset from the start position given by whence
- * @param whence - One of ::SceIoSeekMode.
- *
- * @return < 0 on error. Actual value should be passed returned by the ::ksceIoWaitAsync call.
- */
-int ksceIoLseekAsync(SceUID fd, SceOff offset, int whence);
-
-/**
- * Reposition read/write file descriptor offset (32bit mode)
- *
- * @par Example:
- * @code
- * pos = ksceIoLseek32(fd, -10, SCE_SEEK_END);
- * @endcode
- *
- * @param fd - Opened file descriptor with which to seek
- * @param offset - Relative offset from the start position given by whence
- * @param whence - One of ::SceIoSeekMode.
- *
- * @return The position in the file after the seek.
- */
-int ksceIoLseek32(SceUID fd, int offset, int whence);
-
-/**
- * Reposition read/write file descriptor offset (32bit mode, asynchronous)
- *
- * @param fd - Opened file descriptor with which to seek
- * @param offset - Relative offset from the start position given by whence
- * @param whence - One of ::SceIoSeekMode.
- *
- * @return < 0 on error.
- */
-int ksceIoLseek32Async(SceUID fd, int offset, int whence);
 
 /**
  * Remove directory entry
@@ -284,86 +194,6 @@ int ksceIoSync(const char *device, unsigned int unk);
  * @return < 0 on error.
  */
 int ksceIoSyncByFd(SceUID fd);
-
-/**
-  * Wait for asynchronous completion.
-  *
-  * @param fd - The file descriptor which is current performing an asynchronous action.
-  * @param res - The result of the async action.
-  *
-  * @return < 0 on error.
-  */
-int ksceIoWaitAsync(SceUID fd, SceInt64 *res);
-
-/**
-  * Wait for asynchronous completion (with callbacks).
-  *
-  * @param fd - The file descriptor which is current performing an asynchronous action.
-  * @param res - The result of the async action.
-  *
-  * @return < 0 on error.
-  */
-int ksceIoWaitAsyncCB(SceUID fd, SceInt64 *res);
-
-/**
-  * Poll for asynchronous completion.
-  *
-  * @param fd - The file descriptor which is current performing an asynchronous action.
-  * @param res - The result of the async action.
-  *
-  * @return < 0 on error.
-  */
-int ksceIoPollAsync(SceUID fd, SceInt64 *res);
-
-/**
-  * Get the asynchronous completion status.
-  *
-  * @param fd - The file descriptor which is current performing an asynchronous action.
-  * @param poll - If 0 then waits for the status, otherwise it polls the fd.
-  * @param res - The result of the async action.
-  *
-  * @return < 0 on error.
-  */
-int ksceIoGetAsyncStat(SceUID fd, int poll, SceInt64 *res);
-
-/**
-  * Cancel an asynchronous operation on a file descriptor.
-  *
-  * @param fd - The file descriptor to perform cancel on.
-  *
-  * @return < 0 on error.
-  */
-int ksceIoCancel(SceUID fd);
-
-/**
-  * Get the device type of the currently opened file descriptor.
-  *
-  * @param fd - The opened file descriptor.
-  *
-  * @return < 0 on error, otherwise one of ::SceIoDevType.
-  */
-int ksceIoGetDevType(SceUID fd);
-
-/**
-  * Change the priority of the asynchronous thread.
-  *
-  * @param fd - The opened fd on which the priority should be changed.
-  * @param pri - The priority of the thread.
-  *
-  * @return < 0 on error.
-  */
-int ksceIoChangeAsyncPriority(SceUID fd, int pri);
-
-/**
-  * Sets a callback for the asynchronous action.
-  *
-  * @param fd - The filedescriptor currently performing an asynchronous action.
-  * @param cb - The UID of the callback created with ::sceKernelCreateCallback
-  * @param argp - Pointer to an argument to pass to the callback.
-  *
-  * @return < 0 on error.
-  */
-int ksceIoSetAsyncCallback(SceUID fd, SceUID cb, void *argp);
 
 /**
   * Mounts a device

--- a/include/psp2kern/kernel/threadmgr.h
+++ b/include/psp2kern/kernel/threadmgr.h
@@ -211,16 +211,6 @@ int ksceKernelDelayThread(SceUInt delay);
 int ksceKernelDelayThreadCB(SceUInt delay);
 
 /**
- * Modify the attributes of the current thread.
- *
- * @param unknown - Set to 0.
- * @param attr - The thread attributes to modify.  One of ::SceThreadAttributes.
- *
- * @return < 0 on error.
- */
-int ksceKernelChangeCurrentThreadAttr(int unknown, SceUInt attr);
-
-/**
   * Change the threads current priority.
   *
   * @param thid - The ID of the thread (from ::ksceKernelCreateThread or ::ksceKernelGetThreadId)
@@ -238,15 +228,6 @@ int ksceKernelChangeCurrentThreadAttr(int unknown, SceUInt attr);
 int ksceKernelChangeThreadPriority(SceUID thid, int priority);
 
 /**
- * Release a thread in the wait state.
- *
- * @param thid - The UID of the thread.
- *
- * @return 0 on success, < 0 on error
- */
-int ksceKernelReleaseWaitThread(SceUID thid);
-
-/**
   * Get the current thread Id
   *
   * @return The thread id of the calling thread.
@@ -261,22 +242,6 @@ int ksceKernelGetThreadId(void);
 int ksceKernelGetThreadCurrentPriority(void);
 
 /**
- * Get the exit status of a thread.
- *
- * @param thid - The UID of the thread to check.
- *
- * @return The exit status
- */
-int ksceKernelGetThreadExitStatus(SceUID thid);
-
-/**
- * Check the thread stack?
- *
- * @return Unknown.
- */
-int ksceKernelCheckThreadStack(void);
-
-/**
  * Get the free stack size for a thread.
  *
  * @param thid - The thread ID. Seem to take current thread
@@ -285,35 +250,6 @@ int ksceKernelCheckThreadStack(void);
  * @return The free size.
  */
 int ksceKernelGetThreadStackFreeSize(SceUID thid);
-
-/**
-  * Get the status information for the specified thread.
-  *
-  * @param thid - Id of the thread to get status
-  * @param info - Pointer to the info structure to receive the data.
-  * Note: The structures size field should be set to
-  * sizeof(SceKernelThreadInfo) before calling this function.
-  *
-  * @par Example:
-  * @code
-  * SceKernelThreadInfo status;
-  * status.size = sizeof(SceKernelThreadInfo);
-  * if(ksceKernelGetThreadInfo(thid, &status) == 0)
-  * { Do something... }
-  * @endcode
-  * @return 0 if successful, otherwise the error code.
-  */
-int ksceKernelGetThreadInfo(SceUID thid, SceKernelThreadInfo *info);
-
-/**
- * Retrive the runtime status of a thread.
- *
- * @param thid - UID of the thread to retrieve status.
- * @param status - Pointer to a ::SceKernelThreadRunStatus struct to receive the runtime status.
- *
- * @return 0 if successful, otherwise the error code.
- */
-int ksceKernelGetThreadRunStatus(SceUID thid, SceKernelThreadRunStatus *status);
 
 
 /* Semaphores. */
@@ -405,22 +341,6 @@ int ksceKernelSignalSema(SceUID semaid, int signal);
 int ksceKernelWaitSema(SceUID semaid, int signal, SceUInt *timeout);
 
 /**
- * Lock a semaphore and handle callbacks if necessary.
- *
- * @par Example:
- * @code
- * ksceKernelWaitSemaCB(semaid, 1, 0);
- * @endcode
- *
- * @param semaid - The sema id returned from ::ksceKernelCreateSema
- * @param signal - The value to wait for (i.e. if 1 then wait till reaches a signal state of 1)
- * @param timeout - Timeout in microseconds (assumed).
- *
- * @return < 0 on error.
- */
-int ksceKernelWaitSemaCB(SceUID semaid, int signal, SceUInt *timeout);
-
-/**
  * Poll a semaphore.
  *
  * @param semaid - UID of the semaphore to poll.
@@ -429,26 +349,6 @@ int ksceKernelWaitSemaCB(SceUID semaid, int signal, SceUInt *timeout);
  * @return < 0 on error.
  */
 int ksceKernelPollSema(SceUID semaid, int signal);
-
-/**
- * Cancels a semaphore
- *
- * @param semaid - The sema id returned from ::ksceKernelCreateSema
- * @param setCount - The new lock count of the semaphore
- * @param numWaitThreads - Number of threads waiting for the semaphore
- * @return < 0 On error.
- */
-int ksceKernelCancelSema(SceUID semaid, int setCount, int *numWaitThreads);
-
-/**
- * Retrieve information about a semaphore.
- *
- * @param semaid - UID of the semaphore to retrieve info for.
- * @param info - Pointer to a ::SceKernelSemaInfo struct to receive the info.
- *
- * @return < 0 on error.
- */
-int ksceKernelGetSemaInfo(SceUID semaid, SceKernelSemaInfo *info);
 
 
 /* Mutexes. */
@@ -508,22 +408,6 @@ SceUID ksceKernelCreateMutex(const char *name, SceUInt attr, int initCount, SceK
 int ksceKernelDeleteMutex(SceUID mutexid);
 
 /**
- * Open a mutex
- *
- * @param name - The name of the mutex to open
- * @return Returns the value 0 if it's successful, otherwise -1
- */
-int ksceKernelOpenMutex(const char *name);
-
-/**
- * Close a mutex
- *
- * @param mutexid - The mutex id returned from ::ksceKernelCreateMutex
- * @return Returns the value 0 if it's successful, otherwise -1
- */
-int ksceKernelCloseMutex(SceUID mutexid);
-
-/**
  * Lock a mutex
  *
  * @param mutexid - The mutex id returned from ::ksceKernelCreateMutex
@@ -532,16 +416,6 @@ int ksceKernelCloseMutex(SceUID mutexid);
  * @return < 0 On error.
  */
 int ksceKernelLockMutex(SceUID mutexid, int lockCount, unsigned int *timeout);
-
-/**
- * Lock a mutex and handle callbacks if necessary.
- *
- * @param mutexid - The mutex id returned from ::ksceKernelCreateMutex
- * @param lockCount - The value to increment to the lock count of the mutex
- * @param timeout - Timeout in microseconds (assumed)
- * @return < 0 On error.
- */
-int ksceKernelLockMutexCB(SceUID mutexid, int lockCount, unsigned int *timeout);
 
 /**
  * Try to lock a mutex (non-blocking)
@@ -571,16 +445,6 @@ int ksceKernelUnlockMutex(SceUID mutexid, int unlockCount);
  */
 int ksceKernelCancelMutex(SceUID mutexid, int newCount, int *numWaitThreads);
 
-/**
- * Retrieve information about a mutex.
- *
- * @param mutexid - UID of the mutex to retrieve info for.
- * @param info - Pointer to a ::SceKernelMutexInfo struct to receive the info.
- *
- * @return < 0 on error.
- */
-int ksceKernelGetMutexInfo(SceUID mutexid, SceKernelMutexInfo *info);
-
 typedef struct  SceKernelLwMutexWork {
 	SceInt64 data[4];
 } SceKernelLwMutexWork;
@@ -588,11 +452,6 @@ typedef struct  SceKernelLwMutexWork {
 typedef struct SceKernelLwMutexOptParam {
 	SceSize size;
 } SceKernelLwMutexOptParam;
-
-int ksceKernelCreateLwMutex(SceKernelLwMutexWork *pWork,const char *pName, unsigned int attr, int initCount, const SceKernelLwMutexOptParam *pOptParam);
-int ksceKernelDeleteLwMutex(SceKernelLwMutexWork *pWork);
-int ksceKernelLockLwMutex(SceKernelLwMutexWork *pWork, int lockCount, unsigned int *pTimeout);
-int ksceKernelUnlockLwMutex(SceKernelLwMutexWork *pWork, int unlockCount);
 
 int ksceKernelInitializeFastMutex(void *mutex, const char *name, int unk0, int unk1);
 int ksceKernelLockFastMutex(void *mutex);
@@ -717,16 +576,6 @@ int ksceKernelWaitEventFlagCB(int evid, unsigned int bits, unsigned int wait, un
   */
 int ksceKernelDeleteEventFlag(int evid);
 
-/**
-  * Get the status of an event flag.
-  *
-  * @param event - The UID of the event.
-  * @param status - A pointer to a ::SceKernelEventFlagInfo structure.
-  *
-  * @return < 0 on error.
-  */
-int ksceKernelGetEventFlagInfo(SceUID event, SceKernelEventFlagInfo *info);
-
 /* Condition variables */
 
 typedef struct  SceKernelLwCondWork {
@@ -736,11 +585,6 @@ typedef struct  SceKernelLwCondWork {
 typedef struct SceKernelLwCondOptParam {
 	SceSize size;
 } SceKernelLwCondOptParam;
-
-int ksceKernelCreateLwCond(SceKernelLwCondWork *pWork, const char *pName, unsigned int attr, SceKernelLwMutexWork *pLwMutex, const SceKernelLwCondOptParam *pOptParam);
-int ksceKernelDeleteLwCond(SceKernelLwCondWork *pWork);
-int ksceKernelSignalLwCond(SceKernelLwCondWork *pWork);
-int ksceKernelWaitLwCond(SceKernelLwCondWork *pWork,  unsigned int *pTimeout);
 
 /* Callbacks. */
 
@@ -783,17 +627,6 @@ typedef struct SceKernelCallbackInfo {
  * @return >= 0 A callback id which can be used in subsequent functions, < 0 an error.
  */
 int ksceKernelCreateCallback(const char *name, unsigned int attr, SceKernelCallbackFunction func, void *arg);
-
-/**
-  * Gets the status of a specified callback.
-  *
-  * @param cb - The UID of the callback to retrieve info for.
-  * @param status - Pointer to a status structure. The size parameter should be
-  * initialized before calling.
-  *
-  * @return < 0 on error.
-  */
-int ksceKernelGetCallbackInfo(SceUID cb, SceKernelCallbackInfo *infop);
 
 /**
  * Delete a callback
@@ -839,168 +672,6 @@ int ksceKernelGetCallbackCount(SceUID cb);
  */
 int ksceKernelCheckCallback(void);
 
-
-/* Message pipes */
-
-/**
- * Create a message pipe
- *
- * @param name - Name of the pipe
- * @param type - The type of memory attribute to use internally (set to 0x40)
- * @param attr - Set to 12
- * @param bufSize - The size of the internal buffer in multiples of 0x1000 (4KB)
- * @param opt  - Message pipe options (set to NULL)
- *
- * @return The UID of the created pipe, < 0 on error
- */
-SceUID ksceKernelCreateMsgPipe(const char *name, int type, int attr, unsigned int bufSize, void *opt);
-
-/**
- * Delete a message pipe
- *
- * @param uid - The UID of the pipe
- *
- * @return 0 on success, < 0 on error
- */
-int ksceKernelDeleteMsgPipe(SceUID uid);
-
-/**
- * Send a message to a pipe
- *
- * @param uid - The UID of the pipe
- * @param message - Pointer to the message
- * @param size - Size of the message
- * @param unk1 - Unknown - async vs sync? use 0 for sync
- * @param unk2 - Unknown - use NULL
- * @param timeout - Timeout for send in us. use NULL to wait indefinitely
- *
- * @return 0 on success, < 0 on error
- */
-int ksceKernelSendMsgPipe(SceUID uid, void *message, unsigned int size, int unk1, void *unk2, unsigned int *timeout);
-
-/**
- * Send a message to a pipe (with callback)
- *
- * @param uid - The UID of the pipe
- * @param message - Pointer to the message
- * @param size - Size of the message
- * @param unk1 - Unknown - async vs sync? use 0 for sync
- * @param unk2 - Unknown - use NULL
- * @param timeout - Timeout for send in us. use NULL to wait indefinitely
- *
- * @return 0 on success, < 0 on error
- */
-int ksceKernelSendMsgPipeCB(SceUID uid, void *message, unsigned int size, int unk1, void *unk2, unsigned int *timeout);
-
-/**
- * Try to send a message to a pipe
- *
- * @param uid - The UID of the pipe
- * @param message - Pointer to the message
- * @param size - Size of the message
- * @param unk1 - Unknown - use 0
- * @param unk2 - Unknown - use NULL
- *
- * @return 0 on success, < 0 on error
- */
-int ksceKernelTrySendMsgPipe(SceUID uid, void *message, unsigned int size, int unk1, void *unk2);
-
-/**
- * Receive a message from a pipe
- *
- * @param uid - The UID of the pipe
- * @param message - Pointer to the message
- * @param size - Size of the message
- * @param unk1 - Unknown - async vs sync? use 0 for sync
- * @param unk2 - Unknown - use NULL
- * @param timeout - Timeout for receive in us. use NULL to wait indefinitely
- *
- * @return 0 on success, < 0 on error
- */
-int ksceKernelReceiveMsgPipe(SceUID uid, void *message, unsigned int size, int unk1, void *unk2, unsigned int *timeout);
-
-/**
- * Receive a message from a pipe (with callback)
- *
- * @param uid - The UID of the pipe
- * @param message - Pointer to the message
- * @param size - Size of the message
- * @param unk1 - Unknown - async vs sync? use 0 for sync
- * @param unk2 - Unknown - use NULL
- * @param timeout - Timeout for receive in us. use NULL to wait indefinitely
- *
- * @return 0 on success, < 0 on error
- */
-int ksceKernelReceiveMsgPipeCB(SceUID uid, void *message, unsigned int size, int unk1, void *unk2, unsigned int *timeout);
-
-/**
- * Receive a message from a pipe
- *
- * @param uid - The UID of the pipe
- * @param message - Pointer to the message
- * @param size - Size of the message
- * @param unk1 - Unknown - use 0
- * @param unk2 - Unknown - use NULL
- *
- * @return 0 on success, < 0 on error
- */
-int ksceKernelTryReceiveMsgPipe(SceUID uid, void *message, unsigned int size, int unk1, void *unk2);
-
-/**
- * Cancel a message pipe
- *
- * @param uid - UID of the pipe to cancel
- * @param psend - Receive number of sending threads, NULL is valid
- * @param precv - Receive number of receiving threads, NULL is valid
- *
- * @return 0 on success, < 0 on error
- */
-int ksceKernelCancelMsgPipe(SceUID uid, int *psend, int *precv);
-
-/** Message Pipe status info */
-typedef struct SceKernelMppInfo {
-	SceSize size;
-	SceUID  mppId; // Needs confirmation
-	char    name[32];
-	SceUInt attr;
-	int     bufSize;
-	int     freeSize;
-	int     numSendWaitThreads;
-	int     numReceiveWaitThreads;
-} SceKernelMppInfo;
-
-/**
- * Get the status of a Message Pipe
- *
- * @param uid - The uid of the Message Pipe
- * @param info - Pointer to a ::SceKernelMppInfo structure
- *
- * @return 0 on success, < 0 on error
- */
-int ksceKernelGetMsgPipeInfo(SceUID uid, SceKernelMppInfo *info);
-
-
-/* Misc. */
-
-typedef struct SceKernelSystemInfo {
-	SceSize   size;
-	SceUInt32 activeCpuMask;
-
-	struct {
-		SceKernelSysClock idleClock;
-		SceUInt32         comesOutOfIdleCount;
-		SceUInt32         threadSwitchCount;
-	} cpuInfo[4];
-} SceKernelSystemInfo;
-
-/**
- * Get the system information
- *
- * @param info - Pointer to a ::SceKernelSystemInfo structure
- *
- * @return 0 on success, < 0 on error
- */
-int ksceKernelGetSystemInfo(SceKernelSystemInfo *info);
 
 /* Misc. */
 

--- a/include/psp2kern/udcd.h
+++ b/include/psp2kern/udcd.h
@@ -450,15 +450,6 @@ int ksceUdcdGetDeviceInfo(SceUdcdDeviceInfo *devInfo);
 int ksceUdcdGetDrvState(const char *driverName);
 
 /**
- *  Get the list of drivers
- *  @param flags - One or more ::SceUdcdStatusDriver
- *  @param list - points to the output list
- *  @param size - number of entries in the output list
- *  @return the number of drivers in the output or < 0 in case of error
- */
-int ksceUdcdGetDrvList(unsigned int flags, SceUdcdDriverName *list, int size);
-
-/**
  * Wait for USB state
  * @param state - combination of states (returned by ::ksceUdcdGetDeviceState)
  * @param waitMode - one of the ::SceEventFlagWaitTypes
@@ -466,12 +457,6 @@ int ksceUdcdGetDrvList(unsigned int flags, SceUdcdDriverName *list, int size);
  * @return the usb state or < 0 in case of error
  */
 int ksceUdcdWaitState(unsigned int state, unsigned int waitMode, SceUInt *timeout);
-
-/**
- * Cancel a pending ksceUdcdWaitState
- * @return 0 on success
- */
-int ksceUdcdWaitCancel(void);
 
 /**
  * Register a USB driver.


### PR DESCRIPTION
looks accident, #200 merged into master tree.
and it makes the error on the travis ci.

anyway, we can't use these functions before finding right NID value.
but if we provide functions & doc contains these infos, end-programmers can
have confusion

and I guess, these function just copy-and-paste from the psp sdk or userland
header.
and already we wait too long time for solving issues.

Resolve #201