### PR TITLE
Added db for 3.65/3.67

### DIFF
--- a/db_367.yml
+++ b/db_367.yml
@@ -1,0 +1,86 @@
+version: 2
+firmware: 3.67
+modules:
+  SceSysmem:
+    nid: 0x3380B323
+    libraries:
+      SceSysmemForKernel:
+        kernel: true
+        nid: 0x02451F0F
+        functions:
+          ksceKernelCreateUidObj: 0xFB6390CE
+          ksceKernelRxMemcpyKernelToUserForPid: 0x2995558D
+          ksceKernelGetMemBlockType: 0xD44FE44B
+          ksceKernelFindClassByName: 0x7D87F706
+      SceCpuForKernel:
+        kernel: true
+        nid: 0xA5195D20
+        functions:
+          ksceKernelCpuDcacheInvalidateAll: 0xF9B0B171
+          ksceKernelCpuDcacheWritebackAll: 0x49180814
+          ksceKernelCpuDcacheWritebackInvalidateAll: 0x4BBA5C82
+          ksceKernelCpuIcacheInvalidateRange: 0x2E637B1D
+          ksceKernelCpuIcacheInvalidateAll: 0x803C84BF
+          ksceKernelCpuIcacheAndL2WritebackInvalidateRange: 0x73E895EA
+          ksceKernelCpuDcacheWritebackInvalidateRange: 0x4F442396
+      SceDebugForKernel:
+        kernel: true
+        nid: 0x13D793B7
+        functions:
+          ksceDebugSetHandlers: 0x88AD6D0C
+          ksceDebugRegisterPutcharHandler: 0x22546577
+          ksceDebugGetPutcharHandler: 0x8D474850
+          ksceDebugPutchar: 0x2AABAEDA
+          ksceDebugDisableInfoDump: 0xA465A31A
+      SceUartForKernel:
+        kernel: true
+        nid: 0x1CCD9BA3
+        functions:
+          ksceUartReadAvailable: 0x16780BC3
+          ksceUartWrite: 0x430C48F1
+          ksceUartRead: 0x4E97D3AD
+          ksceUartInit: 0x4C02AA05
+  SceKernelThreadMgr:
+    nid: 0x23A1B482
+    libraries:
+      SceThreadmgrForKernel:
+        kernel: true
+        nid: 0x7F8593BA
+        functions:
+          ksceKernelGetFaultingProcess: 0x6C1F092F
+  SceKernelModulemgr:
+    nid: 0x726C6635
+    libraries:
+      SceModulemgrForKernel:
+        kernel: true
+        nid: 0x92C9FFC2
+        functions:
+          ksceKernelGetModuleInfo: 0xDAA90093
+          ksceKernelGetModuleInternal: 0x37512E29
+          ksceKernelGetModuleList: 0xB72C75A4
+          ksceKernelLoadModuleForPid: 0x4E85022D
+          ksceKernelMountBootfs: 0x185FF1BC
+          ksceKernelStartModuleForPid: 0x3FE47DDF
+          ksceKernelStopModuleForPid: 0xBDBD391D
+          ksceKernelUmountBootfs: 0xBD61AD4D
+          ksceKernelUnloadModuleForPid: 0xFCA9FDB1
+  SceProcessmgr:
+    nid: 0x7CE857A1
+    libraries:
+      SceProcessmgrForKernel:
+        kernel: true
+        nid: 0xEB1F8EF7
+        functions:
+          ksceKernelExitProcess: 0x905621F9
+          ksceKernelLaunchApp: 0x68068618
+          ksceKernelGetProcessAuthid: 0x324F2B20
+          ksceKernelGetProcessKernelBuf: 0xD991C85E
+  SceExcpmgr:
+    nid: 0xF3D9E37C
+    libraries:
+      SceExcpmgrForKernel:
+        kernel: true
+        nid: 0x1496A5B5
+        functions:
+          ksceExcpmgrGetData: 0x96C2869C
+          ksceExcpmgrRegisterHandler: 0x00063675


### PR DESCRIPTION
We need to have a way to specify 3.65/3.67 NIDs. Maybe use `*_367_stub.a`?