### PR TITLE
Refix _sceCommonDialogSetMagicNumber hack

### DIFF
--- a/include/psp2/common_dialog.h
+++ b/include/psp2/common_dialog.h
@@ -107,9 +107,7 @@ typedef struct SceCommonDialogParam {
 static inline
 void _sceCommonDialogSetMagicNumber(SceCommonDialogParam *param)
 {
-#ifdef __vita__
-	param->magic = SCE_COMMON_DIALOG_MAGIC_NUMBER + (SceUInt32)param;
-#endif
+	param->magic = SCE_COMMON_DIALOG_MAGIC_NUMBER + *(SceUInt32*)&param;
 }
 
 static inline


### PR DESCRIPTION
original patch introduced for the Vita3K, only problem in 64bit C++
compiler.
this patch is also hack, but will work on all compilers
also fill the magic value