### PR TITLE
fixed forgotten datatype declaration + creation of kernel_message_ctx

### DIFF
--- a/include/psp2kern/kernel/sysmem.h
+++ b/include/psp2kern/kernel/sysmem.h
@@ -431,7 +431,7 @@ int ksceSysrootUseInternalStorage(void);
 
 int ksceDebugPrintf(const char *fmt, ...);
 
-struct kernel_message_ctx
+typedef struct kernel_message_ctx
 {
   int hex_value0_hi;
   int hex_value0_lo;
@@ -439,7 +439,7 @@ struct kernel_message_ctx
   char* msg0;
   int num;
   char* msg1;
-};
+} kernel_message_ctx;
 
 // msg_type_flag : 0 or 0xB
 


### PR DESCRIPTION
As written in HENkaku Discord someone accidently broke the header file. 
Will add an issue to add stuff to travis-ci that this won't happen again.