### PR TITLE
ci: better check headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ script:
     - export PATH=$VITASDK/bin:$PATH
     - export INCLUDE_DIR=$TRAVIS_BUILD_DIR/include
     # Make sure headers are valid
-    - find $INCLUDE_DIR -type f -name "*.h" -exec arm-vita-eabi-gcc -I$INCLUDE_DIR -c {} -o /dev/null \;
-    - find $INCLUDE_DIR -type f -name "*.h" -exec arm-vita-eabi-g++ -I$INCLUDE_DIR -c {} -o /dev/null \;
+    - find $INCLUDE_DIR -type f -name "*.h" | xargs -I FN -n 1 arm-vita-eabi-gcc -I$INCLUDE_DIR -c FN -o /dev/null
+    - find $INCLUDE_DIR -type f -name "*.h" | xargs -I FN -n 1 arm-vita-eabi-g++ -I$INCLUDE_DIR -c FN -o /dev/null
     - bash $TRAVIS_BUILD_DIR/.travis.d/download_external_libs.sh
     - cd $VITASDK/arm-vita-eabi/include
     - rm -rf psp2 psp2kern vitasdk vitasdk.h

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ script:
     - export PATH=$VITASDK/bin:$PATH
     - export INCLUDE_DIR=$TRAVIS_BUILD_DIR/include
     # Make sure headers are valid
-    - find $INCLUDE_DIR -type f -name "*.h" | xargs -I FN -n 1 arm-vita-eabi-gcc -I$INCLUDE_DIR -c FN -o /dev/null
-    - find $INCLUDE_DIR -type f -name "*.h" | xargs -I FN -n 1 arm-vita-eabi-g++ -I$INCLUDE_DIR -c FN -o /dev/null
+    - find $INCLUDE_DIR -type f -name "*.h" | xargs -I FN -n 1 -P 4 arm-vita-eabi-gcc -I$INCLUDE_DIR -c FN -o /dev/null
+    - find $INCLUDE_DIR -type f -name "*.h" | xargs -I FN -n 1 -P 4 arm-vita-eabi-g++ -I$INCLUDE_DIR -c FN -o /dev/null
     - bash $TRAVIS_BUILD_DIR/.travis.d/download_external_libs.sh
     - cd $VITASDK/arm-vita-eabi/include
     - rm -rf psp2 psp2kern vitasdk vitasdk.h

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,8 @@ script:
     - export PATH=$VITASDK/bin:$PATH
     - export INCLUDE_DIR=$TRAVIS_BUILD_DIR/include
     # Make sure headers are valid
-    - find $INCLUDE_DIR -type f -name "*.h" -exec arm-vita-eabi-gcc -I$INCLUDE_DIR -c {} +
-    - find $INCLUDE_DIR -type f -name "*.h" -exec arm-vita-eabi-g++ -I$INCLUDE_DIR -c {} +
-    # Remove compiled headers
-    - find $INCLUDE_DIR -name "*.gch" -type f -delete
+    - find $INCLUDE_DIR -type f -name "*.h" -exec arm-vita-eabi-gcc -I$INCLUDE_DIR -c {} -o /dev/null \;
+    - find $INCLUDE_DIR -type f -name "*.h" -exec arm-vita-eabi-g++ -I$INCLUDE_DIR -c {} -o /dev/null \;
     - bash $TRAVIS_BUILD_DIR/.travis.d/download_external_libs.sh
     - cd $VITASDK/arm-vita-eabi/include
     - rm -rf psp2 psp2kern vitasdk vitasdk.h

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ script:
     - export PATH=$VITASDK/bin:$PATH
     - export INCLUDE_DIR=$TRAVIS_BUILD_DIR/include
     # Make sure headers are valid
-    - arm-vita-eabi-gcc -I$INCLUDE_DIR -c $INCLUDE_DIR/vitasdk{,kern}.h
-    - arm-vita-eabi-g++ -I$INCLUDE_DIR -c $INCLUDE_DIR/vitasdk{,kern}.h
+    - find $INCLUDE_DIR -type f -name "*.h" -exec arm-vita-eabi-gcc -I$INCLUDE_DIR -c {} +
+    - find $INCLUDE_DIR -type f -name "*.h" -exec arm-vita-eabi-g++ -I$INCLUDE_DIR -c {} +
     # Remove compiled headers
     - find $INCLUDE_DIR -name "*.gch" -type f -delete
     - bash $TRAVIS_BUILD_DIR/.travis.d/download_external_libs.sh

--- a/include/psp2/jpegenc.h
+++ b/include/psp2/jpegenc.h
@@ -6,6 +6,9 @@
 #ifndef _JPEGENC_H_
 #define _JPEGENC_H_
 
+#include <stdint.h>
+#include <psp2/types.h>
+
 typedef void *SceJpegEncoderContext;
 
 typedef enum SceJpegEncErrorCode {

--- a/include/psp2/kernel/dmac.h
+++ b/include/psp2/kernel/dmac.h
@@ -7,6 +7,8 @@
 #ifndef _PSP2_DMAC_H_
 #define _PSP2_DMAC_H_
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/psp2/shutter_sound.h
+++ b/include/psp2/shutter_sound.h
@@ -7,6 +7,8 @@
 #ifndef _PSP2_SHUTTERSOUND_H_
 #define _PSP2_SHUTTERSOUND_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/psp2/udcd.h
+++ b/include/psp2/udcd.h
@@ -7,6 +7,8 @@
 #ifndef _PSP2_UDCD_H_
 #define _PSP2_UDCD_H_
 
+#include <psp2/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/psp2kern/avcodec/jpegenc.h
+++ b/include/psp2kern/avcodec/jpegenc.h
@@ -6,6 +6,8 @@
 #ifndef _PSP2_AVCODEC_JPEGENC_H_
 #define _PSP2_AVCODEC_JPEGENC_H_
 
+#include <psp2/types.h>
+
 typedef void *SceJpegEncoderContext;
 
 typedef enum SceJpegEncErrorCode {

--- a/include/psp2kern/kernel/dmac.h
+++ b/include/psp2kern/kernel/dmac.h
@@ -7,6 +7,8 @@
 #ifndef _PSP2_KERNEL_DMAC_H_
 #define _PSP2_KERNEL_DMAC_H_
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
When headers are compiled separately, there are lots of errors because they don't include the headers that they rely on.

This should be fixed prior to merging this pull request.