### PR TITLE
psp2kern: Change args types of ksceGzipDecompress

### DIFF
--- a/include/psp2kern/kernel/utils.h
+++ b/include/psp2kern/kernel/utils.h
@@ -78,7 +78,7 @@ int ksceHmacSha256Digest(const unsigned char *key, uint32_t key_len, const void 
  *
  * @return dst_size on success, < 0 on error.
  */
-int ksceGzipDecompress(void *dst, int dst_size, const void *src, int *crc32);
+int ksceGzipDecompress(void *dst, uint32_t dst_size, const void *src, uint32_t *crc32);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
these value should be uint32_t instead signed int
related: #353 comments