### PR TITLE
add ksceKernelGetProcessMainModule

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -2408,6 +2408,7 @@ modules:
           ksceKernelStopModuleForPid: 0x7BB4CE54
           ksceKernelUmountBootfs: 0x9C838A6B
           ksceKernelUnloadModuleForPid: 0x5972E2CC
+          ksceKernelGetProcessMainModule: 0x20A27FA9
       SceModulemgrForDriver:
         kernel: true
         nid: 0xD4A60A52

--- a/include/psp2kern/kernel/modulemgr.h
+++ b/include/psp2kern/kernel/modulemgr.h
@@ -104,6 +104,13 @@ int ksceKernelUmountBootfs(void);
 
 int ksceKernelSearchModuleByName(const char* module_name, const char* path, int pid);
 
+/**
+ * @brief Get the main module for a given process.
+ * @param pid The process to query.
+ * @return the UID of the module else < 0 for an error.
+ */
+SceUID ksceKernelGetProcessMainModule(SceUID pid);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
ksceKernelGetProcessMainModule queries the kernel for the main module id for a given process id.