### PR TITLE
add ksceKernelGetProcessMainThread

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -2563,6 +2563,7 @@ modules:
           ksceKernelLaunchApp: 0x71CF71FD
           ksceKernelGetProcessAuthid: 0xE4C83B0D
           ksceKernelGetProcessKernelBuf: 0xB9E68092
+          ksceKernelGetProcessMainThread: 0x95F9ED94
       SceProcessmgrForDriver:
         kernel: true
         nid: 0x746EC971

--- a/include/psp2kern/kernel/threadmgr.h
+++ b/include/psp2kern/kernel/threadmgr.h
@@ -851,6 +851,14 @@ typedef int (*SceKernelWorkQueueWorkFunction)(void *args);
  */
 int ksceKernelEnqueueWorkQueue(SceUID uid, const char *name, SceKernelWorkQueueWorkFunction work, void *args);
 
+
+/**
+ * @brief       Get the main thread for a given process.
+ * @param[in]   pid The process id to query for.
+ * @return      The thread UID on success, else < 0 on error.
+ */
+SceUID ksceKernelGetProcessMainThread(SceUID pid);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
ksceKernelGetProcessMainThread is a kernel service used to query the main thread id for a given process.