### PR TITLE
add ksceKernelGetProcessStatus

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -2581,6 +2581,7 @@ modules:
           ksceKernelGetProcessTimeCore: 0xEC283166
           ksceKernelGetProcessLocalStorageAddr: 0xEE694840
           ksceKernelIsGameBudget: 0xF7A8BB25
+          ksceKernelGetProcessStatus: 0x65B120B8
   SceSblPostSsMgr:
     nid: 0xB6C941F2
     libraries:

--- a/include/psp2kern/kernel/processmgr.h
+++ b/include/psp2kern/kernel/processmgr.h
@@ -38,6 +38,14 @@ int ksceKernelGetProcessLocalStorageAddrForPid(SceUID pid, int key, void **out_a
  */
 int ksceKernelProcessResume(SceUID pid);
 
+/**
+ * @brief       Get the status of a given process.
+ * @param[in]   pid The process ID to query.
+ * @param[out]  status The bit field status of the process.
+ * @return      Zero on success, < 0 on error.
+ */
+int ksceKernelGetProcessStatus(SceUID pid, int *status);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This kernel service queries the status of a given process. I'm unsure what exactly the bits represent. It seems 0x10 is related to suspension status, but I'm not confident in that assumption.