### PR TITLE
add ksceKernelGetThreadIdList

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -2280,6 +2280,7 @@ modules:
           ksceKernelCheckWaitableStatus: 0xD9BD74EB
           ksceKernelCheckCallback: 0xE53E41F6
           ksceKernelTryLockMutex: 0x270993A6
+          ksceKernelGetThreadIdList: 0xEA7B8AEF
       SceThreadmgrForKernel:
         kernel: true
         nid: 0xA8CA0EFD

--- a/include/psp2kern/kernel/threadmgr.h
+++ b/include/psp2kern/kernel/threadmgr.h
@@ -851,6 +851,16 @@ typedef int (*SceKernelWorkQueueWorkFunction)(void *args);
  */
 int ksceKernelEnqueueWorkQueue(SceUID uid, const char *name, SceKernelWorkQueueWorkFunction work, void *args);
 
+/**
+ * @brief       Retreive a list of all threads belonging to a process.
+ * @param[in]   pid         The process to query.
+ * @param[out]  ids         The list of thread ids. Can be NULL if output is not required.
+ * @param[in]   n           The max number of thread ids to copy out.
+ * @param[out]  copy_count  The number of thread ids copied.
+ * @return      The number of threads within the process, else < 0 on error.
+ */
+int ksceKernelGetThreadIdList(SceUID pid, SceUID *ids, int n, int *copy_count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/psp2kern/kernel/threadmgr.h
+++ b/include/psp2kern/kernel/threadmgr.h
@@ -852,7 +852,7 @@ typedef int (*SceKernelWorkQueueWorkFunction)(void *args);
 int ksceKernelEnqueueWorkQueue(SceUID uid, const char *name, SceKernelWorkQueueWorkFunction work, void *args);
 
 /**
- * @brief       Retreive a list of all threads belonging to a process.
+ * @brief       Retrieve a list of all threads belonging to a process.
  * @param[in]   pid         The process to query.
  * @param[out]  ids         The list of thread ids. Can be NULL if output is not required.
  * @param[in]   n           The max number of thread ids to copy out.


### PR DESCRIPTION
ksceKernelGetThreadIdList is a kernel service used to query and obtain the number of thread within a process.