### PR TITLE
add ksceKernelProcessResume

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -2563,6 +2563,7 @@ modules:
           ksceKernelLaunchApp: 0x71CF71FD
           ksceKernelGetProcessAuthid: 0xE4C83B0D
           ksceKernelGetProcessKernelBuf: 0xB9E68092
+          ksceKernelProcessResume: 0x080CDC59
       SceProcessmgrForDriver:
         kernel: true
         nid: 0x746EC971

--- a/include/psp2kern/kernel/processmgr.h
+++ b/include/psp2kern/kernel/processmgr.h
@@ -31,6 +31,13 @@ int ksceKernelCreateProcessLocalStorage(const char *name, SceSize size);
 void *ksceKernelGetProcessLocalStorageAddr(int key);
 int ksceKernelGetProcessLocalStorageAddrForPid(SceUID pid, int key, void **out_addr, int create_if_doesnt_exist);
 
+/**
+ * @brief       Resume a suspended process.
+ * @param[in]   pid The process to resume.
+ * @return      Zero on success, < 0 on error.
+ */
+int ksceKernelProcessResume(SceUID pid);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This kernel service is used to resume a process that is in the suspended state.