### PR TITLE
switch naming ksceKernelProcessResume to ksceKernelResumeProcess

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -2568,7 +2568,7 @@ modules:
           ksceKernelGetProcessKernelBuf: 0xB9E68092
           ksceKernelGetProcessMainThread: 0x95F9ED94
           ksceKernelLaunchApp: 0x71CF71FD
-          ksceKernelProcessResume: 0x080CDC59
+          ksceKernelResumeProcess: 0x080CDC59
       SceProcessmgrForDriver:
         kernel: true
         nid: 0x746EC971

--- a/include/psp2kern/kernel/processmgr.h
+++ b/include/psp2kern/kernel/processmgr.h
@@ -36,7 +36,7 @@ int ksceKernelGetProcessLocalStorageAddrForPid(SceUID pid, int key, void **out_a
  * @param[in]   pid The process to resume.
  * @return      Zero on success, < 0 on error.
  */
-int ksceKernelProcessResume(SceUID pid);
+int ksceKernelResumeProcess(SceUID pid);
 
 /**
  * @brief       Get the status of a given process.


### PR DESCRIPTION
Make it fit in more with existing API