### PR TITLE
add ksceKernelChangeThreadSuspendStatus

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -2206,6 +2206,7 @@ modules:
           ksceKernelCancelCallback: 0xC040EC1C
           ksceKernelCancelMutex: 0x7204B846
           ksceKernelChangeThreadPriority: 0x63DAB420
+          ksceKernelChangeThreadSuspendStatus: 0x04C6764B
           ksceKernelCheckCallback: 0xE53E41F6
           ksceKernelCheckWaitableStatus: 0xD9BD74EB
           ksceKernelClearEvent: 0x9C335818

--- a/include/psp2kern/kernel/threadmgr.h
+++ b/include/psp2kern/kernel/threadmgr.h
@@ -914,6 +914,20 @@ typedef struct ThreadCpuRegisters
  */
 int ksceKernelGetThreadCpuRegisters(SceUID thid, ThreadCpuRegisters *registers);
 
+
+/**
+ * @brief       Change the thread suspension status to another value.
+ *
+ * More research needs to be done to find out exactly what each status actually means. Some examples of useful scenarios:
+ * When handling an exception changing the status to 0x1002 (on a newly suspended thread) will stop the kernel rethrowing the same exception.
+ * When resuming a suspended thread changing the status to 2 will allow it to resume.
+ *
+ * @param[in]   thid    The thread to change.
+ * @param[in]   status  The new status for suspension.
+ * @return      Zero on success, else < 0 on error.
+ */
+int ksceKernelChangeThreadSuspendStatus(SceUID thid, int status);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This service allows you to change the status of a suspended thread. Most of the valid suspend bits are unknown, but some can be used to prevent the kernel rethrowing exceptions or pull threads into the running/ready state.