### PR TITLE
Add db.yml ordering check in CI

### DIFF
--- a/.travis.d/definition_ordering.sh
+++ b/.travis.d/definition_ordering.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+DB_FILE_PATH='./db.yml'
+LIBSEP="        functions:" # name of the yaml block we want to check
+IFS=@
+# iterate over each block and `sort --check` they content
+for lib in $(grep "$LIBSEP\|          " "$DB_FILE_PATH" | sed "s/$LIBSEP/$IFS/"); do
+  printf "$lib" | grep -o "          [^:]*"| LC_ALL=C sort -c
+done

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
     - set -e
     - cd $TRAVIS_BUILD_DIR
     - python $TRAVIS_BUILD_DIR/.travis.d/definition_check.py
+    - bash $TRAVIS_BUILD_DIR/.travis.d/definition_ordering.sh
     - bash $TRAVIS_BUILD_DIR/.travis.d/download_sdk.sh
     - export VITASDK=$PWD/vitasdk
     - export PATH=$VITASDK/bin:$PATH


### PR DESCRIPTION
Following https://github.com/vitasdk/vita-headers/pull/379#issuecomment-449836370 recommandation, I added the db ordering check in a separate travis.d sh file.
So if this thing works find, this pending PR shall fail: https://github.com/vitasdk/vita-headers/pull/380