### PR TITLE
Import NIDs from misc locations

### DIFF
--- a/.travis.d/sort_function_names.py
+++ b/.travis.d/sort_function_names.py
@@ -1,0 +1,44 @@
+import ruamel.yaml as yaml
+
+class HexWInt(yaml.scalarint.ScalarInt):
+    def __new__(cls, value, width):
+        x = yaml.scalarint.ScalarInt.__new__(cls, value)
+        x._width = width   # keep the original width
+        return x
+
+
+def alt_construct_yaml_int(constructor, node):
+    # check for 0x0 starting hex integers
+    value_s = yaml.compat.to_str(constructor.construct_scalar(node))
+    if not value_s.startswith('0x0'):
+        return constructor.construct_yaml_int(node)
+    return HexWInt(int(value_s[2:], 16), len(value_s[2:]))
+
+yaml.constructor.RoundTripConstructor.add_constructor(
+    u'tag:yaml.org,2002:int', alt_construct_yaml_int)
+
+def represent_hexw_int(representer, data):
+    return representer.represent_scalar(u'tag:yaml.org,2002:int',
+                                        '0x{:0{}X}'.format(data, data._width))
+
+yaml.representer.RoundTripRepresenter.add_representer(
+HexWInt, represent_hexw_int)
+
+f_db = open('db.yml')
+db = yaml.round_trip_load(f_db)
+f_db.close()
+
+for module in db['modules']:
+	module = db['modules'][module]
+	for library in module['libraries']:
+		library = module['libraries'][library]
+
+		sorted_functions = yaml.comments.CommentedMap()
+		for func in sorted(library['functions']):
+		    sorted_functions[func] = library['functions'][func]
+
+		library['functions'] = sorted_functions
+
+f_db = open('db.yml', 'w')
+yaml.dump(db, f_db, Dumper=yaml.RoundTripDumper, default_flow_style=False)
+f_db.close()

--- a/db.yml
+++ b/db.yml
@@ -2946,10 +2946,10 @@ modules:
         functions:
           ksceIoCancel: 0x6D59658D
           ksceIoChstat: 0x7D42B8DC
+          ksceIoChstat2: 0x1F98BD50
           ksceIoChstatAsync: 0x7EC442BF
           ksceIoChstatByFd: 0xDF57A75F
           ksceIoChstatByFdAsync: 0xEC974400
-          ksceIoChstat2: 0x1F98BD50
           ksceIoClearErrorEvent: 0x40B933C7
           ksceIoClose: 0xF99DD8A3
           ksceIoCloseAsync: 0x11C57CC6
@@ -2964,16 +2964,16 @@ modules:
           ksceIoDopen: 0x463B25CC
           ksceIoDopenAsync: 0x72F06BDE
           ksceIoDread: 0x20CF5FC7
-          ksceIoDreadAsync: 0x5982B0E3
           ksceIoDread2: 0x03051B02
+          ksceIoDreadAsync: 0x5982B0E3
           ksceIoFlock: 0x16336A0D
           ksceIoGetMediaType: 0x9C220246
           ksceIoGetProcessDefaultPriorityForSystem: 0xCE397158
           ksceIoGetstat: 0x75C96D25
+          ksceIoGetstat2: 0xD6503624
           ksceIoGetstatAsync: 0x94A5304A
           ksceIoGetstatByFd: 0x462F059B
           ksceIoGetstatByFdAsync: 0x0FEE1238
-          ksceIoGetstat2: 0xD6503624
           ksceIoIoctl: 0x161CD33F
           ksceIoIoctlAsync: 0xB761E91B
           ksceIoLseek: 0x62090481
@@ -3195,8 +3195,8 @@ modules:
           ksceSblPostSsMgrDebugEncryptKeystone: 0x42474C8B
           ksceSblPostSsMgrDecryptSealedkey: 0x33275F95
           ksceSblPostSsMgrEncryptSealedkey: 0x08525D8D
-          ksceSblPostSsMgrExecutePmSmF00dCommand8: 0x4663C195
           ksceSblPostSsMgrExecutePmSmF00dCommand: 0xADF92824
+          ksceSblPostSsMgrExecutePmSmF00dCommand8: 0x4663C195
           ksceSblPostSsMgrExecutePmSmSdF00dCommand: 0x19B63D65
           ksceSblPostSsMgrGetExpireDate: 0x4FF2682F
           ksceSblPostSsMgrInitializeSpfsoCtx: 0xBDF18922

--- a/db.yml
+++ b/db.yml
@@ -2095,9 +2095,7 @@ modules:
           ksceKernelGetPhysicalMemoryType: 0x0AAA4FDD
           ksceKernelGetPidContext: 0x2ECF7944
           ksceKernelGetUidClass: 0x85336A1C
-          ksceKernelGetUnknownValidPhysAddressSpace: 0xC9928F5E
           ksceKernelIsPaddrWithinSameSectionForUid: 0xF4AD89D8
-          ksceKernelIsPaddrWithinUnknownValidPhysAddressSpace: 0xA7C0D1FC
           ksceKernelKernelUidForUserUid: 0x45D22597
           ksceKernelKernelUidForUserUidForClass: 0x184172B1
           ksceKernelMapBlockUserVisible: 0x58D21746
@@ -2113,7 +2111,6 @@ modules:
           ksceKernelMemBlockRelease: 0x00575B00
           ksceKernelMemBlockType2Memtype: 0x20C811FA
           ksceKernelMemBlockTypeGetPrivileges: 0x6A0792A3
-          ksceKernelMemBlockTypeGetUnknown: 0xCB0F3A33
           ksceKernelMemRangeRelease: 0x75C70DE0
           ksceKernelMemRangeReleaseForPid: 0xA8525B06
           ksceKernelMemRangeReleaseWithPerm: 0x22CBE925
@@ -2222,7 +2219,6 @@ modules:
           ksceKernelCpuDcacheWritebackAll: 0x73A30DB2
           ksceKernelCpuDcacheWritebackInvalidateAll: 0x76DAB4D0
           ksceKernelCpuDcacheWritebackInvalidateRange: 0x6BA2E51C
-          ksceKernelCpuForKernel_9B8173F4: 0x9B8173F4
           ksceKernelCpuGetCONTEXTIDR: 0x5B6B3274
           ksceKernelCpuGetPaddr: 0x2A46E800
           ksceKernelCpuIcacheAndL2WritebackInvalidateRange: 0x19F17BD0
@@ -2384,17 +2380,11 @@ modules:
           ksceSysrootGetSelfAuthInfo: 0x4F0A4066
           ksceSysrootGetSelfInfo: 0xF10AB792
           ksceSysrootGetSessionId: 0x84783B71
-          ksceSysrootGetUnk10: 0x403B509E
-          ksceSysrootGetUnkC: 0xFFD6E24D
-          ksceSysrootGetUnkC0: 0xAB3CC7D0
           ksceSysrootGetWakeupFactor: 0x2F97041A
           ksceSysrootIsAuCodecIcConexant: 0x46E72428
           ksceSysrootIsBsodReboot: 0x4373AC96
           ksceSysrootIsExternalBootMode: 0x89D19090
           ksceSysrootIsSafeMode: 0x834439A7
-          ksceSysrootIsSomeBootMode2: 0x7918D44E
-          ksceSysrootIsSomeMode: 0xAE7A8F1D
-          ksceSysrootIsUnknownReboot: 0xE4EA1960
           ksceSysrootIsUpdateMode: 0xB0E1FC67
           ksceSysrootIsUsbEnumWakeup: 0x79C9AE10
           ksceSysrootRegisterLicMgrGetLicenseStatus: 0x71DB83A2
@@ -2959,7 +2949,7 @@ modules:
           ksceIoChstatAsync: 0x7EC442BF
           ksceIoChstatByFd: 0xDF57A75F
           ksceIoChstatByFdAsync: 0xEC974400
-          ksceIoChstatForDriver_2: 0x1F98BD50
+          ksceIoChstat2: 0x1F98BD50
           ksceIoClearErrorEvent: 0x40B933C7
           ksceIoClose: 0xF99DD8A3
           ksceIoCloseAsync: 0x11C57CC6
@@ -2975,7 +2965,7 @@ modules:
           ksceIoDopenAsync: 0x72F06BDE
           ksceIoDread: 0x20CF5FC7
           ksceIoDreadAsync: 0x5982B0E3
-          ksceIoDreadForDriver_2: 0x03051B02
+          ksceIoDread2: 0x03051B02
           ksceIoFlock: 0x16336A0D
           ksceIoGetMediaType: 0x9C220246
           ksceIoGetProcessDefaultPriorityForSystem: 0xCE397158
@@ -2983,7 +2973,7 @@ modules:
           ksceIoGetstatAsync: 0x94A5304A
           ksceIoGetstatByFd: 0x462F059B
           ksceIoGetstatByFdAsync: 0x0FEE1238
-          ksceIoGetstatForDriver_2: 0xD6503624
+          ksceIoGetstat2: 0xD6503624
           ksceIoIoctl: 0x161CD33F
           ksceIoIoctlAsync: 0xB761E91B
           ksceIoLseek: 0x62090481
@@ -3028,7 +3018,7 @@ modules:
           ksceVfsOpDevctl: 0xB07B307D
           ksceVfsUnmount: 0x9C7E7B76
           ksceVopChstat: 0x1974FA92
-          ksceVopClsoe: 0x40944C2E
+          ksceVopClose: 0x40944C2E
           ksceVopCreate: 0x9E347C7D
           ksceVopDclose: 0x1350F5C7
           ksceVopDopen: 0x00C9C2DD
@@ -3197,32 +3187,32 @@ modules:
         kernel: true
         nid: 0x2254E1B2
         functions:
-          _ksceSblPostSsMgrExecutePmSmF00dCommandForDriver: 0xFE92A318
+          _ksceSblPostSsMgrExecutePmSmF00dCommand: 0xFE92A318
           ksceSblLicMgrGetActivationKey: 0xF7F1015B
           ksceSblLicMgrGetLicenseStatus: 0x15F37282
-          ksceSblPostSsMgrActivateForDriver: 0x0298382B
-          ksceSblPostSsMgrDebugDecryptKeystoneForDriver: 0xCC5AA5A5
-          ksceSblPostSsMgrDebugEncryptKeystoneForDriver: 0x42474C8B
-          ksceSblPostSsMgrDecryptSealedkeyForDriver: 0x33275F95
-          ksceSblPostSsMgrEncryptSealedkeyForDriver: 0x08525D8D
-          ksceSblPostSsMgrExecutePmSmF00dCommand8ForDriver: 0x4663C195
-          ksceSblPostSsMgrExecutePmSmF00dCommandForDriver: 0xADF92824
-          ksceSblPostSsMgrExecutePmSmSdF00dCommandForDriver: 0x19B63D65
-          ksceSblPostSsMgrGetExpireDateForDriver: 0x4FF2682F
-          ksceSblPostSsMgrInitializeSpfsoCtxForDriver: 0xBDF18922
-          ksceSblPostSsMgrReleaseSpfsoCtxForDriver: 0xAD3B0078
-          ksceSblPostSsMgrSetCpRtcForDriver: 0x3F9BDEDF
-          ksceSblPostSsMgrVerifyKeystoneForDriver: 0xDDA6FA6D
-          ksceSblPostSsMgrVerifyKeystoneWithPasscodeForDriver: 0xF86F1452
-          ksceSblPostSsMgrVerifySpfsoCtxForDriver: 0x686B9461
+          ksceSblPostSsMgrActivate: 0x0298382B
+          ksceSblPostSsMgrDebugDecryptKeystone: 0xCC5AA5A5
+          ksceSblPostSsMgrDebugEncryptKeystone: 0x42474C8B
+          ksceSblPostSsMgrDecryptSealedkey: 0x33275F95
+          ksceSblPostSsMgrEncryptSealedkey: 0x08525D8D
+          ksceSblPostSsMgrExecutePmSmF00dCommand8: 0x4663C195
+          ksceSblPostSsMgrExecutePmSmF00dCommand: 0xADF92824
+          ksceSblPostSsMgrExecutePmSmSdF00dCommand: 0x19B63D65
+          ksceSblPostSsMgrGetExpireDate: 0x4FF2682F
+          ksceSblPostSsMgrInitializeSpfsoCtx: 0xBDF18922
+          ksceSblPostSsMgrReleaseSpfsoCtx: 0xAD3B0078
+          ksceSblPostSsMgrSetCpRtc: 0x3F9BDEDF
+          ksceSblPostSsMgrVerifyKeystone: 0xDDA6FA6D
+          ksceSblPostSsMgrVerifyKeystoneWithPasscode: 0xF86F1452
+          ksceSblPostSsMgrVerifySpfsoCtx: 0x686B9461
           ksceSblRtcMgrGetCpRtcLogical: 0xDE5150FE
           ksceSblRtcMgrGetCpRtcPhysical: 0x942010A0
-          ksceSblUtMgrExecuteUtokenSmCommand1ForDriver: 0xC2E58CE3
+          ksceSblUtMgrExecuteUtokenSmCommand1: 0xC2E58CE3
           ksceSblUtMgrGetTrilithiumBuffer: 0xABDD68CD
-          ksceSblUtMgrHasComTestFlagForDriver: 0x7ACCAA50
-          ksceSblUtMgrHasNpTestFlagForDriver: 0x9FD835B0
-          ksceSblUtMgrHasStoreFlagForDriver: 0x9D2E2D39
-          ksceSblUtMgrResetUtokenFileForDriver: 0x1FF699DD
+          ksceSblUtMgrHasComTestFlag: 0x7ACCAA50
+          ksceSblUtMgrHasNpTestFlag: 0x9FD835B0
+          ksceSblUtMgrHasStoreFlag: 0x9D2E2D39
+          ksceSblUtMgrResetUtokenFile: 0x1FF699DD
       SceSblPmMgr:
         kernel: false
         nid: 0xA9CE5795
@@ -7207,8 +7197,6 @@ modules:
           kscePowerIsLowBattery: 0xD3075926
           kscePowerIsPowerOnline: 0x87440F5E
           kscePowerIsRequest: 0x7FA406DD
-          kscePowerIsSomethingBattery: 0x0D56C601
-          kscePowerIsSomethingBattery2: 0x627A89C6
           kscePowerIsSuspendRequired: 0x78A1A796
           kscePowerRegisterCallback: 0x04B7766E
           kscePowerRequestColdReset: 0x0442D852
@@ -9637,11 +9625,8 @@ modules:
           ksceSblSmSchedProxyExecuteF00DCommand: 0x7894B6F0
           ksceSblSmSchedProxyGetCommandF00DRegister: 0xF70C04EC
           ksceSblSmSchedProxyGetStatus: 0x27EB92F1
-          ksceSblSmSchedProxyGetUnknownF00DRegister: 0x3CE17233
           ksceSblSmSchedProxyInitialize: 0xA488D604
           ksceSblSmSchedProxyInvoke: 0x1916509B
-          ksceSblSmSchedProxyNotImplementedMaybeSMC0x131: 0x984EC9D1
-          ksceSblSmSchedProxyNotImplementedMaybeSMC0x132: 0x1DFC8624
           ksceSblSmSchedProxyReadCry2Arm: 0x973A4A7D
           ksceSblSmSchedProxyUninitialize: 0x33A3A1E2
           ksceSblSmSchedProxyWait: 0xF35EFC1A

--- a/db.yml
+++ b/db.yml
@@ -489,6 +489,13 @@ modules:
           sceAudioOutSetAlcMode: 0x940CE469
           sceAudioOutSetConfig: 0xB8BA0D07
           sceAudioOutSetVolume: 0x64167F11
+          sceAudioOutSetAdopt_forUser: 0x26C82AF2
+          sceAudioOutSetCompress: 0x3601D375
+          sceAudioOutOpenExtPort: 0x6184B939
+          sceAudioOutSetPortVolume_forUser: 0x65840F3D
+          sceAudioOutSetEffectType: 0xB41FACCE
+          sceAudioOutSetAdoptMode: 0xDCC90EDB
+          sceAudioOutGetPortVolume_forUser: 0xFF635DA5
   SceAudioIn:
     nid: 0x3DFB6F18
     libraries:
@@ -501,6 +508,13 @@ modules:
           sceAudioInInput: 0x638ADD2D
           sceAudioInOpenPort: 0x39B50DC1
           sceAudioInReleasePort: 0x3A61B8C4
+          sceAudioInGetInput: 0x08105392
+          sceAudioInSetMicGain: 0x0F34DD73
+          sceAudioInSetMute: 0x1DFE7698
+          sceAudioInInputWithInputDeviceState: 0x343E8251
+          sceAudioInGetMicGain: 0x86118097
+          sceAudioInSelectInput: 0xA0EB852F
+          sceAudioInOpenPortForDiag: 0xC6962E84
   SceAudiodec:
     nid: 0xC
     libraries:
@@ -776,6 +790,12 @@ modules:
           sceCameraSetZoom: 0xF7464216
           sceCameraStart: 0xA8FEAE35
           sceCameraStop: 0x1DD9C9CE
+          sceCameraGetSharpnessOff: 0x34CCAF85
+          sceCameraSetSharpnessOff: 0x4B5405C8
+          sceCameraSetImageQuality: 0x75C4300B
+          sceCameraGetImageQuality: 0xE2AC7BCE
+          sceCameraSetNoiseReduction: 0xF9B79556
+          sceCameraGetNoiseReduction: 0xFEB99ACC
   SceClipboard:
     nid: 0xB4042D2E
     libraries:
@@ -1750,10 +1770,34 @@ modules:
         kernel: false
         nid: 0xE23FAD62
         functions:
-            sceHidKeyboardEnumerate: 0x34BDFACE
-            sceHidKeyboardRead: 0x224A8AD8
-            sceHidMouseEnumerate: 0x2A0D2F54
-            sceHidMouseRead: 0xBDECBDC0
+          sceHidKeyboardEnumerate: 0x34BDFACE
+          sceHidKeyboardRead: 0x224A8AD8
+          sceHidMouseEnumerate: 0x2A0D2F54
+          sceHidMouseRead: 0xBDECBDC0
+          sceHidConsumerControlRegisterReadHintCallback: 0x0D964502
+          sceHidConsumerControlEnumerate: 0x160B334A
+          sceHidKeyboardRegisterReadHintCallback: 0x1C740A7A
+          sceHidControllerRegisterEnumHintCallback: 0x1E9B25E0
+          sceHidMouseUnregisterEnumHintCallback: 0x3E005E5B
+          sceHidConsumerControlRead: 0x55F64676
+          sceHidKeyboardSetIntercept: 0x5D727742
+          sceHidConsumerControlUnregisterEnumHintCallback: 0x5D836BC5
+          sceHidKeyboardClear: 0x67C01C34
+          sceHidKeyboardRegisterEnumHintCallback: 0x743A066F
+          sceHidControllerRead: 0x792C1505
+          sceHidControllerUnregisterEnumHintCallback: 0x7E52ACF1
+          sceHidKeyboardUnregisterEnumHintCallback: 0x8068D61E
+          sceHidControllerUnregisterReadHintCallback: 0x83B7B1D5
+          sceHidMouseRegisterReadHintCallback: 0x90C5CB0A
+          sceHidKeyboardPeek: 0x91F5D4BE
+          sceHidControllerEnumerate: 0x983AF9E8
+          sceHidMouseUnregisterReadHintCallback: 0xAC591B15
+          sceHidConsumerControlUnregisterReadHintCallback: 0xB9E89914
+          sceHidControllerRegisterReadHintCallback: 0xBE5992CA
+          sceHidConsumerControlRegisterEnumHintCallback: 0xC54BDDB1
+          sceHidMouseRegisterEnumHintCallback: 0xC9E35B47
+          sceHidKeyboardGetIntercept: 0xCDA9D24C
+          sceHidKeyboardUnregisterReadHintCallback: 0xF73C5FBA
   SceHttp:
     nid: 0xB015B405
     libraries:
@@ -2305,6 +2349,7 @@ modules:
           ksceKernelWaitSema: 0x3C8B55A9
           ksceKernelWaitThreadEnd: 0x3E20216F
           ksceKernelWaitThreadEndCB: 0x9EF4F62C
+          ksceKernelLockMutexCB_089: 0xD06F2886
       SceThreadmgrForKernel:
         kernel: true
         nid: 0xA8CA0EFD
@@ -2389,6 +2434,103 @@ modules:
           sceKernelUnregisterCallbackFromEvent: 0x18462B11
           sceKernelUnregisterCallbackFromEventAll: 0x888A7361
           sceKernelUnregisterThreadEventHandler: 0x2C8ED6F0
+          sceKernelWaitThreadEndCB_089: 0x0373C5E3
+          _sceKernelTryReceiveMsgPipeVector: 0x03CFCF00
+          _sceKernelGetSemaInfo: 0x0402C633
+          _sceKernelWaitCond: 0x040795C7
+          _sceKernelWaitMultipleEventsCB: 0x0558B7C1
+          _sceKernelGetCondInfo: 0x05C51CE1
+          _sceKernelSignalLwCondAll: 0x07D2584A
+          _sceKernelCreateSema: 0x0D76458E
+          _sceKernelGetEventFlagInfo: 0x106C216F
+          _sceKernelSetEventWithNotifyCallback: 0x118F646E
+          _sceKernelCancelTimer: 0x13117B21
+          _sceKernelWaitLwCond: 0x18C65756
+          _sceKernelCancelMutex: 0x1B74CB89
+          _sceKernelCancelSema: 0x1CAF805D
+          sceKernelSuspendThreadForVM: 0x1FF5960D
+          _sceKernelWaitMultipleEvents: 0x200CC503
+          _sceKernelGetThreadCpuAffinityMask: 0x212E6C35
+          _sceKernelGetTimerEventRemainingTime: 0x215FD24D
+          _sceKernelPollEvent: 0x21C7913E
+          _sceKernelExitCallback: 0x2682E6ED
+          sceKernelOpenMutex_089: 0x2928D2EC
+          _sceKernelCancelEvent: 0x29483405
+          _sceKernelCreateMsgPipeWithLR: 0x2AAC8BFD
+          _sceKernelUnlockLwMutex: 0x2ABC41DF
+          _sceKernelGetThreadContextForVM: 0x377094D5
+          _sceKernelCreateEventFlag: 0x38AA5E8E
+          _sceKernelReceiveMsgPipeVector: 0x3DD9E4AB
+          _sceKernelPulseEventWithNotifyCallback: 0x3E49D3F1
+          _sceKernelWaitEventFlagCB: 0x401E0C68
+          _sceKernelWaitCondCB: 0x452B0AB3
+          _sceKernelWaitSema: 0x45389B6B
+          __sceKernelCreateLwMutex: 0x4BB3154A
+          _sceKernelReceiveMsgPipeVectorCB: 0x4DBF648E
+          _sceKernelWaitEvent: 0x4E0EA70D
+          _sceKernelWaitSignal: 0x50407BF4
+          _sceKernelLockReadRWLockCB: 0x5D86D763
+          _sceKernelGetThreadEventInfo: 0x5DE0B7E9
+          _sceKernelSendMsgPipeVector: 0x5E65E454
+          _sceKernelWaitExceptionCB: 0x5E7876F2
+          _sceKernelPMonThreadGetCounter: 0x6B9711AC
+          _sceKernelGetLwCondInfo: 0x6C79F2F2
+          _sceKernelSignalLwCondTo: 0x6F1A4A2E
+          _sceKernelGetTimerTime: 0x6F2C41BA
+          _sceKernelWaitException: 0x6F7C4DE6
+          _sceKernelGetEventPattern: 0x70358258
+          _sceKernelWaitLwCondCB: 0x72DBB96B
+          _sceKernelDeleteLwCond: 0x75FCF058
+          _sceKernelCreateTimer: 0x79BA0A6D
+          _sceKernelGetMsgPipeInfo: 0x7AE31060
+          _sceKernelWaitEventCB: 0x7D483C33
+          sceKernelResumeThreadForVM: 0x7EB55DAC
+          _sceKernelLockReadRWLock: 0x7EB9E8B5
+          _sceKernelLockMutex: 0x7FA945AD
+          _sceKernelLockWriteRWLock: 0x80191FAA
+          _sceKernelGetSystemInfo: 0x80544E0C
+          _sceKernelGetTimerBase: 0x865DA482
+          _sceKernelGetCallbackInfo: 0x86761234
+          _sceKernelGetRWLockInfo: 0x8CE3AFC7
+          _sceKernelCancelEventWithSetPattern: 0x8E68E870
+          _sceKernelDeleteLwMutex: 0x91262C5F
+          _sceKernelCreateMutex: 0x92667AE5
+          _sceKernelCreateLwCond: 0x940B9EBE
+          _sceKernelCreateSimpleEvent: 0x9C187FAD
+          _sceKernelLockLwMutex: 0x9C572180
+          sceKernelCloseMutex_089: 0xA35427EE
+          _sceKernelGetTimerInfo: 0xAC7FE4F3
+          _sceKernelCreateRWLock: 0xB1877F5E
+          _sceKernelGetThreadInfo: 0xB373D8A1
+          _sceKernelGetEventInfo: 0xB395BBF1
+          _sceKernelTrySendMsgPipeVector: 0xB3D600AB
+          _sceKernelGetSystemTime: 0xB70EBAE9
+          _sceKernelCreateSema_16XX: 0xBD06F27C
+          _sceKernelStartThread: 0xC30B1745
+          _sceKernelSignalLwCond: 0xC37F6983
+          _sceKernelGetThreadRunStatus: 0xC7FB5497
+          _sceKernelCreateCond: 0xCC14FA59
+          _sceKernelRegisterThreadEventHandler: 0xCE6B49D8
+          _sceKernelCancelMsgPipe: 0xCE769C83
+          _sceKernelWaitSignalCB: 0xCEA3FC52
+          _sceKernelCancelRWLock: 0xD004EA15
+          _sceKernelGetThreadExitStatus: 0xD3210C08
+          _sceKernelSetThreadContextForVM: 0xD4785C41
+          _sceKernelGetLwCondInfoById: 0xD9E78D30
+          _sceKernelPollEventFlag: 0xDAB1B1C8
+          _sceKernelLockMutexCB: 0xDB9F5333
+          _sceKernelLockWriteRWLockCB: 0xDBD09B09
+          _sceKernelSetTimerEvent: 0xE2C0BFEF
+          _sceKernelGetMutexInfo: 0xE8CC3DF0
+          _sceKernelWaitThreadEnd: 0xEA5C52F5
+          sceKernelWaitThreadEnd_089: 0xF3489EF4
+          _sceKernelSendMsgPipeVectorCB: 0xF6D515DC
+          _sceKernelCancelEventFlag: 0xF76F3056
+          _sceKernelWaitSemaCB: 0xF8E06784
+          _sceKernelWaitThreadEndCB: 0xFA3D4491
+          _sceKernelWaitEventFlag: 0xFCE2F728
+          _sceKernelGetLwMutexInfoById: 0xFEC9E946
+          _sceKernelSetTimerTime: 0xFF738CD9
       SceThreadmgrCoredumpTime:
         kernel: false
         nid: 0x5E8D0E22
@@ -2469,6 +2611,19 @@ modules:
           sceKernelGetSystemSwVersion: 0x5182E212
           sceKernelInhibitLoadingModule: 0x6CED1F63
           sceKernelIsCalledFromSysModule: 0x85E6D2BB
+          _sceKernelStopModule: 0x086867A8
+          _sceKernelLoadStartModule: 0x60647592
+          _sceKernelStartModule: 0x72CD301F
+          _sceKernelCloseModule: 0x849E78BE
+          _sceKernelStopUnloadModule: 0x86EAEA0A
+          _sceKernelUnloadModule: 0x8E4A7716
+          _sceKernelOpenModule: 0x9D674F45
+          _sceKernelLoadModule: 0xB4C5EF9E
+      SceBacktrace:
+        nid: 0xB07B6A3F
+        kernel: false
+        functions:
+          _sceKernelBacktrace: 0xBF371A98
   SceIofilemgr:
     nid: 0x9642948C
     libraries:
@@ -2539,6 +2694,44 @@ modules:
           sceIoSyncByFdAsync: 0x7E1367CB
           sceIoWrite: 0x34EFD876
           sceIoWriteAsync: 0xE0D63D2A
+          _sceIoOpenAsync: 0x09CD0FC8
+          _sceIoRmdirAsync: 0x13DC3244
+          _sceIoIoctl: 0x1D2988F1
+          _sceIoLseekAsync: 0x2300858E
+          _sceIoDevctlAsync: 0x3EE3F66E
+          _sceIoRename: 0x4912F748
+          _sceIoDevctl: 0x515AC017
+          sceIoGetstatByFdAsync: 0x5167AC1E
+          _sceIoPread: 0x539FD5C4
+          _sceIoSync: 0x5DD867F7
+          _sceIoRemoveAsync: 0x5FFA47E2
+          _sceIoRemove: 0x78955C65
+          _sceIoRenameAsync: 0x81794921
+          _sceIoSyncAsync: 0x86DB0C0E
+          _sceIoDread: 0x8713D662
+          _sceIoGetstat: 0x8E7E11F2
+          _sceIoMkdir: 0x8F1ACC32
+          _sceIoCompleteMultiple: 0x9111D004
+          _sceIoPwrite: 0x9654094B
+          _sceIoLseek: 0xA604764A
+          sceIoChstatByFdAsync: 0xA9F89275
+          _sceIoPwriteAsync: 0xB2D0B2F4
+          _sceIoChstatAsync: 0xB4B021D9
+          _sceIoPreadAsync: 0xBCF5684D
+          sceIoDopenAsync: 0xC49C312F
+          _sceIoOpen: 0xCC67B6FD
+          _sceIoChstat: 0xD2EE455F
+          _sceIoGetstatAsync: 0xD414C89F
+          sceIoDcloseAsync: 0xDC2D7D38
+          _sceIoIoctlAsync: 0xE00DC256
+          _sceIoChstatByFd: 0xE0BE2A30
+          _sceIoGetstatByFd: 0xE6C53567
+          _sceIoDopen: 0xE6E614B5
+          sceIoGetPriorityForSystem: 0xEF5432ED
+          sceIoDreadAsync: 0xF59F37B0
+          _sceIoMkdirAsync: 0xF5C58B21
+          sceIoGetThreadDefaultPriorityForSystem: 0xFCBCEAED
+          _sceIoRmdir: 0xFFFB4D76
   SceOled:
     nid: 0x5410837A
     libraries:
@@ -2546,14 +2739,14 @@ modules:
         kernel: true
         nid: 0x60C7478A
         functions:
-            ksceOledDisplayOff: 0xBC84602E
-            ksceOledDisplayOn: 0x4C7836C7
-            ksceOledGetBrightness: 0x43EF811A
-            ksceOledGetDDB: 0xC9D5987C
-            ksceOledGetDisplayColorSpaceMode: 0x4F8A1D4A
-            ksceOledSetBrightness: 0xF9624C47
-            ksceOledSetDisplayColorSpaceMode: 0xDABBD9D3
-            ksceOledWaitReady: 0x0CC6BCB4
+          ksceOledDisplayOff: 0xBC84602E
+          ksceOledDisplayOn: 0x4C7836C7
+          ksceOledGetBrightness: 0x43EF811A
+          ksceOledGetDDB: 0xC9D5987C
+          ksceOledGetDisplayColorSpaceMode: 0x4F8A1D4A
+          ksceOledSetBrightness: 0xF9624C47
+          ksceOledSetDisplayColorSpaceMode: 0xDABBD9D3
+          ksceOledWaitReady: 0x0CC6BCB4
   SceProcessmgr:
     nid: 0x8B8A6263
     libraries:
@@ -2589,6 +2782,9 @@ modules:
           sceKernelPowerUnlock: 0x466C0CBD
           sceKernelRegisterProcessTerminationCallback: 0x5EC77870
           sceKernelUnregisterProcessTerminationCallback: 0x973A4527
+          _sceKernelGetTimer5Reg: 0x2F73D72F
+          _sceKernelRegisterLibkernelAddresses: 0x56C2E8FF
+          _sceKernelExitProcessForUser: 0xC053DC6B
       SceProcessmgrForKernel:
         kernel: true
         nid: 0x7A69DE86
@@ -6835,6 +7031,7 @@ modules:
           sceRegMgrSystemParamSetBin: 0xD5A73557
           sceRegMgrSystemParamSetInt: 0xC8F73311
           sceRegMgrSystemParamSetStr: 0xCB3246E3
+          sceRegMgrSystemIsBlueScreen: 0x169A0D1D
       SceRegMgrForSDK:
         kernel: false
         nid: 0x67E45817
@@ -7459,6 +7656,7 @@ modules:
           sceTouchSetRegionAttr: 0x08DD4C7C
           sceTouchSetSamplingState: 0x1B9C5D14
           sceTouchSetSamplingStateExt: 0x13CDFC43
+          sceTouchGetPixelDensity2: 0xE0C1DB92
       SceTouchForDriver:
         kernel: true
         nid: 0xA4A7DAFC
@@ -7920,6 +8118,46 @@ modules:
           ksceSblSsEncryptWithPortability: 0x21EC51F6
           ksceSblSsGetNvsData: 0xFDD6D5DE
           ksceSblSsSetNvsData: 0x249ADB07
+      SceSblDmac5Mgr:
+        nid: 0x437366A2
+        kernel: false
+        functions:
+          sceSblDmac5HashTransform: 0x09EBC6EF
+          sceSblDmac5EncDecKeyGen: 0x5BF4F924
+          sceSblDmac5HmacKeyGen: 0xCCE57D33
+          sceSblDmac5EncDec: 0xD0B1F759
+      SceSblQafMgr:
+        nid: 0x756B7E89
+        kernel: false
+        functions:
+          sceSblQafManagerGetQafNameForUser: 0x0F7EA8C2
+          sceSblQafManagerIsAllowKernelDebugForUser: 0x11D30766
+          sceSblQafManagerSetQafTokenForUser: 0x56A16392
+          sceSblQafMgrDeleteQafToken2: 0x62E30BF4
+          sceSblQafMgrIsAllowForceUpdate: 0x63F29BA0
+          sceSblQafMgrIsAllowAllDebugMenuDisplay: 0x66843305
+          sceSblQafMgrIsAllowNpFullTest: 0x72168C6E
+          sceSblQafMgrIsAllowMinimumDebugMenuDisplay: 0xA156BBD2
+          sceSblQafMgrIsAllowNpTest: 0xA9EBCBAC
+          sceSblQafMgrIsAllowNonQAPup: 0xB5621615
+          sceSblQafMgrGetQafToken: 0xB6BAE81D
+          sceSblQafMgrIsAllowLimitedDebugMenuDisplay: 0xC456212D
+          sceSblQafMgrIsAllowScreenShotAlways: 0xD22A8731
+          sceSblQafManagerDeleteQafTokenForUser: 0xD542583F
+          sceSblQafMgrGetQafToken2: 0xDFBA8569
+          sceSblQafMgrGetQafName: 0xF0CA8766
+          sceSblQafMgrIsAllowRemoteSysmoduleLoad: 0xF45AA706
+          sceSblQafMgrSetQafToken2: 0xF4B5C8A5
+      SceSblAimgr:
+        nid: 0xD473F968
+        kernel: false
+        functions:
+          _sceKernelGetOpenPsId: 0x6E283E2E
+      SceSblRng:
+        nid: 0x1843F124
+        kernel: false
+        functions:
+          _sceKernelGetRandomNumber: 0xC37E818C
   SceSblACMgr:
     nid: 0x7474D6F9
     libraries:
@@ -8251,14 +8489,14 @@ modules:
         kernel: true
         nid: 0xFA916D71
         functions:
-            ksceLcdDisplayOff: 0x1A0A7519
-            ksceLcdDisplayOn: 0x5F4124AB
-            ksceLcdGetBrightness: 0x3A6D6AC3
-            ksceLcdGetDDB: 0xE03E120B
-            ksceLcdGetDisplayColorSpaceMode: 0x17F66722
-            ksceLcdSetBrightness: 0x581D3A87
-            ksceLcdSetDisplayColorSpaceMode: 0xD40968FB
-            ksceLcdWaitReady: 0x0C7E03D8
+          ksceLcdDisplayOff: 0x1A0A7519
+          ksceLcdDisplayOn: 0x5F4124AB
+          ksceLcdGetBrightness: 0x3A6D6AC3
+          ksceLcdGetDDB: 0xE03E120B
+          ksceLcdGetDisplayColorSpaceMode: 0x17F66722
+          ksceLcdSetBrightness: 0x581D3A87
+          ksceLcdSetDisplayColorSpaceMode: 0xD40968FB
+          ksceLcdWaitReady: 0x0C7E03D8
   SceLowio:
     nid: 0x17E0D8DF
     libraries:
@@ -8828,6 +9066,18 @@ modules:
           _sceCodecEngineCloseUnmapMemBlock: 0xAD30912D
           _sceCodecEngineFreeMemoryFromUnmapMemBlock: 0x489FF965
           _sceCodecEngineOpenUnmapMemBlock: 0xB0E654EE
+          _sceCodecEngineChangeNumWorkerCoresMax: 0x04BA9415
+          _sceCodecEnginePmonStop: 0x04D5F36B
+          _sceCodecEngineGetMemoryState: 0x1E9E5A79
+          _sceCodecEngineGetProcessorLoad: 0x241B194B
+          _sceCodecEngineChangeNumWorkerCoresDefault: 0x362E9415
+          _sceCodecEnginePmonGetProcessorLoad: 0x3EBA4982
+          _sceCodecEnginePmonStart: 0x6AF71F08
+          _sceCodecEngineChangeNumWorkerCores: 0x7E5E1F38
+          _sceCodecEngineResetNumRpcCalled: 0x8EFF2DAA
+          _sceCodecEngineGetNumRpcCalled: 0x9B157692
+          _sceCodecEnginePmonReset: 0xCA79BFC4
+          _sceCodecEngineSetClockFrequency: 0xDE5EF6CC
   SceExcpmgr:
     nid: 0xF3D9E37C
     libraries:
@@ -8892,3 +9142,266 @@ modules:
           ksceSdifReadSectorSd: 0xB9593652
           ksceSdifWriteSectorMmc: 0x175543D2
           ksceSdifWriteSectorSd: 0xE0781171
+  SceDeci4pDbgp:
+    nid: 0xC242A649
+    libraries:
+      SceDeci4pDbgpForDriver:
+        nid: 0xFBD04C34
+        kernel: true
+        functions:
+          ksceDbgpGetDTraceBreakpointHandler: 0x01D7C7BF
+          ksceDbgpSetDTraceBreakpointHandler: 0x0509AC51
+          ksceDbgpSetDTraceUsdtHandler: 0x7251789E
+          ksceDbgpGetDTraceUsdtHandler: 0x9CD5EE8C
+  SceFios2Kernel:
+    nid: 0x10ECF2D0
+    libraries:
+      SceFios2Kernel:
+        nid: 0x8757B742
+        kernel: false
+        functions:
+          _sceFiosKernelOverlayDHCloseSync: 0x021B4AF7
+          _sceFiosKernelOverlayAddForProcess: 0x2A381357
+          _sceFiosKernelOverlayDHSyncSync: 0x2A9724C9
+          _sceFiosKernelOverlayDHReadSync: 0x2F06ADC6
+          _sceFiosKernelOverlayThreadSetDisabled: 0x3E9172EA
+          _sceFiosKernelOverlayDHOpenSync: 0x5D6A1CCE
+          _sceFiosKernelOverlayThreadIsDisabled: 0x629F4FE4
+          _sceFiosKernelOverlayModify: 0x6D6CDE05
+          _sceFiosKernelOverlayAdd: 0x6DBCF0B2
+          _sceFiosKernelOverlayModifyForProcess: 0x6DF2FC05
+          _sceFiosKernelOverlayDHStatSync: 0x759EBEE6
+          _sceFiosKernelOverlayResolveWithRangeSync: 0x8CCA471A
+          _sceFiosKernelOverlayGetList: 0x9379E2D5
+          _sceFiosKernelOverlayGetRecommendedScheduler: 0xB02E0B26
+          _sceFiosKernelOverlayRemove: 0xB4927173
+          _sceFiosKernelOverlayGetInfoForProcess: 0xBC6B3CC5
+          _sceFiosKernelOverlayResolveSync: 0xE9AE60FB
+          _sceFiosKernelOverlayGetInfo: 0xF44F3505
+          _sceFiosKernelOverlayDHChstatSync: 0xF6A3E335
+          _sceFiosKernelOverlayRemoveForProcess: 0xF8277E07
+  SceSblGcAuthMgr:
+    nid: 0xDB1A9016
+    libraries:
+      SceSblGcAuthMgr:
+        nid: 0x7B13BCF7
+        kernel: false
+        functions:
+          _sceSblGcAuthMgrPcactActivation: 0x032E7CEA
+          _sceSblGcAuthMgrMsSaveBBCipherInit: 0x064BA38A
+          _sceSblGcAuthMgrAdhocBB160Shutdown: 0x076ADAB3
+          _sceSblGcAuthMgrAdhocBB160UniCastEncrypt: 0x08C4EE5F
+          _sceSblGcAuthMgrAdhocBB160GetKeys: 0x09E1E270
+          _sceSblGcAuthMgrGetMediaIdType01: 0x0AC64154
+          _sceSblGcAuthMgrMsSaveBBCipherFinal: 0x18EAAD73
+          _sceSblGcAuthMgrAdhocBB160BroadCastDecrypt: 0x2193A7CB
+          _sceSblGcAuthMgrPsmactVerifyR1: 0x2B604356
+          _sceSblGcAuthMgrAdhocBB224Auth1: 0x307FD67C
+          _sceSblGcAuthMgrMsSaveBBMacInit: 0x3A92780D
+          _sceSblGcAuthMgrPsmactCreateC1: 0x3BD8B007
+          _sceSblGcAuthMgrPkgVry: 0x3E168BC4
+          _sceSblGcAuthMgrAdhocBB224Auth5: 0x459F5503
+          _sceSblGcAuthMgrAdhocBB224Init: 0x5AB126A7
+          _sceSblGcAuthMgrAdhocBB224Auth4: 0x5CCC216C
+          _sceSblGcAuthMgrAdhocBB160Auth1: 0x5E56F845
+          _sceSblGcAuthMgrAdhocBB160BroadCastEncrypt: 0x6125C3D9
+          _sceSblGcAuthMgrMsSaveBBMacUpdate: 0x716C0C3B
+          _sceSblGcAuthMgrAdhocBB224Auth2: 0x788C0517
+          _sceSblGcAuthMgrAdhocBB160Auth4: 0x7F33DE86
+          _sceSblGcAuthMgrSclkSetData2: 0x837D0FB6
+          _sceSblGcAuthMgrSclkGetData1: 0x8A3AF1E8
+          _sceSblGcAuthMgrAdhocBB224Shutdown: 0x8ECEACF9
+          _sceSblGcAuthMgrPcactGetChallenge: 0x98153286
+          _sceSblGcAuthMgrAdhocBB224GetKeys: 0xC236FB28
+          _sceSblGcAuthMgrAdhocBB160Auth3: 0xD1777A14
+          _sceSblGcAuthMgrAdhocBB160Auth2: 0xD2218A6E
+          _sceSblGcAuthMgrAdhocBB224Auth3: 0xD3F95259
+          _sceSblGcAuthMgrAdhocBB160UniCastDecrypt: 0xD79A1B31
+          _sceSblGcAuthMgrAdhocBB160Auth5: 0xD84C2E0C
+          _sceSblGcAuthMgrAdhocBB160Init: 0xE4AA1BB2
+          _sceSblGcAuthMgrMsSaveBBCipherUpdate: 0xF6FECCE0
+          _sceSblGcAuthMgrMsSaveBBMacFinal: 0xFDDDD1D4
+  SceBbmc:
+    nid: 0x858FDE3E
+    libraries:
+      SceBbmc:
+        nid: 0xEB0B15B7
+        kernel: false
+        functions:
+          sceBbmcVerifyPin: 0x057B2157
+          sceBbmcNetworkScanStart: 0x061AFC8C
+          sceBbmcSMSGetListDone: 0x0A67866B
+          sceBbmcDLQGetCurrentFwDone: 0x118CDC1C
+          sceBbmcIsAbleToRunUnderCurrentVoltage: 0x197B5917
+          sceBbmcUnblockPin: 0x1B1015D0
+          sceBbmcIsAbleToRunUnderCurrentTemp: 0x1BC93FE5
+          sceBbmcDLQConfirmChangePartition: 0x1D381E0E
+          sceBbmcSimGetPLMNModeBit: 0x1F2BECDC
+          sceBbmcSetupSetValue: 0x265332ED
+          sceBbmcSetupGetValueDone: 0x3776D173
+          sceBbmcDLQGetCurrentFwStart: 0x3BB8A8DE
+          sceBbmcSMSReadAck: 0x3D366DF3
+          sceBbmcUsbExtIfWrite: 0x4034E750
+          sceBbmcDLUpdaterGetLatestArchiveVersion: 0x4564777A
+          sceBbmcReadSimContentStart: 0x4734B7EB
+          sceBbmcUsbExtIfStart: 0x4ACC9A83
+          sceBbmcGetNetworkInfo: 0x4BF09F40
+          sceBbmcGetComFirmVersion: 0x4F76ACC2
+          sceBbmcResumeSubscriberCallback: 0x53D836E6
+          sceBbmcDLQGetFwListStart: 0x55DE9889
+          sceBbmcDLUpdaterCheckComVersion: 0x5711AE28
+          sceBbmcDLQRestoreEFSNV: 0x5A3CBF5D
+          sceBbmcGpsCellGetLocationInfoStart: 0x5D5096F2
+          sceBbmcDepersonalizeCK: 0x63318445
+          sceBbmcSMSGetListStart: 0x6669D937
+          sceBbmcDebugSelectOutMedia: 0x72FADFFD
+          sceBbmcDLQBackupEFSNV: 0x73E76F56
+          sceBbmcSMSReadStart: 0x74172AD5
+          sceBbmcEnvelopeCmd: 0x768A8471
+          sceBbmcPacketGetLastCallEndReason: 0x794F5690
+          sceBbmcNetworkAttach: 0x7AC350C7
+          sceBbmcDLUpdaterFin: 0x7CC2E683
+          sceBbmcDebugOutString: 0x80E029FE
+          sceBbmcSMSReadDone: 0x86A4ADE4
+          sceBbmcClearEvent: 0x8A586895
+          sceBbmcGetFileRefreshDetail: 0x8DE4A529
+          sceBbmcReserveOperationMode: 0x8DEDBFE9
+          sceBbmcDLQDownloadSafeImage: 0x8E1E5AAF
+          sceBbmcUsbExtIfRead: 0x91EE6FAB
+          sceBbmcGetIdStorageFrom3GModule: 0x924FD942
+          sceBbmcFileRefreshResponse: 0x9537AAAE
+          sceBbmcGetFailureInfo: 0x9831C17B
+          sceBbmcGpsCellGetLocationInfoDone: 0x98718027
+          sceBbmcDLUpdaterStart: 0xAF066666
+          sceBbmcSMSSend: 0xB2B9BE63
+          sceBbmcDLQDownloadSlotImage: 0xB323A5C4
+          sceBbmcPacketReleasePDPContext: 0xB63E07B2
+          sceBbmcGetDriverInfo: 0xB888B51C
+          sceBbmcPacketIfSetControlFlag: 0xB9C53628
+          sceBbmcSetLPMMode: 0xBCA35FC0
+          sceBbmcDLQGetFwListDone: 0xBD2A2EA8
+          sceBbmcDLUpdaterGetSequence: 0xBDD26F9D
+          sceBbmcPacketIfClearControlFlag: 0xBE889D60
+          sceBbmcPacketIfGetControlFlag: 0xBF18905C
+          sceBbmcDLUpdaterContinue: 0xC10A5913
+          sceBbmcGetProactiveCmd: 0xC3910F00
+          sceBbmcNetworkScanDone: 0xC4639A16
+          sceBbmcUnblockCK: 0xC70DF0B8
+          sceBbmcSetupGetValueStart: 0xC946287D
+          sceBbmcDLGetSwdlError: 0xCF5593A1
+          sceBbmcIsPowerConfigForbiddenMode: 0xD31680C9
+          sceBbmcUnsubscribeFeature: 0xD4C16C0A
+          sceBbmcTerminalResponseCmd: 0xD878F761
+          sceBbmcDLUpdaterGetPkgId: 0xDCD146FD
+          sceBbmcSubscribeFeatureId: 0xE13ACE9A
+          sceBbmcNetGetRejectCause: 0xE794FCE6
+          sceBbmcReadSimContentDone: 0xE8471E88
+          sceBbmcGetPinStatus: 0xE8CB543C
+          sceBbmcNetworkScanAbort: 0xE9548598
+          sceBbmcPacketGetCurrentBearerTech: 0xEAAEC538
+          sceBbmcDLUpdaterGetArchiveVersion: 0xEE284EBE
+          sceBbmcTurnOff: 0xEE731598
+          sceBbmcTurnOn: 0xF1B7B34C
+          sceBbmcUsbExtIfStop: 0xF82F293A
+          sceBbmcDLQAbort: 0xFD1B5B45
+          sceBbmcGetCKStatus: 0xFFB454D9
+  SceUlobjMgr:
+    nid: 0xAC99A848
+    libraries:
+      SceUlobjMgr:
+        nid: 0xDB18BB68
+        kernel: false
+        functions:
+          _sceUlobjMgrStartSupportingUserlevelObject: 0x08769991
+          _sceUlobjMgrRegisterLibultProtocolRevision: 0x50F2F2AA
+          _sceUlobjMgrStopSupportingUserlevelObject: 0xEF09284B
+  SceGps:
+    nid: 0x7ECD5642
+    libraries:
+      SceGps:
+        nid: 0x0B6F33FE
+        kernel: false
+        functions:
+          _sceGpsResumeCallback: 0x0A4882B3
+          _sceGpsIsDevice: 0x0EE1BC7B
+          _sceGpsStart: 0x2914F243
+          _sceGpsSelectDevice: 0x2D4D8788
+          _sceGpsOpen: 0x6EAC2C6D
+          _sceGpsClose: 0x73EE0ED1
+          _sceGpsGetDeviceInfo: 0x7F1DFADB
+          _sceGpsGetData: 0x9BAF9579
+          _sceGpsIoctl: 0xB11E674D
+          _sceGpsGetState: 0xB8001499
+          _sceGpsStop: 0xE1ABB52D
+  ScePamgr:
+    nid: 0xA6771119
+    libraries:
+      ScePamgr:
+        nid: 0xAB606F3F
+        kernel: false
+        functions:
+          sceKernelPaGetTraceBufferSize: 0x0DD84F31
+          _sceKernelPaAddBusTraceByKey: 0x0F05045B
+          _sceKernelPaAddGpuTraceByKey: 0x174F2500
+          sceKernelPaRemoveCounterTraceByKey: 0x1FDDEBF0
+          sceKernelPaStartByKey: 0x28D43BE5
+          _sceKernelPaAddArmTraceByKey: 0x2CB10FD0
+          sceKernelPaUnregister: 0x2DE1E55C
+          sceKernelPaRemoveGpuTraceByKey: 0x300258EE
+          sceKernelPaGetSharedKey: 0x30043A1F
+          _sceKernelPaGetGpuSampledData: 0x39096D8F
+          sceKernelPaGetTimebaseValue: 0x3FD2C5F5
+          sceKernelPaInsertBookmark: 0x53B16517
+          sceKernelPaRegisterShared: 0x556105AA
+          _sceKernelPaAddCounterTraceByKey: 0x5F050AAF
+          sceKernelPaGetTraceBufferStatus: 0x78B19CDE
+          sceKernelPerfArmPmonReset: 0x7B9CF258
+          _sceKernelPaSetupTraceBufferByKey: 0x7BD1B4A3
+          sceKernelPerfArmPmonOpen: 0x7F5A960E
+          sceKernelPaRegister: 0x822E0719
+          sceKernelPaStopByKey: 0x8252E671
+          sceKernelPerfArmPmonSelectEvent: 0x9E55649C
+          sceKernelPerfArmPmonStop: 0xA42BDD17
+          sceKernelPaGetIoBaseAddress: 0xA4EE9025
+          sceKernelPerfArmPmonStart: 0xAAE516BC
+          sceKernelPaRemoveBusTraceByKey: 0xBFE73BEB
+          sceKernelPerfArmPmonClose: 0xC9F72613
+          sceKernelPaGetWritePointer: 0xCA0D64C8
+          sceKernelPaGetTimebaseFrequency: 0xCAEE6AF2
+          sceKernelPaRemoveArmTraceByKey: 0xDD4D0A27
+          sceKernelPaSetBookmarkChannelEnableByKey: 0xF8D02FF4
+          sceKernelPerfArmPmonSetCounterValue: 0xFC954C07
+  SceUsbServ:
+    nid: 0xAE54F579
+    libraries:
+      SceUsbServ:
+        nid: 0xDA3C0EF0
+        kernel: false
+        functions:
+          sceUsbServAccessoryDeactivate: 0x154246A9
+          sceUsbServAccessoryActivate: 0xB33AA2EB
+  SceWlanBt:
+    nid: 0x99052D93
+    libraries:
+      SceWlan:
+        nid: 0x22821EA3
+        kernel: false
+        functions:
+          sceWlanGetWakeOnTargetProcess: 0x18E6AFB2
+          sceWlanGetConfiguration: 0x70AF9BD6
+          sceWlanUnregisterCallback: 0x826DC04F
+          sceWlanRegisterCallback: 0xAA2E46F6
+          sceWlanSetConfiguration: 0xDBE8AEF2
+  SceError:
+    nid: 0x8713337B
+    libraries:
+      SceError:
+        nid: 0x5CD2CAD1
+        kernel: false
+        functions:
+          _sceErrorHistoryUpdateSequenceInfo: 0x6FBE4BDC
+          _sceErrorHistoryPostError: 0x70F9D872
+          _sceErrorGetExternalString: 0x85747003
+          _sceErrorHistorySetDefaultFormat: 0xB94DAA2F
+          _sceErrorHistoryClearError: 0xC88F479E
+          _sceErrorHistoryGetError: 0xF16DF981

--- a/db.yml
+++ b/db.yml
@@ -39,6 +39,28 @@ modules:
           ksceAppMgrSystemParamDateTimeSetConf: 0xA9AA3A68
           ksceAppMgrUmount: 0xA714BB35
           ksceAppMgrUpdateRifInfo: 0x894BDCB8
+          ksceAppMgrAppDataMountById: 0x5E311F71
+          ksceAppMgrAppDataMount: 0xB1D3C287
+          ksceAppMgrAppMount: 0xEF0C9533
+          ksceAppMgrAppUmount: 0x1DE3B7C4
+          ksceAppMgrDrmClose: 0x088670A6
+          ksceAppMgrDrmOpen: 0xEA75D157
+          ksceAppMgrGetBootParam: 0xD2541B4A
+          ksceAppMgrMmsMount: 0x13D54107
+          ksceAppMgrPhotoMount: 0x43A35729
+          ksceAppMgrSaveDataGetQuota: 0xE104C37E
+          ksceAppMgrSaveDataMount: 0xE73C9516
+          ksceAppMgrSaveDataSlotCreate: 0xE6F389B8
+          ksceAppMgrSaveDataSlotDelete: 0xB544F2A0
+          ksceAppMgrSaveDataSlotGetParam: 0xD137D486
+          ksceAppMgrSaveDataSlotGetStatus: 0xEC9D5A35
+          ksceAppMgrSaveDataSlotInit: 0x2277F736
+          ksceAppMgrSaveDataSlotSetParam: 0x7E247E47
+          ksceAppMgrSaveDataSlotSetStatus: 0x9ADB00FA
+          ksceAppMgrSaveDataUmount: 0x2B080268
+          ksceAppMgrTrophyMount: 0xE977A833
+          ksceAppMgrWorkDirMount: 0x3A0A9B82
+          ksceAppMgrAppParamGetInt: 0x12CE29F7
       SceAppMgr:
         kernel: false
         nid: 0x8AF17416
@@ -378,6 +400,10 @@ modules:
           sceAppMgrUpdateSaveDataParam: 0x1B0BD20D
           sceAppMgrWorkDirMount: 0x9B3BB24D
           sceAppMgrWorkDirMountById: 0x80E86E42
+          sceAppMgrGetUserDirPathById: 0x63E51420
+          sceAppMgrSaveDataDataRemove2: 0x36040E1D
+          sceAppMgrSaveDataDataSave2: 0xD5CA4F56
+          sceAppMgrThemeDataMount: 0x633A7594
   SceAppUtil:
     nid: 0xCE3E25D4
     libraries:
@@ -436,12 +462,25 @@ modules:
         nid: 0xE96B941B
         functions:
           sceAppUtilCacheMount: 0x0AA56143
+          sceAppUtilCacheUmount: 0x72D26BF4
+          sceAppUtilCacheGetDevInfo: 0x1171B736
       SceAppUtilExt:
         kernel: false
         nid: 0x76D1A509
         functions:
           sceAppUtilExtVideoMount: 0xA0380CF7
           sceAppUtilExtVideoUmount: 0x02E1E2C4
+      SceAppUtilBook:
+        nid: 0xDA27A9D3
+        kernel: true
+        functions:
+          ksceAppUtilBookMount: 0xFDAAF091
+          ksceAppUtilBookUmount: 0x9C1794C2
+      SceAppUtilAddcontForce:
+        nid: 0x9D061921
+        kernel: true
+        functions:
+          ksceAppUtilAddcontForceAddcontMount: 0x6087E5F7
   SceAtrac:
     nid: 0x738129ED
     libraries:
@@ -796,6 +835,11 @@ modules:
           sceCameraGetImageQuality: 0xE2AC7BCE
           sceCameraSetNoiseReduction: 0xF9B79556
           sceCameraGetNoiseReduction: 0xFEB99ACC
+      SceCameraForDriver:
+        nid: 0xBCBC1F4A
+        kernel: true
+        functions:
+          ksceCameraIsActive: 0xEB1CC2CA
   SceClipboard:
     nid: 0xB4042D2E
     libraries:
@@ -981,6 +1025,23 @@ modules:
         nid: 0x2646E9D8
         functions:
           sceCoredumpWriteUserData: 0xDF335DCF
+      SceCoredumpForDriver:
+        nid: 0xA351714A
+        kernel: true
+        functions:
+          ksceCoredumpCafContextCreate: 0x2964AD0A
+          ksceCoredumpCafContextDestroy: 0x95402BF3
+          ksceCoredumpCafCreateIv: 0xE1BCBE8F
+          ksceCoredumpCafFinal: 0xC90F61AF
+          ksceCoredumpCafHeaderFinal: 0x65AA4991
+          ksceCoredumpCafHeaderInit: 0x7C8120C5
+          ksceCoredumpCafHeaderTransform: 0xAE2C2793
+          ksceCoredumpCafInit: 0x9336009B
+          ksceCoredumpCafSegmentFinal: 0xDF17420A
+          ksceCoredumpCafSegmentInit: 0x07185515
+          ksceCoredumpCafSegmentTransform: 0xFB7AEBFE
+          ksceCoredumpCreateDump: 0x0C10313F
+          ksceCoredumpDeleteCrashReportCaf: 0xAD070837
   SceCtrl:
     nid: 0x3BAF0220
     libraries:
@@ -2026,6 +2087,62 @@ modules:
           ksceKernelUidRelease: 0x149885C4
           ksceKernelUidRetain: 0x0F5C84B7
           ksceKernelUnmapMemBlock: 0xFFCD9B60
+          ksceKernelAllocHeapMemoryFromGlobalHeap: 0x7750CEA7
+          ksceKernelAllocHeapMemoryFromGlobalHeapWithOpt: 0x0B4ED16A
+          ksceKernelAllocHeapMemoryWithOpt1: 0xB415B5A8
+          ksceKernelAllocMemBlockWithInfo: 0xD44F464D
+          ksceKernelCreateUidObj: 0x56A13E90
+          ksceKernelCreateUidObjForUid: 0x89A44858
+          ksceKernelCreateUserUidForClass: 0xCED1547B
+          ksceKernelCreateUserUidForName: 0x513B9DDD
+          ksceKernelCreateUserUidForNameWithClass: 0x8DA0BCA5
+          ksceKernelFindMemBlockByAddrForDefaultSize: 0xF3BBE2E1
+          ksceKernelFindMemBlock: 0x9C78064C
+          ksceKernelFindMemBlockForPid: 0x9F6E45E3
+          ksceKernelFirstDifferentBlock32User: 0xBDA6E42B
+          ksceKernelFirstDifferentBlock64User: 0xBB3B02C2
+          ksceKernelFirstDifferentBlock64UserForPid: 0xE83855FD
+          ksceKernelFreeHeapMemoryFromGlobalHeap: 0xFB817A59
+          ksceKernelGetClassForPidForUid: 0xE9728A12
+          ksceKernelGetClassForUid: 0xC74B0152
+          ksceKernelGetMemBlockPARange: 0x98C15666
+          ksceKernelGetMemBlockVBase: 0xB81CF0A3
+          ksceKernelGetMemBlockMappedBase: 0x0B1FD5C3
+          ksceKernelGetMemBlockPaddrListForUid: 0x19A51AC7
+          ksceKernelGetNameForPidByUid: 0x09896EB7
+          ksceKernelGetNameForUid2: 0xE655852F
+          ksceKernelGetNameForUid: 0xA78755EB
+          ksceKernelGetObjectForPidForUid: 0xFE6D7FAE
+          ksceKernelGetObjectForUidForAttr: 0xF6DB54BA
+          ksceGUIDReferObjectWithClassLevel: 0x77066FD1
+          ksceKernelGetObjectForUidForClassTree: 0x72A98D17
+          ksceKernelGUIDGetObject: 0x0FC24464
+          ksceKernelProcModeVAtoPA: 0x61A67D32
+          ksceKernelGetPaddrListForLargePage: 0x08A8A7E8
+          ksceKernelGetPaddrListForSmallPage: 0x16844CE6
+          ksceKernelGetPaddrPair: 0xAE36C775
+          ksceKernelGetPaddrPairForLargePage: 0x32257A24
+          ksceKernelGetPaddrPairForSmallPage: 0xB3575090
+          ksceKernelAddressSpaceVAtoPABySW: 0x65419BD3
+          ksceKernelGetUnknownValidPhysAddressSpace: 0xC9928F5E
+          ksceKernelIsPaddrWithinSameSectionForUid: 0xF4AD89D8
+          ksceKernelIsPaddrWithinUnknownValidPhysAddressSpace: 0xA7C0D1FC
+          ksceKernelKernelUidForUserUidForClass: 0x184172B1
+          ksceKernelMapBlockUserVisibleWithFlag: 0x04059C4B
+          ksceKernelMemBlockDecRefCounterAndReleaseUid: 0xF50BDC0C
+          ksceKernelMemBlockGetInfoEx: 0x24A99FFF
+          ksceKernelMemBlockGetInfoExForVisibilityLevel: 0xA73CFFEF
+          ksceKernelMemBlockGetSomeSize: 0x78337B62
+          ksceKernelMemBlockIncRefCounterAndReleaseUid: 0xEAF3849B
+          ksceKernelMemBlockType2Memtype: 0x20C811FA
+          ksceKernelMemBlockTypeGetPrivileges: 0x6A0792A3
+          ksceKernelMemBlockTypeGetUnknown: 0xCB0F3A33
+          ksceKernelMemcpyUserToUser: 0x1BD44DD5
+          ksceKernelOpenUidForName: 0xD76E7452
+          ksceKernelSetNameForPidForUid: 0x12624884
+          ksceKernelSetObjectForUid: 0x4CFA4100
+          ksceKernelSwitchPidContext: 0x2D711589
+          ksceKernelGetPhysicalMemoryType: 0x0AAA4FDD
       SceSysmemForKernel:
         kernel: true
         nid: 0x63A519E5
@@ -2042,6 +2159,19 @@ modules:
           ksceKernelNameHeapGetInfo: 0xE443253B
           ksceKernelRxMemcpyKernelToUserForPid: 0x30931572
           ksceKernelUIDEntryHeapGetInfo: 0x686AA15C
+          ksceKernelAllocSystemCallTable: 0x5FFE4B79
+          ksceKernelGetHeapInfo: 0x91733EF4
+          ksceKernelFreeSimpleMemBlock: 0xA1FFA2C9
+          ksceKernelSysrootAlloc: 0xC0A4D2F3
+          ksceGUIDGetObjectWithClass: 0x7ABFA9A7
+          ksceGUIDKernelCreateWithAttr: 0x53E1FFDE
+          ksceGUIDOpenByGUID: 0xCF53EEE4
+          ksceKernelCreateAddressSpace: 0x4A3737F0
+          ksceKernelDeleteAddressSpace: 0xF2D7FE3A
+          ksceKernelAddressSpaceFreeAllMemBlock: 0x89CE1F31
+          ksceKernelAddressSpaceSetPhyMemPart: 0x67955EE9
+          ksceKernelAddressSpaceUnmap: 0xCE72839E
+          ksceKernelAddressSpaceVAtoPA: 0xF2179820
       SceSysclibForDriver:
         kernel: true
         nid: 0x7EE45391
@@ -2091,6 +2221,20 @@ modules:
           ksceKernelCpuRestoreContext: 0x0A4F0FB9
           ksceKernelCpuSaveContext: 0x211B89DA
           ksceKernelCpuUnrestrictedMemcpy: 0x8C683DEC
+          ksceKernelCpuGetCONTEXTIDR: 0x5B6B3274
+          ksceKernelCpuUpdateSCTLR: 0x04008CF7
+          ksceKernelCpuBranchPredictorInvalidateAllIS: 0x1BB2BB8D
+          ksceKernelCpuBranchPredictorInvalidateAll: 0x4C4C7D6B
+          ksceKernelCpuDcacheInvalidateMVAC: 0x470EAE1E
+          ksceKernelCpuDcacheInvalidateMVACRange: 0x583F30D1
+          ksceKernelCpuDcacheCleanMVAC: 0xF7159B55
+          ksceKernelCpuDcacheCleanMVACRange: 0xC5C1EE4E
+          ksceKernelCpuDcacheCleanInvalidateMVAC: 0xC8E8C9E9
+          ksceKernelCpuIcacheInvalidateAllU: 0xAEE0B489
+          ksceKernelCpuPreloadEngineKill: 0xD0D85FF8
+          ksceKernelMMUVAtoPAWithMode: 0x67343A07
+          ksceKernelCpuGetPaddr: 0x2A46E800
+          ksceKernelCpuForKernel_9B8173F4: 0x9B8173F4
       SceCpuForDriver:
         kernel: true
         nid: 0x40ECDB0E
@@ -2107,11 +2251,108 @@ modules:
           ksceKernelCpuSpinLockIrqRestore: 0x740A0750
           ksceKernelCpuSpinLockIrqSave: 0xEC53D007
           ksceKernelCpuSuspendIntr: 0xD32ACE9E
+          ksceKernelCpuAtomicAddAndGet8: 0x1E850481
+          ksceKernelCpuAtomicAddAndGet16: 0x59F74E94
+          ksceKernelCpuAtomicAddAndGet32: 0x5F6A8743
+          ksceKernelCpuAtomicAddAndGet64: 0x4E459A03
+          ksceKernelCpuAtomicAddUnless8: 0x5CC62CEC
+          ksceKernelCpuAtomicAddUnless16: 0x0F84AFE9
+          ksceKernelCpuAtomicAddUnless32: 0x1F157DC3
+          ksceKernelCpuAtomicAddUnless64: 0x06CCFA4B
+          ksceKernelCpuAtomicAndAndGet8: 0x32B62B1A
+          ksceKernelCpuAtomicAndAndGet16: 0xB281D52A
+          ksceKernelCpuAtomicAndAndGet32: 0xDF899E4B
+          ksceKernelCpuAtomicAndAndGet64: 0xD18E7B54
+          ksceKernelCpuAtomicClearAndGet8: 0x8E538AB5
+          ksceKernelCpuAtomicClearAndGet16: 0x6B050D7C
+          ksceKernelCpuAtomicClearAndGet32: 0x78C1F148
+          ksceKernelCpuAtomicClearAndGet64: 0x2149CD4C
+          ksceKernelCpuAtomicClearMask8: 0x1B3336B0
+          ksceKernelCpuAtomicClearMask16: 0x1BE58599
+          ksceKernelCpuAtomicClearMask32: 0x4AE1BCC0
+          ksceKernelCpuAtomicClearMask64: 0x55760309
+          ksceKernelCpuAtomicCompareAndSet8: 0x3627F4E0
+          ksceKernelCpuAtomicCompareAndSet16: 0x6F63F56D
+          ksceKernelCpuAtomicCompareAndSet32: 0xCDA96E81
+          ksceKernelCpuAtomicCompareAndSet64: 0x4B527009
+          ksceKernelCpuAtomicDecIfPositive8: 0x45153D4E
+          ksceKernelCpuAtomicDecIfPositive16: 0x9A693F5B
+          ksceKernelCpuAtomicDecIfPositive32: 0x2A71B03C
+          ksceKernelCpuAtomicDecIfPositive64: 0x267D0B33
+          ksceKernelCpuAtomicGetAndAdd8: 0xFCDCD4DE
+          ksceKernelCpuAtomicGetAndAdd16: 0x225DF91A
+          ksceKernelCpuAtomicGetAndAdd32: 0x341B6E81
+          ksceKernelCpuAtomicGetAndAdd64: 0x043FD446
+          ksceKernelCpuAtomicGetAndAnd8: 0xD8E675C0
+          ksceKernelCpuAtomicGetAndAnd16: 0x4A820BC5
+          ksceKernelCpuAtomicGetAndAnd32: 0x10EB35EB
+          ksceKernelCpuAtomicGetAndAnd64: 0x18A17E07
+          ksceKernelCpuAtomicGetAndClear8: 0x382D1466
+          ksceKernelCpuAtomicGetAndClear16: 0x8E9C086D
+          ksceKernelCpuAtomicGetAndClear32: 0xE36F3A46
+          ksceKernelCpuAtomicGetAndClear64: 0x88BA6002
+          ksceKernelCpuAtomicGetAndOr8: 0xBDF6F8E4
+          ksceKernelCpuAtomicGetAndOr16: 0x004F09D1
+          ksceKernelCpuAtomicGetAndOr32: 0x2A40BB93
+          ksceKernelCpuAtomicGetAndOr64: 0xCB73D6D5
+          ksceKernelCpuAtomicGetAndSet8: 0x29599FC8
+          ksceKernelCpuAtomicGetAndSet16: 0x085532C8
+          ksceKernelCpuAtomicGetAndSet32: 0x0EE04C03
+          ksceKernelCpuAtomicGetAndSet64: 0xD2DEE625
+          ksceKernelCpuAtomicGetAndSub8: 0x7B43D0D7
+          ksceKernelCpuAtomicGetAndSub16: 0x3EE9B5B8
+          ksceKernelCpuAtomicGetAndSub32: 0xF891CF2A
+          ksceKernelCpuAtomicGetAndSub64: 0xA7585370
+          ksceKernelCpuAtomicGetAndXor8: 0xBAF47F7B
+          ksceKernelCpuAtomicGetAndXor16: 0x711801E6
+          ksceKernelCpuAtomicGetAndXor32: 0x77E34309
+          ksceKernelCpuAtomicGetAndXor64: 0xE212ECAD
+          ksceKernelCpuAtomicOrAndGet8: 0x5D515F1B
+          ksceKernelCpuAtomicOrAndGet16: 0xADD39B84
+          ksceKernelCpuAtomicOrAndGet32: 0xBC248C30
+          ksceKernelCpuAtomicOrAndGet64: 0x3E218AF7
+          ksceKernelCpuAtomicSet8: 0x0836537E
+          ksceKernelCpuAtomicSet16: 0x532CA3E8
+          ksceKernelCpuAtomicSet32: 0x3168BC57
+          ksceKernelCpuAtomicSet64: 0xC381CE8C
+          ksceKernelCpuAtomicSetIfGreaterGet8: 0xC3868071
+          ksceKernelCpuAtomicSetIfGreaterGet16: 0x875B094D
+          ksceKernelCpuAtomicSetIfGreaterGet32: 0x26F71995
+          ksceKernelCpuAtomicSubAndGet8: 0xEB085370
+          ksceKernelCpuAtomicSubAndGet16: 0x515682C9
+          ksceKernelCpuAtomicSubAndGet32: 0xA4884C4E
+          ksceKernelCpuAtomicSubAndGet64: 0xB5F8919C
+          ksceKernelCpuAtomicXorAndGet8: 0x03887992
+          ksceKernelCpuAtomicXorAndGet16: 0x646003D6
+          ksceKernelCpuAtomicXorAndGet32: 0x4244BE65
+          ksceKernelCpuAtomicXorAndGet64: 0x692C51B3
+          ksceKernelCpuDcacheAndL2CleanInvalidateMVACRange_20: 0xE551F99B
+          ksceKernelCpuIsVaddrMapped: 0x337CBDF3
+          ksceKernelCpuLockStoreLR: 0xBF82DEB2
+          ksceKernelCpuTryLockStoreLR: 0x5AC9D394
+          ksceKernelCpuUnlockStoreLR: 0xD6ED0C46
+          ksceKernelCpuLockStoreFlag: 0x3F42B434
+          ksceKernelCpuTryLockStoreFlag: 0x4F7790B4
+          ksceKernelCpuUnlockStoreFlag: 0xCB8ABDF0
+          ksceKernelCpuTryLockSuspendIntrStoreLR: 0x27C0B340
+          ksceKernelCpuLockSuspendIntrStoreFlag: 0x4C38CE4D
+          ksceKernelCpuTryLockSuspendIntrStoreFlag: 0xDE6482C6
+          ksceKernelCpuUnlockResumeIntrStoreFlag: 0x9EC91017
+          ksceKernelCpuSpinLockStoreLR: 0xCAC9AE80
+          ksceKernelCpuTrySpinLockStoreLR: 0x093925BD
+          ksceKernelCpuSpinUnlockStoreLR: 0xF5FD5676
+          ksceKernelCpuTrySpinLockSuspendIntrStoreLR: 0xF02467D1
       SceSysrootForDriver:
         kernel: true
         nid: 0x2ED7F97A
         functions:
           ksceKernelSysrootGetSystemSwVersion: 0x67AAB627
+          ksceSysrootGetHardwareInfo: 0x930B1342
+          ksceSysrootUtMgrHasNpTestFlag: 0xA43599E9
+          ksceKernelInvokeInitCallback: 0x93CD44CD
+          ksceKernelSysrootCoredumpTrigger: 0xCD8CD242
+          ksceKernelSysrootGetShellPid: 0x05093E7B
+          ksceKernelSysrootSetSystemSwVersion: 0x3276086B
       SceSysrootForKernel:
         kernel: true
         nid: 0x3691DA45
@@ -2129,6 +2370,36 @@ modules:
           ksceSysrootIsUsbEnumWakeup: 0x79C9AE10
           ksceSysrootUseExternalStorage: 0x55392965
           ksceSysrootUseInternalStorage: 0x50FE3B4D
+          ksceKernelSysrootGetSharedMemory: 0xC8C8C321
+          ksceKernelSysrootGetPUIDEntryHeap: 0x88DE85EF
+          ksceKernelSysrootGetStatus: 0x5C426B19
+          ksceKernelSysrootIofilemgrStart: 0xF6A6D205
+          ksceKernelSysrootGetCurrentUIDEntryHeapCB: 0xB4C24588
+          ksceKernelSysrootGetCurrentAddressSpaceCB: 0x63EBB05B
+          ksceKernelSysrootAppMgrSpawnProcess: 0x3ACACD22
+          ksceSysrootGetNidName: 0x0B79E220
+          ksceSysrootGetModuleInfoForPid: 0xFF9F80FF
+          ksceKernelSysrootGetVbaseResetVector: 0xCC85905B
+          ksceSysrootGetFactorySystemSwVersion: 0xD3872270
+          ksceSysrootGetUnkC: 0xFFD6E24D
+          ksceSysrootGetUnk10: 0x403B509E
+          ksceSysrootGetUnkC0: 0xAB3CC7D0
+          ksceSysrootGetWakeupFactor: 0x2F97041A
+          ksceSysrootGetSessionId: 0x84783B71
+          ksceKernelIsSomeBootMode: 0x7B7F8171
+          ksceKernelIsColdBoot: 0xD7198963
+          ksceSysrootIsSomeBootMode2: 0x7918D44E
+          ksceSysrootIsSomeMode: 0xAE7A8F1D
+          ksceSysrootIsUnknownReboot: 0xE4EA1960
+          ksceSysrootRegisterLicMgrGetLicenseStatus: 0x71DB83A2
+          ksceKernelSysrootGetThreadAccessLevel: 0x20009397
+          ksceKernelAllocHeapMemory: 0xD351EBC8
+          ksceKernelSysrootGetModulePrivate: 0x37EC12BB
+          ksceKernelSysrootSetSysroot: 0x36916C30
+          ksceKernelSysrootProcessmgrStart2: 0x62E8F511
+          ksceKernelSysrootDbgpSuspendProcessAndWaitResume: 0x256B2394
+          ksceKernelSysrootIsUserModeThread: 0x7FC7A163
+          ksceKernelSysrootCheckRemapCodeForUser: 0xF8769E86
       SceKernelSuspendForDriver:
         kernel: true
         nid: 0x7290B21C
@@ -2175,6 +2446,13 @@ modules:
           ksceSblAimgrIsTest: 0x3B638885
           ksceSblAimgrIsTool: 0x274663A0
           ksceSblAimgrIsVITA: 0x4273B97B
+          ksceSblAIMgrGetProductSubCode: 0xB33CEC8F
+          ksceSblAIMgrIsJapaneseFat: 0x6D5A3FC9
+          ksceSblAIMgrIsToolRev3: 0xBB9D146B
+          ksceSblAIMgrIsToolRev4: 0x37A79140
+          ksceSblAIMgrIsToolRev5: 0xE5E47FF7
+          ksceSblAIMgrIsPrototypeRev2: 0xFF5784B9
+          ksceSblAIMgrIsPrototypeRev7: 0x05F79D4A
       SceQafMgrForDriver:
         kernel: true
         nid: 0x4E29D3B6
@@ -2233,6 +2511,8 @@ modules:
           ksceZlibDecompress: 0x900148DB
           ksceZlibGetCompressedData: 0x01EB6C45
           ksceZlibGetInfo: 0x5B9BCD75
+          ksceMt19937GlobalInit: 0xD428CC2A
+          ksceMt19937GlobalUninit: 0x875B2A1C
       SceDebugForDriver:
         kernel: true
         nid: 0x88758561
@@ -2260,6 +2540,26 @@ modules:
           ksceUartRead: 0x9BBF1255
           ksceUartReadAvailable: 0x38DB7629
           ksceUartWrite: 0x41973874
+      ScePmMgrForDriver:
+        nid: 0xF13F32F9
+        kernel: true
+        functions:
+          kscePmMgrGetProductMode: 0x2AC815A2
+          kscePmMgrIsExternalBootMode: 0xBD1F193B
+      SceProcEventForDriver:
+        nid: 0x887F19D0
+        kernel: true
+        functions:
+          ksceKernelUnregisterProcEventHandler: 0x3DED57CC
+          ksceKernelRegisterProcEventHandler: 0x2A43912D
+          ksceKernelInvokeProcEventHandler: 0x414CC813
+      SceDebugLedForDriver:
+        nid: 0x7BC05EAD
+        kernel: true
+        functions:
+          ksceKernelSetGPI: 0x51C5325A
+          ksceKernelGetGPO: 0x3BB289F7
+          ksceKernelSetGPOMask: 0x098473B0
   SceKernelThreadMgr:
     nid: 0xF46ED7B2
     libraries:
@@ -2350,6 +2650,13 @@ modules:
           ksceKernelWaitThreadEnd: 0x3E20216F
           ksceKernelWaitThreadEndCB: 0x9EF4F62C
           ksceKernelLockMutexCB_089: 0xD06F2886
+          ksceKernelChangeCurrentThreadAttr: 0x751C9B7A
+          ksceKernelGetThreadInfo: 0x283807E2
+          ksceKernelReceiveMsgPipeVector: 0xDA1F256B
+          ksceKernelReceiveMsgPipeVectorCB: 0xDA5C9AC6
+          ksceKernelChangeThreadCpuAffinityMask: 0x6D0733A8
+          ksceKernelGetProcessIdFromTLS: 0xFA54D49A
+          ksceKernelRegisterTimer: 0xC58DF384
       SceThreadmgrForKernel:
         kernel: true
         nid: 0xA8CA0EFD
@@ -2531,6 +2838,7 @@ modules:
           _sceKernelWaitEventFlag: 0xFCE2F728
           _sceKernelGetLwMutexInfoById: 0xFEC9E946
           _sceKernelSetTimerTime: 0xFF738CD9
+          sceKernelGetThreadCpuAffinityMask: 0xF1AE5654
       SceThreadmgrCoredumpTime:
         kernel: false
         nid: 0x5E8D0E22
@@ -2539,6 +2847,8 @@ modules:
       SceCpu:
         kernel: false
         nid: 0x45265161
+        functions:
+          sceKernelCpuGetCpuId: 0x2704CFEE
       SceDebugLed:
         kernel: false
         nid: 0xAE004C0A
@@ -2559,6 +2869,7 @@ modules:
           ksceKernelCheckDipsw: 0xA98FC2FD
           ksceKernelClearDipsw: 0xF1F3E9FE
           ksceKernelSetDipsw: 0x82E45FBF
+          ksceKernelGetDipswInfo: 0xB2AD48BE
   SceKernelModulemgr:
     nid: 0x726C6635
     libraries:
@@ -2584,6 +2895,10 @@ modules:
           ksceKernelStopModuleForPid: 0x7BB4CE54
           ksceKernelUmountBootfs: 0x9C838A6B
           ksceKernelUnloadModuleForPid: 0x5972E2CC
+          ksceKernelLoadPtLoadSegForFwloader: 0x448810D5
+          ksceKernelFinalizeKbl: 0xFDD7F646
+          ksceKernelRegisterSyscall: 0xB427025E
+          ksceKernelUnloadProcessModules: 0x0E33258E
       SceModulemgrForDriver:
         kernel: true
         nid: 0xD4A60A52
@@ -2599,6 +2914,9 @@ modules:
           ksceKernelStopUnloadModule: 0x03B30B7E
           ksceKernelStopUnloadModuleForPid: 0x49A3EDC7
           ksceKernelUnloadModule: 0x728E72A6
+          ksceKernelRegisterLibary: 0x861638AD
+          ksceKernelReleaseLibary: 0x0975B104
+          ksceKernelStopUnloadSharedModuleForPid: 0x02D3D0C1
       SceModulemgr:
         kernel: false
         nid: 0xEAED1616
@@ -2624,6 +2942,11 @@ modules:
         kernel: false
         functions:
           _sceKernelBacktrace: 0xBF371A98
+      SceBacktraceForDriver:
+        nid: 0x77CB3DD6
+        kernel: true
+        functions:
+          ksceKernelBacktrace: 0x166B9C8C
   SceIofilemgr:
     nid: 0x9642948C
     libraries:
@@ -2665,10 +2988,63 @@ modules:
           ksceIoSetProcessDefaultPriorityForSystem: 0xABE65071
           ksceIoSync: 0xDDF78594
           ksceIoSyncByFd: 0x338DCD68
+          ksceIoSyncByFd2: 0x43170575
           ksceIoSyncByFdAsync: 0x041209CF
           ksceIoUmount: 0x20574100
           ksceIoWrite: 0x21EE91F0
           ksceIoWriteAsync: 0xA1BD13D0
+          ksceVopIoctl: 0x333C904D
+          ksceVopGetstat: 0x50A63ACF
+          ksceVopOpen: 0x76B79BEC
+          ksceVopCreate: 0x9E347C7D
+          ksceVopClsoe: 0x40944C2E
+          ksceVopRead: 0x570388A5
+          ksceVopWrite: 0x9A68378D
+          ksceVopPread: 0xABBC80E3
+          ksceVopPwrite: 0xA53C040D
+          ksceVopLseek: 0xB2B13818
+          ksceVopMkdir: 0x2F3F8C70
+          ksceVopRmdir: 0x1D551105
+          ksceVopDopen: 0x00C9C2DD
+          ksceVopDread: 0x77584C8F
+          ksceVopDclose: 0x1350F5C7
+          ksceVopChstat: 0x1974FA92
+          ksceVopRename: 0x36A794C7
+          ksceVopSync: 0x9CD96406
+          ksceVfsOpDevctl: 0xB07B307D
+          ksceVfsOpDecodePathElem: 0xF7DAC0F5
+          kscePfsMgrVfsMount: 0xFEEE44A9
+          kscePfsMgrVfsUmount: 0xD220539D
+          ksceVfsNodeWaitEventFlag: 0xAA45010B
+          ksceVfsNodeSetEventFlag: 0x6048F245
+          ksceVfsUnmount: 0x9C7E7B76
+          ksceVfsDeleteVfs: 0x9CBFA725
+          ksceVfsAddVfs: 0x673D2FCD
+          ksceVfsMount: 0xB62DE9A6
+          ksceVfsGetNewNode: 0xD60B5C63
+          ksceIoDreadForDriver_2: 0x03051B02
+          ksceIoOpenForPid: 0xC3D34965
+          ksceIoChstatForDriver_2: 0x1F98BD50
+          ksceIoGetstatForDriver_2: 0xD6503624
+          ksceIoChstatAsync: 0x7EC442BF
+          ksceIoChstatByFdAsync: 0xEC974400
+          ksceIoDevctlAsync: 0xA9302946
+          ksceIoGetstatByFdAsync: 0x0FEE1238
+          ksceIoGetstatAsync: 0x94A5304A
+          ksceIoIoctlAsync: 0xB761E91B
+          ksceIoIoctl: 0x161CD33F
+          ksceIoMkdirAsync: 0x27003443
+          ksceIoPreadAsync: 0x64A46A2C
+          ksceIoPwriteAsync: 0x202CDDE3
+          ksceIoRemoveAsync: 0xF9D6507D
+          ksceIoRenameAsync: 0xAACBC47A
+          ksceIoRmdirAsync: 0xF5B0B36C
+          ksceIoSyncAsync: 0x4F9EA8B0
+          ksceIoDopenAsync: 0x72F06BDE
+          ksceIoDcloseAsync: 0xC08F199F
+          ksceIoDreadAsync: 0x5982B0E3
+          ksceIoSetPathMappingFunction: 0xCFAECF18
+          ksceIoGetMediaType: 0x9C220246
       SceIofilemgr:
         kernel: false
         nid: 0xF2FF276E
@@ -2796,6 +3172,9 @@ modules:
           ksceKernelLaunchApp: 0x71CF71FD
           ksceKernelResumeProcess: 0x080CDC59
           ksceKernelSuspendProcess: 0x6AECE4CD
+          ksceKernelLibcTime: 0x9E38C556
+          ksceKernelLibcGettimeofday: 0xDE8B8B5E
+          ksceKernelGetClassForUid: 0xC6820972
       SceProcessmgrForDriver:
         kernel: true
         nid: 0x746EC971
@@ -2839,6 +3218,11 @@ modules:
           ksceSblUtMgrHasNpTestFlagForDriver: 0x9FD835B0
           ksceSblUtMgrHasStoreFlagForDriver: 0x9D2E2D39
           ksceSblUtMgrResetUtokenFileForDriver: 0x1FF699DD
+          ksceSblLicMgrGetActivationKey: 0xF7F1015B
+          ksceSblLicMgrGetLicenseStatus: 0x15F37282
+          ksceSblUtMgrGetTrilithiumBuffer: 0xABDD68CD
+          ksceSblRtcMgrGetCpRtcPhysical: 0x942010A0
+          ksceSblRtcMgrGetCpRtcLogical: 0xDE5150FE
       SceSblPmMgr:
         kernel: false
         nid: 0xA9CE5795
@@ -2876,6 +3260,10 @@ modules:
         nid: 0x000DF81A
         functions:
           sceSblUtMgrResetUtokenFile: 0x1CD57182
+          sceSblUtMgrUpdateUtoken: 0xBDE74645
+          sceSblUtMgrReadUtoken: 0xD2836E0D
+          sceSblUtMgrGetCurrentSecureTick: 0xCFCB1355
+          sceSblUtMgrIsTrilithiumFlagEnabled: 0x04CA1311
   SceLibKernel:
     nid: 0xF9C9C52F
     libraries:
@@ -3178,6 +3566,9 @@ modules:
           sceSblGcAuthMgrMsSaveBBCipherFinal: 0xEB02F15D
           sceSblGcAuthMgrMsSaveBBMacUpdate: 0xEE2D40F7
           sceSblGcAuthMgrPcactActivation: 0x17C0CEF4
+          sceIoClose: 0xF5C6F098
+          sceIoRead: 0x713523E1
+          sceIoWrite: 0x11FED231
       SceLibRng:
         kernel: false
         nid: 0xF9AC7CF8
@@ -6263,6 +6654,17 @@ modules:
           ksceNpDrmRemoveActData: 0x8B85A509
           ksceNpDrmUpdateAccountId: 0x116FC0D6
           ksceNpDrmUpdateDebugSettings: 0xA91C7443
+          ksceNpDrmPackageSetGameExist: 0x3BFD2850
+      ScePsmDrm:
+        nid: 0x3F2B0888
+        kernel: false
+        functions:
+          scePsmDrmGetRifKey: 0x207A2C53
+      ScePsmDrmForDriver:
+        nid: 0x9F4924F2
+        kernel: true
+        functions:
+          kscePsmDrmGetRifInfo: 0x984F9017
   SceNpManager:
     nid: 0x2D4B5F41
     libraries:
@@ -6820,7 +7222,8 @@ modules:
           kscePowerSetCompatClockFrequency: 0xFFC84E69
           kscePowerSetDisplayBrightness: 0x43D5CE1D
           kscePowerSetDisplayMaxBrightness: 0x77027B6B
-          kscePowerSetGpuClockFrequency: 0x264C24FC
+          kscePowerSetGpuClockFrequency: 0x621BD8FD
+          kscePowerSetGpuEs4ClockFrequency: 0x264C24FC
           kscePowerSetGpuXbarClockFrequency: 0xA7739DBE
           kscePowerSetIdleCallback: 0x1BA2FCAE
           kscePowerSetIdleTimer: 0x6BC26FC7
@@ -6832,6 +7235,11 @@ modules:
           kscePowerUnregisterCallback: 0xDFA8BAF8
           kscePowerWlanActivate: 0x6D2CA84B
           kscePowerWlanDeactivate: 0x23BB0A60
+          kscePowerSetPowerSwMode2: 0x0CD21B1F
+          kscePowerIsSomethingBattery: 0x0D56C601
+          kscePowerIsSomethingBattery2: 0x627A89C6
+          kscePowerGetVenezia: 0x0E58FCDF
+          kscePowerSetVenezia: 0xE5573571
       SceLedForDriver:
         kernel: true
         nid: 0x282C1323
@@ -7165,6 +7573,10 @@ modules:
           sceRtcTickAddTicks: 0x4559E2DB
           sceRtcTickAddWeeks: 0xE713C640
           sceRtcTickAddYears: 0xDF6C3E1B
+          sceRtcGetCurrentAdNetworkTick: 0x5612AF12
+          sceRtcGetCurrentDebugNetworkTick: 0x4ED6BA6C
+          sceRtcGetCurrentGpsTick: 0xBB92534F
+          sceRtcGetCurrentRetainedNetworkTick: 0xA086AE18
   SceRudp:
     nid: 0x0B6F819A
     libraries:
@@ -8091,6 +8503,14 @@ modules:
           vshSysconShowModeClear: 0xD7E71C94
           vshSysconShowModeSet: 0x5E2A8BBD
           vshSysconVerifyConfigstorageScript: 0xE1E2BAD0
+      SceDrmBridge:
+        nid: 0xFF4CD67F
+        kernel: false
+        functions:
+          sceDrmBridgeGetCurrentSecureTick: 0xFFB164E2
+          sceDrmBridgeIsAllowRemotePlayDebug: 0x1BBB62E9
+          sceDrmBridgeMlnpsnlAuth1: 0xE04F767B
+          sceDrmBridgeMlnpsnlAuth2: 0x6D483DFC
   SceStdio:
     nid: 0x771A73C0
     libraries:
@@ -8118,6 +8538,33 @@ modules:
           ksceSblSsEncryptWithPortability: 0x21EC51F6
           ksceSblSsGetNvsData: 0xFDD6D5DE
           ksceSblSsSetNvsData: 0x249ADB07
+          ksceSblSsMgrGetRandomData: 0xAC57F4F0
+          ksceSblDmac5Rnd: 0x4DD1B2E5
+          ksceSblDmac5AesEcbEnc: 0xC517770D
+          ksceSblDmac5AesEcbDec: 0x7C978BE7
+          ksceSblSsMgrAESECBEncrypt: 0x01BE0374
+          ksceSblSsMgrAESECBDecrypt: 0x8B4700CB
+          ksceSblDmac5AesEcbEncNP: 0x0F7D28AF
+          ksceSblDmac5AesEcbDecNP: 0x197ACF6F
+          ksceSblSsMgrDES64ECBEncrypt: 0x37DD5CBF
+          ksceSblSsMgrDES64ECBDecrypt: 0x8EAFB18A
+          ksceSblSsMgrDES64CBCEncrypt: 0x05B38698
+          ksceSblSsMgrDES64CBCDecrypt: 0x926BCCF0
+          ksceSblDmac5AesCbcEnc: 0xE6E1AD15
+          ksceSblDmac5AEsCbcDec: 0x121FA69F
+          ksceSblDmac5AesCbcEncNP: 0x711C057A
+          ksceSblDmac5AesCbcDecNP: 0x1901CB5E
+          ksceSblSsMgrAESCTREncrypt: 0x82B5DCEF
+          ksceSblSsMgrAESCTRDecrypt: 0x7D46768C
+          ksceSblSsMgrSHA1: 0xEB3AF9B5
+          ksceSblDmac5Sha1HmacTransform: 0x6704D985
+          ksceSblSsMgrHMACSHA1WithKeygen: 0x92E37656
+          ksceSblSsMgrHMACSHA256: 0x79F38554
+          ksceSblSsMgrAESCMAC: 0xEA6ACB6D
+          ksceSblSsMgrAESCMACWithKeygen: 0x83B058F5
+          ksceSblSsMgrExecuteDmac5HashCommand: 0x9641374E
+          ksceSblAimgrGetOpenPsId: 0xA5B5D269
+          ksceSblSsMgrMemset: 0xCD98CC92
       SceSblDmac5Mgr:
         nid: 0x437366A2
         kernel: false
@@ -8158,6 +8605,14 @@ modules:
         kernel: false
         functions:
           _sceKernelGetRandomNumber: 0xC37E818C
+      SceSblSsMgrForKernel:
+        nid: 0x74580D9F
+        kernel: true
+        functions:
+          ksceSblNvsReadData: 0xC2EC8F5A
+          ksceSblNvsWriteData: 0xE29E161C
+          ksceSblQafManagerGetQAFlags: 0x83D254FF
+          ksceSblQafManagerGetQafName: 0xE2DD0378
   SceSblACMgr:
     nid: 0x7474D6F9
     libraries:
@@ -8173,11 +8628,51 @@ modules:
           ksceSblACMgrIsPspEmu: 0xFD00C72A
           ksceSblACMgrIsShell: 0x8612B243
           ksceSblACMgrIsSystem: 0x0948F41C
+          ksceSblACMgrIsWebCoreOrWebKitProcess: 0x0139FC20
+          ksceSblACMgrIsPSMRuntime: 0x091F7247
+          ksceSblACMgrIsNotSandboxed: 0x0B6E6CD7
+          ksceSblACMgrIsAllowedVirtualMachine: 0x2A29453C
+          ksceSblACMgrIsFself: 0x426A4E8C
+          ksceSblACMgrGetPathId: 0x4322F188
+          ksceSblACMgrIsAllowedExtendedMemory: 0x4DB7F512
+          ksceSblACMgrIsNonGameOrGameProgram: 0x8A54DF3A
+          ksceSblACMgrIsUpdaterUISetupperOrPkgInstallerSpawn: 0x962CD237
+          ksceSblACMgrGetSelfAuthInfo: 0x96AF69BD
+          ksceSblACMgrIsSceShell: 0x991FDC15
+          ksceSblACMgrIsSIEApp: 0xA67E8E5B
+          ksceSblACMgrIsPSMDevAssistant: 0xC98D82EE
+          ksceSblACMgrIsMiniSettingsForQA: 0xD0E11C89
       SceSblACMgr:
         kernel: false
         nid: 0xF069F219
         functions:
           _sceSblACMgrIsGameProgram: 0x3C17A7F7
+      SceSblACMgrForKernel:
+        nid: 0x11F9B314
+        kernel: true
+        functions:
+          ksceSblACMgrIsGameProgram: 0x05FDC646
+          kscePfsACSetFSAttrByMode: 0x2AE6CF27
+          ksceSblACMgrIsSystem: 0x31C23B66
+          ksceSblACMgrIsSIEApp: 0x3388F595
+          ksceSblACMgrIsAllowedExtendedMemory: 0x384D20FD
+          ksceSblACMgrIsNonGameProgram: 0x3F99279F
+          ksceSblACMgrIsPspEmu: 0x47B67F72
+          ksceSblACMgrIsNonGameOrGameProgram: 0x570D6AD3
+          ksceSblACMgrIsFself: 0x5AC59172
+          ksceSblACMgrGetSelfAuthInfo: 0x7C2AF978
+          ksceSblACIsSystemProgram: 0x930CD037
+          ksceSblACMgrIsAllowedVirtualMachine: 0x96403142
+          ksceSblACMgrIsPSMRuntime: 0x966B3738
+          ksceSblACMgrIsUpdaterUISetupperOrPkgInstallerSpawn: 0x98B28671
+          ksceSblACMgrHasCapability: 0x9EDAF856
+          ksceSblACMgrIsWebCoreOrWebKitProcess: 0xA7C3001D
+          ksceSblACMgrIsMiniSettingsForQA: 0xAF6F208E
+          ksceSblACMgrIsDevelopmentMode: 0xBBA13D9C
+          ksceSblACMgrIsPSMDevAssistant: 0xC90A9216
+          ksceSblACMgrGetMediaType: 0xD442962E
+          ksceSblACMgrIsNotSandboxed: 0xF5AD56E4
+          ksceSblACMgrIsSceShell: 0xF9FEF5F0
   SceSblUpdateMgr:
     nid: 0x528F6BF5
     libraries:
@@ -8360,6 +8855,7 @@ modules:
           scePromoterUtilityPromotePkgWithRif: 0x86641BC6
           scePromoterUtilityUpdateLiveArea: 0x17D73ECA
           scePromoterUtilityUpdateUpgradableStatus: 0x82E69783
+          scePromoterUtilityRemoveSavedata: 0xCB0A59B0
   SceMtpIfDriver:
     nid: 0xEA885947
     libraries:
@@ -8408,6 +8904,17 @@ modules:
           ksceKernelTriggerSGI: 0x29F62500
           ksceKernelTriggerSubIntr: 0xCC94B294
           ksceKernelUnmaskIntr: 0x7117E827
+          ksceKernelIsSubInterruptOccurred: 0x950B864B
+          ksceKernelResumeIntr: 0xA4C772AF
+          ksceKernelSuspendSubIntr: 0x3A9EA7D1
+          ksceKernelResumeSubIntr: 0x957023D0
+          ksceKernelRegisterIntrHookHandler: 0x99048AEC
+          ksceKernelReleaseIntrHookHandler: 0xA0B7F44E
+      SceIntrmgrForKernel:
+        nid: 0x07AC5E3A
+        kernel: true
+        functions:
+          ksceKernelQueryIntrHandlerInfo: 0xB5AFAE49
   SceSyscon:
     nid: 0x5358BA05
     libraries:
@@ -8482,6 +8989,8 @@ modules:
           ksceSysconUpdaterSetSegment: 0x9B00BC7F
           ksceSysconVerifyConfigstorageScript: 0xCC6F90A8
           ksceSysconWaitInitialized: 0x55DF1C9B
+          ksceSysconIsLowBatteryInhibitUpdateReboot: 0x1A0C140F
+          ksceSysconIsLowBatteryInhibitUpdateDownload: 0x1E3130EE
   SceLcd:
     nid: 0x32FDD1BB
     libraries:
@@ -8567,11 +9076,17 @@ modules:
           ksceDsiSendBlankingPacket: 0x7640F607
           ksceDsiSetLanesAndPixelSize: 0x78E6E3CF
           ksceDsiSetVic: 0x97BFEA76
+          ksceDsiStartDisplay: 0xC2E85919
       SceIftuForDriver:
         kernel: true
         nid: 0xCAFCFE50
         functions:
           ksceIftuCsc: 0x67E37EFC
+          ksceIftuEnable: 0x0D7C02F7
+          ksceIftuSetInputFrameBuffer: 0x7CE0C4DA
+          ksceIftuSetMergeSetting: 0xAF19FD85
+          ksceIftuDisable: 0xC11F30B3
+          ksceIftuSetOutputFormat: 0xE6EE2C6B
   SceSblAuthMgr:
     nid: 0x1773372D
     libraries:
@@ -8581,9 +9096,19 @@ modules:
         functions:
           ksceSblAuthMgrClearDmac5Key: 0xF2BB723E
           ksceSblAuthMgrSetDmac5Key: 0x122ACDEA
+          ksceSblAuthMgrOpen: 0xA9CD2A09
+          ksceSblAuthMgrClose: 0x026ACBAD
+          ksceSblAuthMgrAuthHeader: 0xF3411881
+          ksceSblAuthMgrSetupAuthSegment: 0x89CCDA2C
+          ksceSblAuthMgrLoadBlock: 0xBC422443
+          ksceSblAuthMgrCompareSwVersion: 0xABAB8466
       SceSblAuthMgrForDriver:
         kernel: true
         nid: 0x4EB2B1BB
+        functions:
+          ksceSblAuthMgrGetEKc: 0x868B9E9A
+          ksceSblAuthMgrDecBindData: 0x41DAEA12
+          ksceSblAuthMgrVerifySpfsoCtx: 0x24C4CE64
   SceMotionDev:
     nid: 0x466A97BD
     libraries:
@@ -8635,6 +9160,9 @@ modules:
           ksceMotionDevSamplingStart: 0xC02C85AB
           ksceMotionDevSamplingStop: 0xFD0B0785
           ksceMotionDevSetSamplingMode: 0xDBAF611A
+          ksceMotionDevGetCalibrationData: 0xF0251700
+          ksceMotionDevGetCalibrationHeader: 0x3B23DF55
+          ksceMotionDevGetEvaInfo: 0x5B53AC26
   ScePaf:
     nid: 0xCD679177
     libraries:
@@ -8787,6 +9315,14 @@ modules:
           ksceKernelDmaOpAlloc: 0x7CD5088A
           ksceKernelDmaOpAssign: 0xFCE4171A
           ksceKernelDmaOpFree: 0xADFF1186
+          ksceKernelDmaOpSetupChain: 0x167079FC
+          ksceKernelDmaOpQuit: 0x03052D0D
+          ksceKernelDmaOpConcatenate: 0xA4454DEA
+          ksceKernelDmaOpEnQueue: 0x543F54CF
+          ksceKernelDmaOpDeQueue: 0x7433F70F
+          ksceKernelDmaOpSetCallback: 0xCF627CFD
+          ksceKernelDmaOpSync: 0x397A917C
+          ksceKernelDmaOpSetupDirect: 0x01A599E0
   SceCompat:
     nid: 0x8F2D0378
     libraries:
@@ -9098,6 +9634,18 @@ modules:
           ksceSblSmSchedProxyGetStatus: 0x27EB92F1
           ksceSblSmSchedProxyInvoke: 0x1916509B
           ksceSblSmSchedProxyWait: 0xF35EFC1A
+          ksceSblSmSchedProxyInitialize: 0xA488D604
+          ksceSblSmSchedProxyChangeF00DStatus: 0xDE4EAC3C
+          ksceSblSmSchedProxyNotImplementedMaybeSMC0x131: 0x984EC9D1
+          ksceSblSmSchedProxyNotImplementedMaybeSMC0x132: 0x1DFC8624
+          ksceSblSmSchedProxyGetCommandF00DRegister: 0xF70C04EC
+          ksceSblSmSchedProxyGetUnknownF00DRegister: 0x3CE17233
+          ksceSblSmSchedProxyWriteCry2Arm: 0x15B0E4DF
+          ksceSblSmSchedProxyReadCry2Arm: 0x973A4A7D
+          ksceSblSmSchedProxyEnableCry2ArmInterrupt: 0x8B84AC2A
+          ksceSblSmSchedProxyDisableCry2ArmInterrupt: 0x85EDA5FC
+          ksceSblSmSchedProxyUninitialize: 0x33A3A1E2
+          ksceSblSmSchedProxyExecuteF00DCommand: 0x7894B6F0
   SceSblSsSmComm:
     nid: 0xBB4B5D92
     libraries:
@@ -9180,6 +9728,38 @@ modules:
           _sceFiosKernelOverlayGetInfo: 0xF44F3505
           _sceFiosKernelOverlayDHChstatSync: 0xF6A3E335
           _sceFiosKernelOverlayRemoveForProcess: 0xF8277E07
+      SceFios2KernelForDriver:
+        nid: 0x54D6B9EB
+        kernel: true
+        functions:
+          ksceFiosKernelOverlayAdd: 0x2607EE4C
+          ksceFiosKernelOverlayAddForProcess: 0x17E65A1C
+          ksceFiosKernelOverlayGetInfo: 0x725E6817
+          ksceFiosKernelOverlayGetInfoForProcess: 0xF1762BC2
+          ksceFiosKernelOverlayGetList: 0xFF42AAF0
+          ksceFiosKernelOverlayGetRecommendedScheduler: 0x241BF0D6
+          ksceFiosKernelOverlayModify: 0x7F8B960C
+          ksceFiosKernelOverlayModifyForProcess: 0x853EA82A
+          ksceFiosKernelOverlayRemove: 0x2368FEB5
+          ksceFiosKernelOverlayRemoveForProcess: 0x23247EFB
+          ksceFiosKernelOverlayResolveSync: 0x0F456345
+          ksceFiosKernelOverlayResolveWithRangeSync: 0xD3D968FC
+          ksceFiosKernelOverlayThreadIsDisabled: 0xE71192C5
+          ksceFiosKernelOverlayThreadSetDisabled: 0x03727E5E
+      SceFios2Kernel02:
+        nid: 0xE83E40A6
+        kernel: false
+        functions:
+          sceFiosKernelOverlayAddForProcess02: 0xB77C366D
+          sceFiosKernelOverlayGetInfoForProcess02: 0x111DCCFA
+          sceFiosKernelOverlayGetList02: 0xD90FC293
+          sceFiosKernelOverlayGetRecommendedScheduler02: 0x26B9D08A
+          sceFiosKernelOverlayModifyForProcess02: 0x6A976528
+          sceFiosKernelOverlayRemoveForProcess02: 0x50A7167C
+          sceFiosKernelOverlayResolveSync02: 0xD76F046A
+          sceFiosKernelOverlayResolveWithRangeSync02: 0x8DAD1FED
+          sceFiosKernelOverlayThreadIsDisabled02: 0xD6A4FDD6
+          sceFiosKernelOverlayThreadSetDisabled02: 0x7F26D4DD
   SceSblGcAuthMgr:
     nid: 0xDB1A9016
     libraries:
@@ -9392,6 +9972,14 @@ modules:
           sceWlanUnregisterCallback: 0x826DC04F
           sceWlanRegisterCallback: 0xAA2E46F6
           sceWlanSetConfiguration: 0xDBE8AEF2
+      SceWlanBtForDriver:
+        nid: 0xFD94FCE9
+        kernel: true
+        functions:
+          ksceWlanBtDetachMonitor: 0xA7FDE9DC
+          ksceWlanBtSetConfiguration: 0x4C96C3B7
+          ksceWlanBtGetConfiguration: 0x0FC89113
+          ksceWlanBtAttachMonitor: 0xC5AA6F43
   SceError:
     nid: 0x8713337B
     libraries:
@@ -9405,3 +9993,56 @@ modules:
           _sceErrorHistorySetDefaultFormat: 0xB94DAA2F
           _sceErrorHistoryClearError: 0xC88F479E
           _sceErrorHistoryGetError: 0xF16DF981
+  SceSystimer:
+    nid: 0x9A1E946B
+    libraries:
+      SceSystimerForDriver:
+        nid: 0xA47EB09A
+        kernel: true
+        functions:
+          ksceKernelSysTimerAlloc: 0xE2B9D8E9
+  SceDriverUser:
+    nid: 0xAD0AEA9A
+    libraries:
+      SceErrorUser:
+        nid: 0xD401318D
+        kernel: true
+        functions:
+          ksceErrorHistoryUpdateSequenceInfo: 0x1AA2E39E
+          ksceErrorHistorySetDefaultFormat: 0x395240A1
+          ksceErrorHistoryClearError: 0x7DF547D1
+          ksceErrorGetExternalString: 0xA4DE5B69
+          ksceErrorHistoryGetError: 0xB908B17F
+          ksceErrorHistoryPostError: 0xBC416CFA
+      SceDrmBridgeUser:
+        nid: 0x91AFEB43
+        kernel: true
+        functions:
+          ksceDrmBridgeGetCurrentSecureTick: 0x7C994327
+          ksceDrmBridgeIsAllowRemotePlayDebug: 0x1F82FF68
+          ksceDrmBridgeMlnpsnlAuth1: 0x7D0DB83F
+          ksceDrmBridgeMlnpsnlAuth2: 0x6471937D
+  SceClockgen:
+    nid: 0x1247DEBB
+    libraries:
+      SceClockgenForDriver:
+        nid: 0xFF160234
+        kernel: true
+        functions:
+          ksceClockgenWlanBtClkDisable: 0xB6F0A532
+  ScePfsMgr:
+    nid: 0x538BA86B
+    libraries:
+      ScePfsMgrForKernel:
+        nid: 0xA067B56F
+        kernel: true
+        functions:
+          kscePfsMount: 0xA772209C
+          kscePfsMount2: 0x2D48AEA2
+          kscePfsUnmount: 0x680BC384
+          kscePfsApprove: 0xD8D0FEE5
+          kscePfsDisapprove: 0x2D67D8CA
+          kscePfsAcidDirMount: 0x4A4A8243
+          kscePfsAcidDirUnmount: 0x00C8AF80
+          kscePfsAcidDirApprove: 0x8CDA249A
+          kscePfsAcidDirSet: 0xB0CC0A1A

--- a/db.yml
+++ b/db.yml
@@ -9,6 +9,11 @@ modules:
         nid: 0xDCE180F8
         functions:
           ksceAppMgrAcInstGetAcdirParam: 0x474AABDF
+          ksceAppMgrAppDataMount: 0xB1D3C287
+          ksceAppMgrAppDataMountById: 0x5E311F71
+          ksceAppMgrAppMount: 0xEF0C9533
+          ksceAppMgrAppParamGetInt: 0x12CE29F7
+          ksceAppMgrAppUmount: 0x1DE3B7C4
           ksceAppMgrBgdlSetQueueStatus: 0x5B1BE482
           ksceAppMgrCheckContentInstallPeriod: 0x193784A9
           ksceAppMgrCheckPfsMounted: 0x0B1BEEE0
@@ -21,8 +26,11 @@ modules:
           ksceAppMgrCloudDataSrcMount: 0x6D4D6FFE
           ksceAppMgrCloudDataVerifyHeader: 0x55D48190
           ksceAppMgrDebugSettingNotifyUpdate: 0x7554330F
+          ksceAppMgrDrmClose: 0x088670A6
+          ksceAppMgrDrmOpen: 0xEA75D157
           ksceAppMgrFakeSaveDataCreateMount: 0x12FC3FA8
           ksceAppMgrGameDataMount: 0xCE356B2D
+          ksceAppMgrGetBootParam: 0xD2541B4A
           ksceAppMgrGetPfsProcessStatus: 0xE72D2A4A
           ksceAppMgrGetSystemDataFile: 0xAEC49533
           ksceAppMgrIsExclusiveProcessRunning: 0xA888C2DC
@@ -31,25 +39,14 @@ modules:
           ksceAppMgrLoadSafeMemory: 0xFAF3DAAA
           ksceAppMgrLocalBackupGetOfflineId: 0x61B13981
           ksceAppMgrLocalBackupVerifyOfflineHeader: 0x62E98C42
-          ksceAppMgrRegisterPath: 0xB53FB98E
-          ksceAppMgrSaveDataLocalBackupTargetGetList: 0x9B3F7D66
-          ksceAppMgrSaveDataLocalBackupTargetRemoveItem: 0xC4EF95BB
-          ksceAppMgrSaveDataNotifyBackupFinished: 0x6989B258
-          ksceAppMgrSaveSafeMemory: 0xD366AA44
-          ksceAppMgrSystemParamDateTimeSetConf: 0xA9AA3A68
-          ksceAppMgrUmount: 0xA714BB35
-          ksceAppMgrUpdateRifInfo: 0x894BDCB8
-          ksceAppMgrAppDataMountById: 0x5E311F71
-          ksceAppMgrAppDataMount: 0xB1D3C287
-          ksceAppMgrAppMount: 0xEF0C9533
-          ksceAppMgrAppUmount: 0x1DE3B7C4
-          ksceAppMgrDrmClose: 0x088670A6
-          ksceAppMgrDrmOpen: 0xEA75D157
-          ksceAppMgrGetBootParam: 0xD2541B4A
           ksceAppMgrMmsMount: 0x13D54107
           ksceAppMgrPhotoMount: 0x43A35729
+          ksceAppMgrRegisterPath: 0xB53FB98E
           ksceAppMgrSaveDataGetQuota: 0xE104C37E
+          ksceAppMgrSaveDataLocalBackupTargetGetList: 0x9B3F7D66
+          ksceAppMgrSaveDataLocalBackupTargetRemoveItem: 0xC4EF95BB
           ksceAppMgrSaveDataMount: 0xE73C9516
+          ksceAppMgrSaveDataNotifyBackupFinished: 0x6989B258
           ksceAppMgrSaveDataSlotCreate: 0xE6F389B8
           ksceAppMgrSaveDataSlotDelete: 0xB544F2A0
           ksceAppMgrSaveDataSlotGetParam: 0xD137D486
@@ -58,9 +55,12 @@ modules:
           ksceAppMgrSaveDataSlotSetParam: 0x7E247E47
           ksceAppMgrSaveDataSlotSetStatus: 0x9ADB00FA
           ksceAppMgrSaveDataUmount: 0x2B080268
+          ksceAppMgrSaveSafeMemory: 0xD366AA44
+          ksceAppMgrSystemParamDateTimeSetConf: 0xA9AA3A68
           ksceAppMgrTrophyMount: 0xE977A833
+          ksceAppMgrUmount: 0xA714BB35
+          ksceAppMgrUpdateRifInfo: 0x894BDCB8
           ksceAppMgrWorkDirMount: 0x3A0A9B82
-          ksceAppMgrAppParamGetInt: 0x12CE29F7
       SceAppMgr:
         kernel: false
         nid: 0x8AF17416
@@ -331,6 +331,7 @@ modules:
           sceAppMgrGetStatusByName: 0x656E0ABD
           sceAppMgrGetSystemDataFilePlayReady: 0x1E1E97EE
           sceAppMgrGetUserDirPath: 0x5253338C
+          sceAppMgrGetUserDirPathById: 0x63E51420
           sceAppMgrGetVs0UserDataDrive: 0xC0631748
           sceAppMgrGetVs0UserModuleDrive: 0x906154DE
           sceAppMgrInitSafeMemoryById: 0x3E53681A
@@ -364,7 +365,9 @@ modules:
           sceAppMgrReceiveSystemEvent: 0x10B5765F
           sceAppMgrSaveDataAddMount: 0x8B224917
           sceAppMgrSaveDataDataRemove: 0x4544FCC5
+          sceAppMgrSaveDataDataRemove2: 0x36040E1D
           sceAppMgrSaveDataDataSave: 0x84DE76C7
+          sceAppMgrSaveDataDataSave2: 0xD5CA4F56
           sceAppMgrSaveDataGetQuota: 0x0717E2AE
           sceAppMgrSaveDataMount: 0x31F3CC59
           sceAppMgrSaveDataSlotCreate: 0x5181D7B3
@@ -393,6 +396,7 @@ modules:
           sceAppMgrSystemParamDateTimeGetConf: 0xE39FC7D5
           sceAppMgrSystemParamGetInt: 0x5B75180C
           sceAppMgrSystemParamGetString: 0x09899A08
+          sceAppMgrThemeDataMount: 0x633A7594
           sceAppMgrTrophyMount: 0x84FE08EE
           sceAppMgrTrophyMountById: 0x316207F3
           sceAppMgrUmount: 0x5E375921
@@ -400,10 +404,6 @@ modules:
           sceAppMgrUpdateSaveDataParam: 0x1B0BD20D
           sceAppMgrWorkDirMount: 0x9B3BB24D
           sceAppMgrWorkDirMountById: 0x80E86E42
-          sceAppMgrGetUserDirPathById: 0x63E51420
-          sceAppMgrSaveDataDataRemove2: 0x36040E1D
-          sceAppMgrSaveDataDataSave2: 0xD5CA4F56
-          sceAppMgrThemeDataMount: 0x633A7594
   SceAppUtil:
     nid: 0xCE3E25D4
     libraries:
@@ -461,9 +461,9 @@ modules:
         kernel: false
         nid: 0xE96B941B
         functions:
+          sceAppUtilCacheGetDevInfo: 0x1171B736
           sceAppUtilCacheMount: 0x0AA56143
           sceAppUtilCacheUmount: 0x72D26BF4
-          sceAppUtilCacheGetDevInfo: 0x1171B736
       SceAppUtilExt:
         kernel: false
         nid: 0x76D1A509
@@ -521,20 +521,20 @@ modules:
         functions:
           sceAudioOutGetAdopt: 0x12FB1767
           sceAudioOutGetConfig: 0x9C8EDAEA
+          sceAudioOutGetPortVolume_forUser: 0xFF635DA5
           sceAudioOutGetRestSample: 0x9A5370C4
+          sceAudioOutOpenExtPort: 0x6184B939
           sceAudioOutOpenPort: 0x5BC341E4
           sceAudioOutOutput: 0x02DB3F5F
           sceAudioOutReleasePort: 0x69E2E6B5
-          sceAudioOutSetAlcMode: 0x940CE469
-          sceAudioOutSetConfig: 0xB8BA0D07
-          sceAudioOutSetVolume: 0x64167F11
-          sceAudioOutSetAdopt_forUser: 0x26C82AF2
-          sceAudioOutSetCompress: 0x3601D375
-          sceAudioOutOpenExtPort: 0x6184B939
-          sceAudioOutSetPortVolume_forUser: 0x65840F3D
-          sceAudioOutSetEffectType: 0xB41FACCE
           sceAudioOutSetAdoptMode: 0xDCC90EDB
-          sceAudioOutGetPortVolume_forUser: 0xFF635DA5
+          sceAudioOutSetAdopt_forUser: 0x26C82AF2
+          sceAudioOutSetAlcMode: 0x940CE469
+          sceAudioOutSetCompress: 0x3601D375
+          sceAudioOutSetConfig: 0xB8BA0D07
+          sceAudioOutSetEffectType: 0xB41FACCE
+          sceAudioOutSetPortVolume_forUser: 0x65840F3D
+          sceAudioOutSetVolume: 0x64167F11
   SceAudioIn:
     nid: 0x3DFB6F18
     libraries:
@@ -543,17 +543,17 @@ modules:
         nid: 0xF8DC61A3
         functions:
           sceAudioInGetAdopt: 0x566AC433
+          sceAudioInGetInput: 0x08105392
+          sceAudioInGetMicGain: 0x86118097
           sceAudioInGetStatus: 0x2F940377
           sceAudioInInput: 0x638ADD2D
+          sceAudioInInputWithInputDeviceState: 0x343E8251
           sceAudioInOpenPort: 0x39B50DC1
+          sceAudioInOpenPortForDiag: 0xC6962E84
           sceAudioInReleasePort: 0x3A61B8C4
-          sceAudioInGetInput: 0x08105392
+          sceAudioInSelectInput: 0xA0EB852F
           sceAudioInSetMicGain: 0x0F34DD73
           sceAudioInSetMute: 0x1DFE7698
-          sceAudioInInputWithInputDeviceState: 0x343E8251
-          sceAudioInGetMicGain: 0x86118097
-          sceAudioInSelectInput: 0xA0EB852F
-          sceAudioInOpenPortForDiag: 0xC6962E84
   SceAudiodec:
     nid: 0xC
     libraries:
@@ -802,10 +802,13 @@ modules:
           sceCameraGetExposureCeiling: 0x5FA5B1BB
           sceCameraGetGain: 0x2C36D6F3
           sceCameraGetISO: 0x4EBD5C68
+          sceCameraGetImageQuality: 0xE2AC7BCE
           sceCameraGetNightmode: 0x12B6FF26
+          sceCameraGetNoiseReduction: 0xFEB99ACC
           sceCameraGetReverse: 0x44F6043F
           sceCameraGetSaturation: 0x624F7653
           sceCameraGetSharpness: 0xAA72C3DC
+          sceCameraGetSharpnessOff: 0x34CCAF85
           sceCameraGetWhiteBalance: 0xDBFFA1DA
           sceCameraGetZoom: 0x06D3816C
           sceCameraIsActive: 0x103A75B8
@@ -821,20 +824,17 @@ modules:
           sceCameraSetExposureCeiling: 0x04F34BEE
           sceCameraSetGain: 0xE65CFE86
           sceCameraSetISO: 0x3CF630A1
+          sceCameraSetImageQuality: 0x75C4300B
           sceCameraSetNightmode: 0x3F26233E
+          sceCameraSetNoiseReduction: 0xF9B79556
           sceCameraSetReverse: 0x1175F477
           sceCameraSetSaturation: 0xF9F7CA3D
           sceCameraSetSharpness: 0xD1A5BB0B
+          sceCameraSetSharpnessOff: 0x4B5405C8
           sceCameraSetWhiteBalance: 0x4D4514AC
           sceCameraSetZoom: 0xF7464216
           sceCameraStart: 0xA8FEAE35
           sceCameraStop: 0x1DD9C9CE
-          sceCameraGetSharpnessOff: 0x34CCAF85
-          sceCameraSetSharpnessOff: 0x4B5405C8
-          sceCameraSetImageQuality: 0x75C4300B
-          sceCameraGetImageQuality: 0xE2AC7BCE
-          sceCameraSetNoiseReduction: 0xF9B79556
-          sceCameraGetNoiseReduction: 0xFEB99ACC
       SceCameraForDriver:
         nid: 0xBCBC1F4A
         kernel: true
@@ -1831,34 +1831,34 @@ modules:
         kernel: false
         nid: 0xE23FAD62
         functions:
+          sceHidConsumerControlEnumerate: 0x160B334A
+          sceHidConsumerControlRead: 0x55F64676
+          sceHidConsumerControlRegisterEnumHintCallback: 0xC54BDDB1
+          sceHidConsumerControlRegisterReadHintCallback: 0x0D964502
+          sceHidConsumerControlUnregisterEnumHintCallback: 0x5D836BC5
+          sceHidConsumerControlUnregisterReadHintCallback: 0xB9E89914
+          sceHidControllerEnumerate: 0x983AF9E8
+          sceHidControllerRead: 0x792C1505
+          sceHidControllerRegisterEnumHintCallback: 0x1E9B25E0
+          sceHidControllerRegisterReadHintCallback: 0xBE5992CA
+          sceHidControllerUnregisterEnumHintCallback: 0x7E52ACF1
+          sceHidControllerUnregisterReadHintCallback: 0x83B7B1D5
+          sceHidKeyboardClear: 0x67C01C34
           sceHidKeyboardEnumerate: 0x34BDFACE
+          sceHidKeyboardGetIntercept: 0xCDA9D24C
+          sceHidKeyboardPeek: 0x91F5D4BE
           sceHidKeyboardRead: 0x224A8AD8
+          sceHidKeyboardRegisterEnumHintCallback: 0x743A066F
+          sceHidKeyboardRegisterReadHintCallback: 0x1C740A7A
+          sceHidKeyboardSetIntercept: 0x5D727742
+          sceHidKeyboardUnregisterEnumHintCallback: 0x8068D61E
+          sceHidKeyboardUnregisterReadHintCallback: 0xF73C5FBA
           sceHidMouseEnumerate: 0x2A0D2F54
           sceHidMouseRead: 0xBDECBDC0
-          sceHidConsumerControlRegisterReadHintCallback: 0x0D964502
-          sceHidConsumerControlEnumerate: 0x160B334A
-          sceHidKeyboardRegisterReadHintCallback: 0x1C740A7A
-          sceHidControllerRegisterEnumHintCallback: 0x1E9B25E0
-          sceHidMouseUnregisterEnumHintCallback: 0x3E005E5B
-          sceHidConsumerControlRead: 0x55F64676
-          sceHidKeyboardSetIntercept: 0x5D727742
-          sceHidConsumerControlUnregisterEnumHintCallback: 0x5D836BC5
-          sceHidKeyboardClear: 0x67C01C34
-          sceHidKeyboardRegisterEnumHintCallback: 0x743A066F
-          sceHidControllerRead: 0x792C1505
-          sceHidControllerUnregisterEnumHintCallback: 0x7E52ACF1
-          sceHidKeyboardUnregisterEnumHintCallback: 0x8068D61E
-          sceHidControllerUnregisterReadHintCallback: 0x83B7B1D5
-          sceHidMouseRegisterReadHintCallback: 0x90C5CB0A
-          sceHidKeyboardPeek: 0x91F5D4BE
-          sceHidControllerEnumerate: 0x983AF9E8
-          sceHidMouseUnregisterReadHintCallback: 0xAC591B15
-          sceHidConsumerControlUnregisterReadHintCallback: 0xB9E89914
-          sceHidControllerRegisterReadHintCallback: 0xBE5992CA
-          sceHidConsumerControlRegisterEnumHintCallback: 0xC54BDDB1
           sceHidMouseRegisterEnumHintCallback: 0xC9E35B47
-          sceHidKeyboardGetIntercept: 0xCDA9D24C
-          sceHidKeyboardUnregisterReadHintCallback: 0xF73C5FBA
+          sceHidMouseRegisterReadHintCallback: 0x90C5CB0A
+          sceHidMouseUnregisterEnumHintCallback: 0x3E005E5B
+          sceHidMouseUnregisterReadHintCallback: 0xAC591B15
   SceHttp:
     nid: 0xB015B405
     libraries:
@@ -2038,32 +2038,82 @@ modules:
         kernel: true
         nid: 0x6F25E18A
         functions:
+          ksceGUIDReferObjectWithClassLevel: 0x77066FD1
+          ksceKernelAddressSpaceVAtoPABySW: 0x65419BD3
           ksceKernelAllocHeapMemory: 0x7B4CB60A
+          ksceKernelAllocHeapMemoryFromGlobalHeap: 0x7750CEA7
+          ksceKernelAllocHeapMemoryFromGlobalHeapWithOpt: 0x0B4ED16A
+          ksceKernelAllocHeapMemoryWithOpt1: 0xB415B5A8
           ksceKernelAllocHeapMemoryWithOption: 0x49D4DD9B
           ksceKernelAllocMemBlock: 0xC94850C9
+          ksceKernelAllocMemBlockWithInfo: 0xD44F464D
           ksceKernelCreateClass: 0x61317102
           ksceKernelCreateHeap: 0x9328E0E8
+          ksceKernelCreateUidObj: 0x56A13E90
+          ksceKernelCreateUidObjForUid: 0x89A44858
           ksceKernelCreateUserUid: 0xBF209859
+          ksceKernelCreateUserUidForClass: 0xCED1547B
+          ksceKernelCreateUserUidForName: 0x513B9DDD
+          ksceKernelCreateUserUidForNameWithClass: 0x8DA0BCA5
           ksceKernelDeleteHeap: 0xD6437637
           ksceKernelDeleteUid: 0x047D32F2
           ksceKernelDeleteUserUid: 0x84A4AF5E
+          ksceKernelFindMemBlock: 0x9C78064C
           ksceKernelFindMemBlockByAddr: 0x8A1742F6
+          ksceKernelFindMemBlockByAddrForDefaultSize: 0xF3BBE2E1
           ksceKernelFindMemBlockByAddrForPid: 0x857F1D5A
+          ksceKernelFindMemBlockForPid: 0x9F6E45E3
+          ksceKernelFirstDifferentBlock32User: 0xBDA6E42B
+          ksceKernelFirstDifferentBlock64User: 0xBB3B02C2
+          ksceKernelFirstDifferentBlock64UserForPid: 0xE83855FD
           ksceKernelFirstDifferentIntUserForPid: 0x8334454F
           ksceKernelFreeHeapMemory: 0x3EBCE343
+          ksceKernelFreeHeapMemoryFromGlobalHeap: 0xFB817A59
           ksceKernelFreeMemBlock: 0x009E1C61
+          ksceKernelGUIDGetObject: 0x0FC24464
+          ksceKernelGetClassForPidForUid: 0xE9728A12
+          ksceKernelGetClassForUid: 0xC74B0152
           ksceKernelGetMemBlockBase: 0xA841EDDA
+          ksceKernelGetMemBlockMappedBase: 0x0B1FD5C3
+          ksceKernelGetMemBlockPARange: 0x98C15666
+          ksceKernelGetMemBlockPaddrListForUid: 0x19A51AC7
+          ksceKernelGetMemBlockVBase: 0xB81CF0A3
+          ksceKernelGetNameForPidByUid: 0x09896EB7
+          ksceKernelGetNameForUid: 0xA78755EB
+          ksceKernelGetNameForUid2: 0xE655852F
           ksceKernelGetObjForUid: 0x00ED6C14
+          ksceKernelGetObjectForPidForUid: 0xFE6D7FAE
+          ksceKernelGetObjectForUidForAttr: 0xF6DB54BA
+          ksceKernelGetObjectForUidForClassTree: 0x72A98D17
           ksceKernelGetPaddr: 0x8D160E65
           ksceKernelGetPaddrList: 0xE68BEEBD
+          ksceKernelGetPaddrListForLargePage: 0x08A8A7E8
+          ksceKernelGetPaddrListForSmallPage: 0x16844CE6
+          ksceKernelGetPaddrPair: 0xAE36C775
+          ksceKernelGetPaddrPairForLargePage: 0x32257A24
+          ksceKernelGetPaddrPairForSmallPage: 0xB3575090
+          ksceKernelGetPhysicalMemoryType: 0x0AAA4FDD
           ksceKernelGetPidContext: 0x2ECF7944
           ksceKernelGetUidClass: 0x85336A1C
+          ksceKernelGetUnknownValidPhysAddressSpace: 0xC9928F5E
+          ksceKernelIsPaddrWithinSameSectionForUid: 0xF4AD89D8
+          ksceKernelIsPaddrWithinUnknownValidPhysAddressSpace: 0xA7C0D1FC
           ksceKernelKernelUidForUserUid: 0x45D22597
+          ksceKernelKernelUidForUserUidForClass: 0x184172B1
           ksceKernelMapBlockUserVisible: 0x58D21746
+          ksceKernelMapBlockUserVisibleWithFlag: 0x04059C4B
           ksceKernelMapUserBlock: 0x7D4F8B5F
           ksceKernelMapUserBlockDefaultType: 0x278BC201
           ksceKernelMapUserBlockDefaultTypeForPid: 0x0091D74D
+          ksceKernelMemBlockDecRefCounterAndReleaseUid: 0xF50BDC0C
+          ksceKernelMemBlockGetInfoEx: 0x24A99FFF
+          ksceKernelMemBlockGetInfoExForVisibilityLevel: 0xA73CFFEF
+          ksceKernelMemBlockGetSomeSize: 0x78337B62
+          ksceKernelMemBlockIncRefCounterAndReleaseUid: 0xEAF3849B
           ksceKernelMemBlockRelease: 0x00575B00
+          ksceKernelMemBlockType2Memtype: 0x20C811FA
+          ksceKernelMemBlockTypeGetPrivileges: 0x6A0792A3
+          ksceKernelMemBlockTypeGetUnknown: 0xCB0F3A33
           ksceKernelMemRangeRelease: 0x75C70DE0
           ksceKernelMemRangeReleaseForPid: 0xA8525B06
           ksceKernelMemRangeReleaseWithPerm: 0x22CBE925
@@ -2075,82 +2125,44 @@ modules:
           ksceKernelMemcpyKernelToUserForPidUnchecked: 0xFED82F2D
           ksceKernelMemcpyUserToKernel: 0xBC996A7A
           ksceKernelMemcpyUserToKernelForPid: 0x605275F8
+          ksceKernelMemcpyUserToUser: 0x1BD44DD5
           ksceKernelMemcpyUserToUserForPid: 0x8E086C33
+          ksceKernelOpenUidForName: 0xD76E7452
+          ksceKernelProcModeVAtoPA: 0x61A67D32
           ksceKernelRemapBlock: 0xDFE2C8CB
           ksceKernelRoMemcpyKernelToUserForPid: 0x571D2739
+          ksceKernelSetNameForPidForUid: 0x12624884
+          ksceKernelSetObjectForUid: 0x4CFA4100
           ksceKernelStrncpyKernelToUser: 0x80BD6FEB
           ksceKernelStrncpyUserForPid: 0x75AAF178
           ksceKernelStrncpyUserToKernel: 0xDB3EC244
           ksceKernelStrnlenUser: 0xB429D419
           ksceKernelStrnlenUserForPid: 0x9929EB07
+          ksceKernelSwitchPidContext: 0x2D711589
           ksceKernelSwitchVmaForPid: 0x6F2ACDAE
           ksceKernelUidRelease: 0x149885C4
           ksceKernelUidRetain: 0x0F5C84B7
           ksceKernelUnmapMemBlock: 0xFFCD9B60
-          ksceKernelAllocHeapMemoryFromGlobalHeap: 0x7750CEA7
-          ksceKernelAllocHeapMemoryFromGlobalHeapWithOpt: 0x0B4ED16A
-          ksceKernelAllocHeapMemoryWithOpt1: 0xB415B5A8
-          ksceKernelAllocMemBlockWithInfo: 0xD44F464D
-          ksceKernelCreateUidObj: 0x56A13E90
-          ksceKernelCreateUidObjForUid: 0x89A44858
-          ksceKernelCreateUserUidForClass: 0xCED1547B
-          ksceKernelCreateUserUidForName: 0x513B9DDD
-          ksceKernelCreateUserUidForNameWithClass: 0x8DA0BCA5
-          ksceKernelFindMemBlockByAddrForDefaultSize: 0xF3BBE2E1
-          ksceKernelFindMemBlock: 0x9C78064C
-          ksceKernelFindMemBlockForPid: 0x9F6E45E3
-          ksceKernelFirstDifferentBlock32User: 0xBDA6E42B
-          ksceKernelFirstDifferentBlock64User: 0xBB3B02C2
-          ksceKernelFirstDifferentBlock64UserForPid: 0xE83855FD
-          ksceKernelFreeHeapMemoryFromGlobalHeap: 0xFB817A59
-          ksceKernelGetClassForPidForUid: 0xE9728A12
-          ksceKernelGetClassForUid: 0xC74B0152
-          ksceKernelGetMemBlockPARange: 0x98C15666
-          ksceKernelGetMemBlockVBase: 0xB81CF0A3
-          ksceKernelGetMemBlockMappedBase: 0x0B1FD5C3
-          ksceKernelGetMemBlockPaddrListForUid: 0x19A51AC7
-          ksceKernelGetNameForPidByUid: 0x09896EB7
-          ksceKernelGetNameForUid2: 0xE655852F
-          ksceKernelGetNameForUid: 0xA78755EB
-          ksceKernelGetObjectForPidForUid: 0xFE6D7FAE
-          ksceKernelGetObjectForUidForAttr: 0xF6DB54BA
-          ksceGUIDReferObjectWithClassLevel: 0x77066FD1
-          ksceKernelGetObjectForUidForClassTree: 0x72A98D17
-          ksceKernelGUIDGetObject: 0x0FC24464
-          ksceKernelProcModeVAtoPA: 0x61A67D32
-          ksceKernelGetPaddrListForLargePage: 0x08A8A7E8
-          ksceKernelGetPaddrListForSmallPage: 0x16844CE6
-          ksceKernelGetPaddrPair: 0xAE36C775
-          ksceKernelGetPaddrPairForLargePage: 0x32257A24
-          ksceKernelGetPaddrPairForSmallPage: 0xB3575090
-          ksceKernelAddressSpaceVAtoPABySW: 0x65419BD3
-          ksceKernelGetUnknownValidPhysAddressSpace: 0xC9928F5E
-          ksceKernelIsPaddrWithinSameSectionForUid: 0xF4AD89D8
-          ksceKernelIsPaddrWithinUnknownValidPhysAddressSpace: 0xA7C0D1FC
-          ksceKernelKernelUidForUserUidForClass: 0x184172B1
-          ksceKernelMapBlockUserVisibleWithFlag: 0x04059C4B
-          ksceKernelMemBlockDecRefCounterAndReleaseUid: 0xF50BDC0C
-          ksceKernelMemBlockGetInfoEx: 0x24A99FFF
-          ksceKernelMemBlockGetInfoExForVisibilityLevel: 0xA73CFFEF
-          ksceKernelMemBlockGetSomeSize: 0x78337B62
-          ksceKernelMemBlockIncRefCounterAndReleaseUid: 0xEAF3849B
-          ksceKernelMemBlockType2Memtype: 0x20C811FA
-          ksceKernelMemBlockTypeGetPrivileges: 0x6A0792A3
-          ksceKernelMemBlockTypeGetUnknown: 0xCB0F3A33
-          ksceKernelMemcpyUserToUser: 0x1BD44DD5
-          ksceKernelOpenUidForName: 0xD76E7452
-          ksceKernelSetNameForPidForUid: 0x12624884
-          ksceKernelSetObjectForUid: 0x4CFA4100
-          ksceKernelSwitchPidContext: 0x2D711589
-          ksceKernelGetPhysicalMemoryType: 0x0AAA4FDD
       SceSysmemForKernel:
         kernel: true
         nid: 0x63A519E5
         functions:
+          ksceGUIDGetObjectWithClass: 0x7ABFA9A7
           ksceGUIDGetUIDVectorByClass: 0xEC7D36EF
+          ksceGUIDKernelCreateWithAttr: 0x53E1FFDE
+          ksceGUIDOpenByGUID: 0xCF53EEE4
+          ksceKernelAddressSpaceFreeAllMemBlock: 0x89CE1F31
+          ksceKernelAddressSpaceSetPhyMemPart: 0x67955EE9
+          ksceKernelAddressSpaceUnmap: 0xCE72839E
+          ksceKernelAddressSpaceVAtoPA: 0xF2179820
+          ksceKernelAllocSystemCallTable: 0x5FFE4B79
+          ksceKernelCreateAddressSpace: 0x4A3737F0
           ksceKernelCreateUidObj: 0xDF0288D7
+          ksceKernelDeleteAddressSpace: 0xF2D7FE3A
           ksceKernelFindClassByName: 0x62989905
+          ksceKernelFreeSimpleMemBlock: 0xA1FFA2C9
           ksceKernelGetFixedHeapInfoByPointer: 0x219E90FD
+          ksceKernelGetHeapInfo: 0x91733EF4
           ksceKernelGetHeapInfoByPtr: 0x68451777
           ksceKernelGetMemBlockType: 0x289BE3EC
           ksceKernelGetUidDLinkClass: 0xC105604E
@@ -2158,20 +2170,8 @@ modules:
           ksceKernelGetUidMemBlockClass: 0xAF729575
           ksceKernelNameHeapGetInfo: 0xE443253B
           ksceKernelRxMemcpyKernelToUserForPid: 0x30931572
-          ksceKernelUIDEntryHeapGetInfo: 0x686AA15C
-          ksceKernelAllocSystemCallTable: 0x5FFE4B79
-          ksceKernelGetHeapInfo: 0x91733EF4
-          ksceKernelFreeSimpleMemBlock: 0xA1FFA2C9
           ksceKernelSysrootAlloc: 0xC0A4D2F3
-          ksceGUIDGetObjectWithClass: 0x7ABFA9A7
-          ksceGUIDKernelCreateWithAttr: 0x53E1FFDE
-          ksceGUIDOpenByGUID: 0xCF53EEE4
-          ksceKernelCreateAddressSpace: 0x4A3737F0
-          ksceKernelDeleteAddressSpace: 0xF2D7FE3A
-          ksceKernelAddressSpaceFreeAllMemBlock: 0x89CE1F31
-          ksceKernelAddressSpaceSetPhyMemPart: 0x67955EE9
-          ksceKernelAddressSpaceUnmap: 0xCE72839E
-          ksceKernelAddressSpaceVAtoPA: 0xF2179820
+          ksceKernelUIDEntryHeapGetInfo: 0x686AA15C
       SceSysclibForDriver:
         kernel: true
         nid: 0x7EE45391
@@ -2211,34 +2211,110 @@ modules:
         kernel: true
         nid: 0x54BF2BAB
         functions:
+          ksceKernelCpuBranchPredictorInvalidateAll: 0x4C4C7D6B
+          ksceKernelCpuBranchPredictorInvalidateAllIS: 0x1BB2BB8D
+          ksceKernelCpuDcacheCleanInvalidateMVAC: 0xC8E8C9E9
+          ksceKernelCpuDcacheCleanMVAC: 0xF7159B55
+          ksceKernelCpuDcacheCleanMVACRange: 0xC5C1EE4E
           ksceKernelCpuDcacheInvalidateAll: 0x2F3BF020
+          ksceKernelCpuDcacheInvalidateMVAC: 0x470EAE1E
+          ksceKernelCpuDcacheInvalidateMVACRange: 0x583F30D1
           ksceKernelCpuDcacheWritebackAll: 0x73A30DB2
           ksceKernelCpuDcacheWritebackInvalidateAll: 0x76DAB4D0
           ksceKernelCpuDcacheWritebackInvalidateRange: 0x6BA2E51C
+          ksceKernelCpuForKernel_9B8173F4: 0x9B8173F4
+          ksceKernelCpuGetCONTEXTIDR: 0x5B6B3274
+          ksceKernelCpuGetPaddr: 0x2A46E800
           ksceKernelCpuIcacheAndL2WritebackInvalidateRange: 0x19F17BD0
           ksceKernelCpuIcacheInvalidateAll: 0x264DA250
+          ksceKernelCpuIcacheInvalidateAllU: 0xAEE0B489
           ksceKernelCpuIcacheInvalidateRange: 0xF4C7F578
+          ksceKernelCpuPreloadEngineKill: 0xD0D85FF8
           ksceKernelCpuRestoreContext: 0x0A4F0FB9
           ksceKernelCpuSaveContext: 0x211B89DA
           ksceKernelCpuUnrestrictedMemcpy: 0x8C683DEC
-          ksceKernelCpuGetCONTEXTIDR: 0x5B6B3274
           ksceKernelCpuUpdateSCTLR: 0x04008CF7
-          ksceKernelCpuBranchPredictorInvalidateAllIS: 0x1BB2BB8D
-          ksceKernelCpuBranchPredictorInvalidateAll: 0x4C4C7D6B
-          ksceKernelCpuDcacheInvalidateMVAC: 0x470EAE1E
-          ksceKernelCpuDcacheInvalidateMVACRange: 0x583F30D1
-          ksceKernelCpuDcacheCleanMVAC: 0xF7159B55
-          ksceKernelCpuDcacheCleanMVACRange: 0xC5C1EE4E
-          ksceKernelCpuDcacheCleanInvalidateMVAC: 0xC8E8C9E9
-          ksceKernelCpuIcacheInvalidateAllU: 0xAEE0B489
-          ksceKernelCpuPreloadEngineKill: 0xD0D85FF8
           ksceKernelMMUVAtoPAWithMode: 0x67343A07
-          ksceKernelCpuGetPaddr: 0x2A46E800
-          ksceKernelCpuForKernel_9B8173F4: 0x9B8173F4
       SceCpuForDriver:
         kernel: true
         nid: 0x40ECDB0E
         functions:
+          ksceKernelCpuAtomicAddAndGet16: 0x59F74E94
+          ksceKernelCpuAtomicAddAndGet32: 0x5F6A8743
+          ksceKernelCpuAtomicAddAndGet64: 0x4E459A03
+          ksceKernelCpuAtomicAddAndGet8: 0x1E850481
+          ksceKernelCpuAtomicAddUnless16: 0x0F84AFE9
+          ksceKernelCpuAtomicAddUnless32: 0x1F157DC3
+          ksceKernelCpuAtomicAddUnless64: 0x06CCFA4B
+          ksceKernelCpuAtomicAddUnless8: 0x5CC62CEC
+          ksceKernelCpuAtomicAndAndGet16: 0xB281D52A
+          ksceKernelCpuAtomicAndAndGet32: 0xDF899E4B
+          ksceKernelCpuAtomicAndAndGet64: 0xD18E7B54
+          ksceKernelCpuAtomicAndAndGet8: 0x32B62B1A
+          ksceKernelCpuAtomicClearAndGet16: 0x6B050D7C
+          ksceKernelCpuAtomicClearAndGet32: 0x78C1F148
+          ksceKernelCpuAtomicClearAndGet64: 0x2149CD4C
+          ksceKernelCpuAtomicClearAndGet8: 0x8E538AB5
+          ksceKernelCpuAtomicClearMask16: 0x1BE58599
+          ksceKernelCpuAtomicClearMask32: 0x4AE1BCC0
+          ksceKernelCpuAtomicClearMask64: 0x55760309
+          ksceKernelCpuAtomicClearMask8: 0x1B3336B0
+          ksceKernelCpuAtomicCompareAndSet16: 0x6F63F56D
+          ksceKernelCpuAtomicCompareAndSet32: 0xCDA96E81
+          ksceKernelCpuAtomicCompareAndSet64: 0x4B527009
+          ksceKernelCpuAtomicCompareAndSet8: 0x3627F4E0
+          ksceKernelCpuAtomicDecIfPositive16: 0x9A693F5B
+          ksceKernelCpuAtomicDecIfPositive32: 0x2A71B03C
+          ksceKernelCpuAtomicDecIfPositive64: 0x267D0B33
+          ksceKernelCpuAtomicDecIfPositive8: 0x45153D4E
+          ksceKernelCpuAtomicGetAndAdd16: 0x225DF91A
+          ksceKernelCpuAtomicGetAndAdd32: 0x341B6E81
+          ksceKernelCpuAtomicGetAndAdd64: 0x043FD446
+          ksceKernelCpuAtomicGetAndAdd8: 0xFCDCD4DE
+          ksceKernelCpuAtomicGetAndAnd16: 0x4A820BC5
+          ksceKernelCpuAtomicGetAndAnd32: 0x10EB35EB
+          ksceKernelCpuAtomicGetAndAnd64: 0x18A17E07
+          ksceKernelCpuAtomicGetAndAnd8: 0xD8E675C0
+          ksceKernelCpuAtomicGetAndClear16: 0x8E9C086D
+          ksceKernelCpuAtomicGetAndClear32: 0xE36F3A46
+          ksceKernelCpuAtomicGetAndClear64: 0x88BA6002
+          ksceKernelCpuAtomicGetAndClear8: 0x382D1466
+          ksceKernelCpuAtomicGetAndOr16: 0x004F09D1
+          ksceKernelCpuAtomicGetAndOr32: 0x2A40BB93
+          ksceKernelCpuAtomicGetAndOr64: 0xCB73D6D5
+          ksceKernelCpuAtomicGetAndOr8: 0xBDF6F8E4
+          ksceKernelCpuAtomicGetAndSet16: 0x085532C8
+          ksceKernelCpuAtomicGetAndSet32: 0x0EE04C03
+          ksceKernelCpuAtomicGetAndSet64: 0xD2DEE625
+          ksceKernelCpuAtomicGetAndSet8: 0x29599FC8
+          ksceKernelCpuAtomicGetAndSub16: 0x3EE9B5B8
+          ksceKernelCpuAtomicGetAndSub32: 0xF891CF2A
+          ksceKernelCpuAtomicGetAndSub64: 0xA7585370
+          ksceKernelCpuAtomicGetAndSub8: 0x7B43D0D7
+          ksceKernelCpuAtomicGetAndXor16: 0x711801E6
+          ksceKernelCpuAtomicGetAndXor32: 0x77E34309
+          ksceKernelCpuAtomicGetAndXor64: 0xE212ECAD
+          ksceKernelCpuAtomicGetAndXor8: 0xBAF47F7B
+          ksceKernelCpuAtomicOrAndGet16: 0xADD39B84
+          ksceKernelCpuAtomicOrAndGet32: 0xBC248C30
+          ksceKernelCpuAtomicOrAndGet64: 0x3E218AF7
+          ksceKernelCpuAtomicOrAndGet8: 0x5D515F1B
+          ksceKernelCpuAtomicSet16: 0x532CA3E8
+          ksceKernelCpuAtomicSet32: 0x3168BC57
+          ksceKernelCpuAtomicSet64: 0xC381CE8C
+          ksceKernelCpuAtomicSet8: 0x0836537E
+          ksceKernelCpuAtomicSetIfGreaterGet16: 0x875B094D
+          ksceKernelCpuAtomicSetIfGreaterGet32: 0x26F71995
+          ksceKernelCpuAtomicSetIfGreaterGet8: 0xC3868071
+          ksceKernelCpuAtomicSubAndGet16: 0x515682C9
+          ksceKernelCpuAtomicSubAndGet32: 0xA4884C4E
+          ksceKernelCpuAtomicSubAndGet64: 0xB5F8919C
+          ksceKernelCpuAtomicSubAndGet8: 0xEB085370
+          ksceKernelCpuAtomicXorAndGet16: 0x646003D6
+          ksceKernelCpuAtomicXorAndGet32: 0x4244BE65
+          ksceKernelCpuAtomicXorAndGet64: 0x692C51B3
+          ksceKernelCpuAtomicXorAndGet8: 0x03887992
+          ksceKernelCpuDcacheAndL2CleanInvalidateMVACRange_20: 0xE551F99B
           ksceKernelCpuDcacheAndL2InvalidateRange: 0x02796361
           ksceKernelCpuDcacheAndL2WritebackInvalidateRange: 0x364E68A4
           ksceKernelCpuDcacheAndL2WritebackRange: 0x103872A5
@@ -2247,159 +2323,83 @@ modules:
           ksceKernelCpuDisableInterrupts: 0x821FC0EE
           ksceKernelCpuEnableInterrupts: 0xF5BAD43B
           ksceKernelCpuGetCpuId: 0x5E4D5DE1
+          ksceKernelCpuIsVaddrMapped: 0x337CBDF3
+          ksceKernelCpuLockStoreFlag: 0x3F42B434
+          ksceKernelCpuLockStoreLR: 0xBF82DEB2
+          ksceKernelCpuLockSuspendIntrStoreFlag: 0x4C38CE4D
           ksceKernelCpuResumeIntr: 0x7BB9D5DF
           ksceKernelCpuSpinLockIrqRestore: 0x740A0750
           ksceKernelCpuSpinLockIrqSave: 0xEC53D007
-          ksceKernelCpuSuspendIntr: 0xD32ACE9E
-          ksceKernelCpuAtomicAddAndGet8: 0x1E850481
-          ksceKernelCpuAtomicAddAndGet16: 0x59F74E94
-          ksceKernelCpuAtomicAddAndGet32: 0x5F6A8743
-          ksceKernelCpuAtomicAddAndGet64: 0x4E459A03
-          ksceKernelCpuAtomicAddUnless8: 0x5CC62CEC
-          ksceKernelCpuAtomicAddUnless16: 0x0F84AFE9
-          ksceKernelCpuAtomicAddUnless32: 0x1F157DC3
-          ksceKernelCpuAtomicAddUnless64: 0x06CCFA4B
-          ksceKernelCpuAtomicAndAndGet8: 0x32B62B1A
-          ksceKernelCpuAtomicAndAndGet16: 0xB281D52A
-          ksceKernelCpuAtomicAndAndGet32: 0xDF899E4B
-          ksceKernelCpuAtomicAndAndGet64: 0xD18E7B54
-          ksceKernelCpuAtomicClearAndGet8: 0x8E538AB5
-          ksceKernelCpuAtomicClearAndGet16: 0x6B050D7C
-          ksceKernelCpuAtomicClearAndGet32: 0x78C1F148
-          ksceKernelCpuAtomicClearAndGet64: 0x2149CD4C
-          ksceKernelCpuAtomicClearMask8: 0x1B3336B0
-          ksceKernelCpuAtomicClearMask16: 0x1BE58599
-          ksceKernelCpuAtomicClearMask32: 0x4AE1BCC0
-          ksceKernelCpuAtomicClearMask64: 0x55760309
-          ksceKernelCpuAtomicCompareAndSet8: 0x3627F4E0
-          ksceKernelCpuAtomicCompareAndSet16: 0x6F63F56D
-          ksceKernelCpuAtomicCompareAndSet32: 0xCDA96E81
-          ksceKernelCpuAtomicCompareAndSet64: 0x4B527009
-          ksceKernelCpuAtomicDecIfPositive8: 0x45153D4E
-          ksceKernelCpuAtomicDecIfPositive16: 0x9A693F5B
-          ksceKernelCpuAtomicDecIfPositive32: 0x2A71B03C
-          ksceKernelCpuAtomicDecIfPositive64: 0x267D0B33
-          ksceKernelCpuAtomicGetAndAdd8: 0xFCDCD4DE
-          ksceKernelCpuAtomicGetAndAdd16: 0x225DF91A
-          ksceKernelCpuAtomicGetAndAdd32: 0x341B6E81
-          ksceKernelCpuAtomicGetAndAdd64: 0x043FD446
-          ksceKernelCpuAtomicGetAndAnd8: 0xD8E675C0
-          ksceKernelCpuAtomicGetAndAnd16: 0x4A820BC5
-          ksceKernelCpuAtomicGetAndAnd32: 0x10EB35EB
-          ksceKernelCpuAtomicGetAndAnd64: 0x18A17E07
-          ksceKernelCpuAtomicGetAndClear8: 0x382D1466
-          ksceKernelCpuAtomicGetAndClear16: 0x8E9C086D
-          ksceKernelCpuAtomicGetAndClear32: 0xE36F3A46
-          ksceKernelCpuAtomicGetAndClear64: 0x88BA6002
-          ksceKernelCpuAtomicGetAndOr8: 0xBDF6F8E4
-          ksceKernelCpuAtomicGetAndOr16: 0x004F09D1
-          ksceKernelCpuAtomicGetAndOr32: 0x2A40BB93
-          ksceKernelCpuAtomicGetAndOr64: 0xCB73D6D5
-          ksceKernelCpuAtomicGetAndSet8: 0x29599FC8
-          ksceKernelCpuAtomicGetAndSet16: 0x085532C8
-          ksceKernelCpuAtomicGetAndSet32: 0x0EE04C03
-          ksceKernelCpuAtomicGetAndSet64: 0xD2DEE625
-          ksceKernelCpuAtomicGetAndSub8: 0x7B43D0D7
-          ksceKernelCpuAtomicGetAndSub16: 0x3EE9B5B8
-          ksceKernelCpuAtomicGetAndSub32: 0xF891CF2A
-          ksceKernelCpuAtomicGetAndSub64: 0xA7585370
-          ksceKernelCpuAtomicGetAndXor8: 0xBAF47F7B
-          ksceKernelCpuAtomicGetAndXor16: 0x711801E6
-          ksceKernelCpuAtomicGetAndXor32: 0x77E34309
-          ksceKernelCpuAtomicGetAndXor64: 0xE212ECAD
-          ksceKernelCpuAtomicOrAndGet8: 0x5D515F1B
-          ksceKernelCpuAtomicOrAndGet16: 0xADD39B84
-          ksceKernelCpuAtomicOrAndGet32: 0xBC248C30
-          ksceKernelCpuAtomicOrAndGet64: 0x3E218AF7
-          ksceKernelCpuAtomicSet8: 0x0836537E
-          ksceKernelCpuAtomicSet16: 0x532CA3E8
-          ksceKernelCpuAtomicSet32: 0x3168BC57
-          ksceKernelCpuAtomicSet64: 0xC381CE8C
-          ksceKernelCpuAtomicSetIfGreaterGet8: 0xC3868071
-          ksceKernelCpuAtomicSetIfGreaterGet16: 0x875B094D
-          ksceKernelCpuAtomicSetIfGreaterGet32: 0x26F71995
-          ksceKernelCpuAtomicSubAndGet8: 0xEB085370
-          ksceKernelCpuAtomicSubAndGet16: 0x515682C9
-          ksceKernelCpuAtomicSubAndGet32: 0xA4884C4E
-          ksceKernelCpuAtomicSubAndGet64: 0xB5F8919C
-          ksceKernelCpuAtomicXorAndGet8: 0x03887992
-          ksceKernelCpuAtomicXorAndGet16: 0x646003D6
-          ksceKernelCpuAtomicXorAndGet32: 0x4244BE65
-          ksceKernelCpuAtomicXorAndGet64: 0x692C51B3
-          ksceKernelCpuDcacheAndL2CleanInvalidateMVACRange_20: 0xE551F99B
-          ksceKernelCpuIsVaddrMapped: 0x337CBDF3
-          ksceKernelCpuLockStoreLR: 0xBF82DEB2
-          ksceKernelCpuTryLockStoreLR: 0x5AC9D394
-          ksceKernelCpuUnlockStoreLR: 0xD6ED0C46
-          ksceKernelCpuLockStoreFlag: 0x3F42B434
-          ksceKernelCpuTryLockStoreFlag: 0x4F7790B4
-          ksceKernelCpuUnlockStoreFlag: 0xCB8ABDF0
-          ksceKernelCpuTryLockSuspendIntrStoreLR: 0x27C0B340
-          ksceKernelCpuLockSuspendIntrStoreFlag: 0x4C38CE4D
-          ksceKernelCpuTryLockSuspendIntrStoreFlag: 0xDE6482C6
-          ksceKernelCpuUnlockResumeIntrStoreFlag: 0x9EC91017
           ksceKernelCpuSpinLockStoreLR: 0xCAC9AE80
-          ksceKernelCpuTrySpinLockStoreLR: 0x093925BD
           ksceKernelCpuSpinUnlockStoreLR: 0xF5FD5676
+          ksceKernelCpuSuspendIntr: 0xD32ACE9E
+          ksceKernelCpuTryLockStoreFlag: 0x4F7790B4
+          ksceKernelCpuTryLockStoreLR: 0x5AC9D394
+          ksceKernelCpuTryLockSuspendIntrStoreFlag: 0xDE6482C6
+          ksceKernelCpuTryLockSuspendIntrStoreLR: 0x27C0B340
+          ksceKernelCpuTrySpinLockStoreLR: 0x093925BD
           ksceKernelCpuTrySpinLockSuspendIntrStoreLR: 0xF02467D1
+          ksceKernelCpuUnlockResumeIntrStoreFlag: 0x9EC91017
+          ksceKernelCpuUnlockStoreFlag: 0xCB8ABDF0
+          ksceKernelCpuUnlockStoreLR: 0xD6ED0C46
       SceSysrootForDriver:
         kernel: true
         nid: 0x2ED7F97A
         functions:
-          ksceKernelSysrootGetSystemSwVersion: 0x67AAB627
-          ksceSysrootGetHardwareInfo: 0x930B1342
-          ksceSysrootUtMgrHasNpTestFlag: 0xA43599E9
           ksceKernelInvokeInitCallback: 0x93CD44CD
           ksceKernelSysrootCoredumpTrigger: 0xCD8CD242
           ksceKernelSysrootGetShellPid: 0x05093E7B
+          ksceKernelSysrootGetSystemSwVersion: 0x67AAB627
           ksceKernelSysrootSetSystemSwVersion: 0x3276086B
+          ksceSysrootGetHardwareInfo: 0x930B1342
+          ksceSysrootUtMgrHasNpTestFlag: 0xA43599E9
       SceSysrootForKernel:
         kernel: true
         nid: 0x3691DA45
         functions:
+          ksceKernelAllocHeapMemory: 0xD351EBC8
           ksceKernelGetProcessTitleId: 0xEC3124A3
           ksceKernelGetSysbase: 0x3E455842
           ksceKernelGetSysrootBuffer: 0x9DB56D1F
+          ksceKernelIsColdBoot: 0xD7198963
+          ksceKernelIsSomeBootMode: 0x7B7F8171
+          ksceKernelSysrootAppMgrSpawnProcess: 0x3ACACD22
+          ksceKernelSysrootCheckRemapCodeForUser: 0xF8769E86
+          ksceKernelSysrootDbgpSuspendProcessAndWaitResume: 0x256B2394
+          ksceKernelSysrootGetCurrentAddressSpaceCB: 0x63EBB05B
+          ksceKernelSysrootGetCurrentUIDEntryHeapCB: 0xB4C24588
+          ksceKernelSysrootGetModulePrivate: 0x37EC12BB
+          ksceKernelSysrootGetPUIDEntryHeap: 0x88DE85EF
+          ksceKernelSysrootGetSharedMemory: 0xC8C8C321
+          ksceKernelSysrootGetStatus: 0x5C426B19
+          ksceKernelSysrootGetThreadAccessLevel: 0x20009397
+          ksceKernelSysrootGetVbaseResetVector: 0xCC85905B
+          ksceKernelSysrootIofilemgrStart: 0xF6A6D205
+          ksceKernelSysrootIsUserModeThread: 0x7FC7A163
+          ksceKernelSysrootProcessmgrStart2: 0x62E8F511
+          ksceKernelSysrootSetSysroot: 0x36916C30
+          ksceSysrootGetFactorySystemSwVersion: 0xD3872270
+          ksceSysrootGetModuleInfoForPid: 0xFF9F80FF
+          ksceSysrootGetNidName: 0x0B79E220
           ksceSysrootGetSelfAuthInfo: 0x4F0A4066
           ksceSysrootGetSelfInfo: 0xF10AB792
+          ksceSysrootGetSessionId: 0x84783B71
+          ksceSysrootGetUnk10: 0x403B509E
+          ksceSysrootGetUnkC: 0xFFD6E24D
+          ksceSysrootGetUnkC0: 0xAB3CC7D0
+          ksceSysrootGetWakeupFactor: 0x2F97041A
           ksceSysrootIsAuCodecIcConexant: 0x46E72428
           ksceSysrootIsBsodReboot: 0x4373AC96
           ksceSysrootIsExternalBootMode: 0x89D19090
           ksceSysrootIsSafeMode: 0x834439A7
-          ksceSysrootIsUpdateMode: 0xB0E1FC67
-          ksceSysrootIsUsbEnumWakeup: 0x79C9AE10
-          ksceSysrootUseExternalStorage: 0x55392965
-          ksceSysrootUseInternalStorage: 0x50FE3B4D
-          ksceKernelSysrootGetSharedMemory: 0xC8C8C321
-          ksceKernelSysrootGetPUIDEntryHeap: 0x88DE85EF
-          ksceKernelSysrootGetStatus: 0x5C426B19
-          ksceKernelSysrootIofilemgrStart: 0xF6A6D205
-          ksceKernelSysrootGetCurrentUIDEntryHeapCB: 0xB4C24588
-          ksceKernelSysrootGetCurrentAddressSpaceCB: 0x63EBB05B
-          ksceKernelSysrootAppMgrSpawnProcess: 0x3ACACD22
-          ksceSysrootGetNidName: 0x0B79E220
-          ksceSysrootGetModuleInfoForPid: 0xFF9F80FF
-          ksceKernelSysrootGetVbaseResetVector: 0xCC85905B
-          ksceSysrootGetFactorySystemSwVersion: 0xD3872270
-          ksceSysrootGetUnkC: 0xFFD6E24D
-          ksceSysrootGetUnk10: 0x403B509E
-          ksceSysrootGetUnkC0: 0xAB3CC7D0
-          ksceSysrootGetWakeupFactor: 0x2F97041A
-          ksceSysrootGetSessionId: 0x84783B71
-          ksceKernelIsSomeBootMode: 0x7B7F8171
-          ksceKernelIsColdBoot: 0xD7198963
           ksceSysrootIsSomeBootMode2: 0x7918D44E
           ksceSysrootIsSomeMode: 0xAE7A8F1D
           ksceSysrootIsUnknownReboot: 0xE4EA1960
+          ksceSysrootIsUpdateMode: 0xB0E1FC67
+          ksceSysrootIsUsbEnumWakeup: 0x79C9AE10
           ksceSysrootRegisterLicMgrGetLicenseStatus: 0x71DB83A2
-          ksceKernelSysrootGetThreadAccessLevel: 0x20009397
-          ksceKernelAllocHeapMemory: 0xD351EBC8
-          ksceKernelSysrootGetModulePrivate: 0x37EC12BB
-          ksceKernelSysrootSetSysroot: 0x36916C30
-          ksceKernelSysrootProcessmgrStart2: 0x62E8F511
-          ksceKernelSysrootDbgpSuspendProcessAndWaitResume: 0x256B2394
-          ksceKernelSysrootIsUserModeThread: 0x7FC7A163
-          ksceKernelSysrootCheckRemapCodeForUser: 0xF8769E86
+          ksceSysrootUseExternalStorage: 0x55392965
+          ksceSysrootUseInternalStorage: 0x50FE3B4D
       SceKernelSuspendForDriver:
         kernel: true
         nid: 0x7290B21C
@@ -2436,6 +2436,13 @@ modules:
         kernel: true
         nid: 0xFD00C69A
         functions:
+          ksceSblAIMgrGetProductSubCode: 0xB33CEC8F
+          ksceSblAIMgrIsJapaneseFat: 0x6D5A3FC9
+          ksceSblAIMgrIsPrototypeRev2: 0xFF5784B9
+          ksceSblAIMgrIsPrototypeRev7: 0x05F79D4A
+          ksceSblAIMgrIsToolRev3: 0xBB9D146B
+          ksceSblAIMgrIsToolRev4: 0x37A79140
+          ksceSblAIMgrIsToolRev5: 0xE5E47FF7
           ksceSblAimgrGetSMI: 0x47D9CF13
           ksceSblAimgrGetTargetId: 0x14345161
           ksceSblAimgrIsCEX: 0xD78B04A2
@@ -2446,13 +2453,6 @@ modules:
           ksceSblAimgrIsTest: 0x3B638885
           ksceSblAimgrIsTool: 0x274663A0
           ksceSblAimgrIsVITA: 0x4273B97B
-          ksceSblAIMgrGetProductSubCode: 0xB33CEC8F
-          ksceSblAIMgrIsJapaneseFat: 0x6D5A3FC9
-          ksceSblAIMgrIsToolRev3: 0xBB9D146B
-          ksceSblAIMgrIsToolRev4: 0x37A79140
-          ksceSblAIMgrIsToolRev5: 0xE5E47FF7
-          ksceSblAIMgrIsPrototypeRev2: 0xFF5784B9
-          ksceSblAIMgrIsPrototypeRev7: 0x05F79D4A
       SceQafMgrForDriver:
         kernel: true
         nid: 0x4E29D3B6
@@ -2488,6 +2488,8 @@ modules:
           ksceHmacSha1Digest: 0x29A28957
           ksceHmacSha224Digest: 0x7F2A7B99
           ksceHmacSha256Digest: 0x83EFA1CC
+          ksceMt19937GlobalInit: 0xD428CC2A
+          ksceMt19937GlobalUninit: 0x875B2A1C
           ksceMt19937Init: 0x4C9A5730
           ksceMt19937UInt: 0x92AEDFBC
           ksceSfmt19937FillArray32: 0x2B30548B
@@ -2511,8 +2513,6 @@ modules:
           ksceZlibDecompress: 0x900148DB
           ksceZlibGetCompressedData: 0x01EB6C45
           ksceZlibGetInfo: 0x5B9BCD75
-          ksceMt19937GlobalInit: 0xD428CC2A
-          ksceMt19937GlobalUninit: 0x875B2A1C
       SceDebugForDriver:
         kernel: true
         nid: 0x88758561
@@ -2550,15 +2550,15 @@ modules:
         nid: 0x887F19D0
         kernel: true
         functions:
-          ksceKernelUnregisterProcEventHandler: 0x3DED57CC
-          ksceKernelRegisterProcEventHandler: 0x2A43912D
           ksceKernelInvokeProcEventHandler: 0x414CC813
+          ksceKernelRegisterProcEventHandler: 0x2A43912D
+          ksceKernelUnregisterProcEventHandler: 0x3DED57CC
       SceDebugLedForDriver:
         nid: 0x7BC05EAD
         kernel: true
         functions:
-          ksceKernelSetGPI: 0x51C5325A
           ksceKernelGetGPO: 0x3BB289F7
+          ksceKernelSetGPI: 0x51C5325A
           ksceKernelSetGPOMask: 0x098473B0
   SceKernelThreadMgr:
     nid: 0xF46ED7B2
@@ -2569,6 +2569,8 @@ modules:
         functions:
           ksceKernelCancelCallback: 0xC040EC1C
           ksceKernelCancelMutex: 0x7204B846
+          ksceKernelChangeCurrentThreadAttr: 0x751C9B7A
+          ksceKernelChangeThreadCpuAffinityMask: 0x6D0733A8
           ksceKernelChangeThreadPriority: 0x63DAB420
           ksceKernelChangeThreadSuspendStatus: 0x04C6764B
           ksceKernelCheckCallback: 0xE53E41F6
@@ -2597,6 +2599,7 @@ modules:
           ksceKernelGetCallbackCount: 0x0892D8DF
           ksceKernelGetMutexInfo: 0x69B78A12
           ksceKernelGetProcessId: 0x9DCB4B7A
+          ksceKernelGetProcessIdFromTLS: 0xFA54D49A
           ksceKernelGetSystemTimeLow: 0x47F6DE49
           ksceKernelGetSystemTimeWide: 0xF4EE4FA9
           ksceKernelGetThreadCpuAffinityMask: 0x83DC703D
@@ -2604,6 +2607,7 @@ modules:
           ksceKernelGetThreadCurrentPriority: 0x01414F0B
           ksceKernelGetThreadId: 0x59D06540
           ksceKernelGetThreadIdList: 0xEA7B8AEF
+          ksceKernelGetThreadInfo: 0x283807E2
           ksceKernelGetThreadStackFreeSize: 0x7B278A0B
           ksceKernelGetThreadTLSAddr: 0x66EEA46A
           ksceKernelGetThreadmgrUIDClass: 0x0A20775A
@@ -2612,12 +2616,16 @@ modules:
           ksceKernelInitializeFastMutex: 0xAF8E1266
           ksceKernelLockFastMutex: 0x70627F3A
           ksceKernelLockMutex: 0x16AC80C5
+          ksceKernelLockMutexCB_089: 0xD06F2886
           ksceKernelNotifyCallback: 0xC3E00919
           ksceKernelPollEventFlag: 0x76C6555B
           ksceKernelPollSema: 0x4FDDFE24
           ksceKernelPulseEvent: 0x2427C81B
           ksceKernelPulseEventWithNotifyCallback: 0x714A107A
+          ksceKernelReceiveMsgPipeVector: 0xDA1F256B
+          ksceKernelReceiveMsgPipeVectorCB: 0xDA5C9AC6
           ksceKernelRegisterCallbackToEvent: 0x832A7E0C
+          ksceKernelRegisterTimer: 0xC58DF384
           ksceKernelRunWithStack: 0xE54FD746
           ksceKernelSetEvent: 0x9EA3A45C
           ksceKernelSetEventFlag: 0xD4780C3E
@@ -2649,14 +2657,6 @@ modules:
           ksceKernelWaitSema: 0x3C8B55A9
           ksceKernelWaitThreadEnd: 0x3E20216F
           ksceKernelWaitThreadEndCB: 0x9EF4F62C
-          ksceKernelLockMutexCB_089: 0xD06F2886
-          ksceKernelChangeCurrentThreadAttr: 0x751C9B7A
-          ksceKernelGetThreadInfo: 0x283807E2
-          ksceKernelReceiveMsgPipeVector: 0xDA1F256B
-          ksceKernelReceiveMsgPipeVectorCB: 0xDA5C9AC6
-          ksceKernelChangeThreadCpuAffinityMask: 0x6D0733A8
-          ksceKernelGetProcessIdFromTLS: 0xFA54D49A
-          ksceKernelRegisterTimer: 0xC58DF384
       SceThreadmgrForKernel:
         kernel: true
         nid: 0xA8CA0EFD
@@ -2666,6 +2666,97 @@ modules:
         kernel: false
         nid: 0x859A24B1
         functions:
+          __sceKernelCreateLwMutex: 0x4BB3154A
+          _sceKernelCancelEvent: 0x29483405
+          _sceKernelCancelEventFlag: 0xF76F3056
+          _sceKernelCancelEventWithSetPattern: 0x8E68E870
+          _sceKernelCancelMsgPipe: 0xCE769C83
+          _sceKernelCancelMutex: 0x1B74CB89
+          _sceKernelCancelRWLock: 0xD004EA15
+          _sceKernelCancelSema: 0x1CAF805D
+          _sceKernelCancelTimer: 0x13117B21
+          _sceKernelCreateCond: 0xCC14FA59
+          _sceKernelCreateEventFlag: 0x38AA5E8E
+          _sceKernelCreateLwCond: 0x940B9EBE
+          _sceKernelCreateMsgPipeWithLR: 0x2AAC8BFD
+          _sceKernelCreateMutex: 0x92667AE5
+          _sceKernelCreateRWLock: 0xB1877F5E
+          _sceKernelCreateSema: 0x0D76458E
+          _sceKernelCreateSema_16XX: 0xBD06F27C
+          _sceKernelCreateSimpleEvent: 0x9C187FAD
+          _sceKernelCreateTimer: 0x79BA0A6D
+          _sceKernelDeleteLwCond: 0x75FCF058
+          _sceKernelDeleteLwMutex: 0x91262C5F
+          _sceKernelExitCallback: 0x2682E6ED
+          _sceKernelGetCallbackInfo: 0x86761234
+          _sceKernelGetCondInfo: 0x05C51CE1
+          _sceKernelGetEventFlagInfo: 0x106C216F
+          _sceKernelGetEventInfo: 0xB395BBF1
+          _sceKernelGetEventPattern: 0x70358258
+          _sceKernelGetLwCondInfo: 0x6C79F2F2
+          _sceKernelGetLwCondInfoById: 0xD9E78D30
+          _sceKernelGetLwMutexInfoById: 0xFEC9E946
+          _sceKernelGetMsgPipeInfo: 0x7AE31060
+          _sceKernelGetMutexInfo: 0xE8CC3DF0
+          _sceKernelGetRWLockInfo: 0x8CE3AFC7
+          _sceKernelGetSemaInfo: 0x0402C633
+          _sceKernelGetSystemInfo: 0x80544E0C
+          _sceKernelGetSystemTime: 0xB70EBAE9
+          _sceKernelGetThreadContextForVM: 0x377094D5
+          _sceKernelGetThreadCpuAffinityMask: 0x212E6C35
+          _sceKernelGetThreadEventInfo: 0x5DE0B7E9
+          _sceKernelGetThreadExitStatus: 0xD3210C08
+          _sceKernelGetThreadInfo: 0xB373D8A1
+          _sceKernelGetThreadRunStatus: 0xC7FB5497
+          _sceKernelGetTimerBase: 0x865DA482
+          _sceKernelGetTimerEventRemainingTime: 0x215FD24D
+          _sceKernelGetTimerInfo: 0xAC7FE4F3
+          _sceKernelGetTimerTime: 0x6F2C41BA
+          _sceKernelLockLwMutex: 0x9C572180
+          _sceKernelLockMutex: 0x7FA945AD
+          _sceKernelLockMutexCB: 0xDB9F5333
+          _sceKernelLockReadRWLock: 0x7EB9E8B5
+          _sceKernelLockReadRWLockCB: 0x5D86D763
+          _sceKernelLockWriteRWLock: 0x80191FAA
+          _sceKernelLockWriteRWLockCB: 0xDBD09B09
+          _sceKernelPMonThreadGetCounter: 0x6B9711AC
+          _sceKernelPollEvent: 0x21C7913E
+          _sceKernelPollEventFlag: 0xDAB1B1C8
+          _sceKernelPulseEventWithNotifyCallback: 0x3E49D3F1
+          _sceKernelReceiveMsgPipeVector: 0x3DD9E4AB
+          _sceKernelReceiveMsgPipeVectorCB: 0x4DBF648E
+          _sceKernelRegisterThreadEventHandler: 0xCE6B49D8
+          _sceKernelSendMsgPipeVector: 0x5E65E454
+          _sceKernelSendMsgPipeVectorCB: 0xF6D515DC
+          _sceKernelSetEventWithNotifyCallback: 0x118F646E
+          _sceKernelSetThreadContextForVM: 0xD4785C41
+          _sceKernelSetTimerEvent: 0xE2C0BFEF
+          _sceKernelSetTimerTime: 0xFF738CD9
+          _sceKernelSignalLwCond: 0xC37F6983
+          _sceKernelSignalLwCondAll: 0x07D2584A
+          _sceKernelSignalLwCondTo: 0x6F1A4A2E
+          _sceKernelStartThread: 0xC30B1745
+          _sceKernelTryReceiveMsgPipeVector: 0x03CFCF00
+          _sceKernelTrySendMsgPipeVector: 0xB3D600AB
+          _sceKernelUnlockLwMutex: 0x2ABC41DF
+          _sceKernelWaitCond: 0x040795C7
+          _sceKernelWaitCondCB: 0x452B0AB3
+          _sceKernelWaitEvent: 0x4E0EA70D
+          _sceKernelWaitEventCB: 0x7D483C33
+          _sceKernelWaitEventFlag: 0xFCE2F728
+          _sceKernelWaitEventFlagCB: 0x401E0C68
+          _sceKernelWaitException: 0x6F7C4DE6
+          _sceKernelWaitExceptionCB: 0x5E7876F2
+          _sceKernelWaitLwCond: 0x18C65756
+          _sceKernelWaitLwCondCB: 0x72DBB96B
+          _sceKernelWaitMultipleEvents: 0x200CC503
+          _sceKernelWaitMultipleEventsCB: 0x0558B7C1
+          _sceKernelWaitSema: 0x45389B6B
+          _sceKernelWaitSemaCB: 0xF8E06784
+          _sceKernelWaitSignal: 0x50407BF4
+          _sceKernelWaitSignalCB: 0xCEA3FC52
+          _sceKernelWaitThreadEnd: 0xEA5C52F5
+          _sceKernelWaitThreadEndCB: 0xFA3D4491
           sceKernelCancelCallback: 0x30741EF2
           sceKernelChangeActiveCpuMask: 0x001173F8
           sceKernelChangeThreadCpuAffinityMask: 0x15129174
@@ -2680,6 +2771,7 @@ modules:
           sceKernelCloseEventFlag: 0x9A68F547
           sceKernelCloseMsgPipe: 0x1305A065
           sceKernelCloseMutex: 0x03E23AF6
+          sceKernelCloseMutex_089: 0xA35427EE
           sceKernelCloseRWLock: 0xFD5BD5C1
           sceKernelCloseSema: 0xA2D81F9E
           sceKernelCloseSimpleEvent: 0xFEF4CA53
@@ -2705,6 +2797,7 @@ modules:
           sceKernelGetMsgPipeCreatorId: 0x70E2A6D2
           sceKernelGetProcessId: 0x9DCB4B7A
           sceKernelGetSystemTimeWide: 0xF4EE4FA9
+          sceKernelGetThreadCpuAffinityMask: 0xF1AE5654
           sceKernelGetThreadStackFreeSize: 0x4F8A3DA0
           sceKernelGetThreadTLSAddr: 0xBACA6891
           sceKernelGetThreadmgrUIDClass: 0xC9678F7F
@@ -2715,6 +2808,7 @@ modules:
           sceKernelOpenEventFlag: 0xBC19F8A1
           sceKernelOpenMsgPipe: 0x0E1CB9F6
           sceKernelOpenMutex: 0x52E17182
+          sceKernelOpenMutex_089: 0x2928D2EC
           sceKernelOpenRWLock: 0xCE510196
           sceKernelOpenSema: 0xCBE235C7
           sceKernelOpenSimpleEvent: 0x4E1E4DF8
@@ -2722,6 +2816,7 @@ modules:
           sceKernelPollSema: 0x866EF048
           sceKernelPulseEvent: 0x8D27BAD6
           sceKernelRegisterCallbackToEvent: 0x76FB37E9
+          sceKernelResumeThreadForVM: 0x7EB55DAC
           sceKernelSendSignal: 0xD4C367B2
           sceKernelSetEvent: 0x324218CD
           sceKernelSetEventFlag: 0xEC94DFF7
@@ -2732,6 +2827,7 @@ modules:
           sceKernelSignalSema: 0xE6B761D1
           sceKernelStartTimer: 0x48091E0C
           sceKernelStopTimer: 0x869E9F20
+          sceKernelSuspendThreadForVM: 0x1FF5960D
           sceKernelTryLockMutex: 0x72FC1F54
           sceKernelTryLockReadRWLock: 0xEFDDA456
           sceKernelTryLockWriteRWLock: 0x206CBB66
@@ -2742,103 +2838,7 @@ modules:
           sceKernelUnregisterCallbackFromEventAll: 0x888A7361
           sceKernelUnregisterThreadEventHandler: 0x2C8ED6F0
           sceKernelWaitThreadEndCB_089: 0x0373C5E3
-          _sceKernelTryReceiveMsgPipeVector: 0x03CFCF00
-          _sceKernelGetSemaInfo: 0x0402C633
-          _sceKernelWaitCond: 0x040795C7
-          _sceKernelWaitMultipleEventsCB: 0x0558B7C1
-          _sceKernelGetCondInfo: 0x05C51CE1
-          _sceKernelSignalLwCondAll: 0x07D2584A
-          _sceKernelCreateSema: 0x0D76458E
-          _sceKernelGetEventFlagInfo: 0x106C216F
-          _sceKernelSetEventWithNotifyCallback: 0x118F646E
-          _sceKernelCancelTimer: 0x13117B21
-          _sceKernelWaitLwCond: 0x18C65756
-          _sceKernelCancelMutex: 0x1B74CB89
-          _sceKernelCancelSema: 0x1CAF805D
-          sceKernelSuspendThreadForVM: 0x1FF5960D
-          _sceKernelWaitMultipleEvents: 0x200CC503
-          _sceKernelGetThreadCpuAffinityMask: 0x212E6C35
-          _sceKernelGetTimerEventRemainingTime: 0x215FD24D
-          _sceKernelPollEvent: 0x21C7913E
-          _sceKernelExitCallback: 0x2682E6ED
-          sceKernelOpenMutex_089: 0x2928D2EC
-          _sceKernelCancelEvent: 0x29483405
-          _sceKernelCreateMsgPipeWithLR: 0x2AAC8BFD
-          _sceKernelUnlockLwMutex: 0x2ABC41DF
-          _sceKernelGetThreadContextForVM: 0x377094D5
-          _sceKernelCreateEventFlag: 0x38AA5E8E
-          _sceKernelReceiveMsgPipeVector: 0x3DD9E4AB
-          _sceKernelPulseEventWithNotifyCallback: 0x3E49D3F1
-          _sceKernelWaitEventFlagCB: 0x401E0C68
-          _sceKernelWaitCondCB: 0x452B0AB3
-          _sceKernelWaitSema: 0x45389B6B
-          __sceKernelCreateLwMutex: 0x4BB3154A
-          _sceKernelReceiveMsgPipeVectorCB: 0x4DBF648E
-          _sceKernelWaitEvent: 0x4E0EA70D
-          _sceKernelWaitSignal: 0x50407BF4
-          _sceKernelLockReadRWLockCB: 0x5D86D763
-          _sceKernelGetThreadEventInfo: 0x5DE0B7E9
-          _sceKernelSendMsgPipeVector: 0x5E65E454
-          _sceKernelWaitExceptionCB: 0x5E7876F2
-          _sceKernelPMonThreadGetCounter: 0x6B9711AC
-          _sceKernelGetLwCondInfo: 0x6C79F2F2
-          _sceKernelSignalLwCondTo: 0x6F1A4A2E
-          _sceKernelGetTimerTime: 0x6F2C41BA
-          _sceKernelWaitException: 0x6F7C4DE6
-          _sceKernelGetEventPattern: 0x70358258
-          _sceKernelWaitLwCondCB: 0x72DBB96B
-          _sceKernelDeleteLwCond: 0x75FCF058
-          _sceKernelCreateTimer: 0x79BA0A6D
-          _sceKernelGetMsgPipeInfo: 0x7AE31060
-          _sceKernelWaitEventCB: 0x7D483C33
-          sceKernelResumeThreadForVM: 0x7EB55DAC
-          _sceKernelLockReadRWLock: 0x7EB9E8B5
-          _sceKernelLockMutex: 0x7FA945AD
-          _sceKernelLockWriteRWLock: 0x80191FAA
-          _sceKernelGetSystemInfo: 0x80544E0C
-          _sceKernelGetTimerBase: 0x865DA482
-          _sceKernelGetCallbackInfo: 0x86761234
-          _sceKernelGetRWLockInfo: 0x8CE3AFC7
-          _sceKernelCancelEventWithSetPattern: 0x8E68E870
-          _sceKernelDeleteLwMutex: 0x91262C5F
-          _sceKernelCreateMutex: 0x92667AE5
-          _sceKernelCreateLwCond: 0x940B9EBE
-          _sceKernelCreateSimpleEvent: 0x9C187FAD
-          _sceKernelLockLwMutex: 0x9C572180
-          sceKernelCloseMutex_089: 0xA35427EE
-          _sceKernelGetTimerInfo: 0xAC7FE4F3
-          _sceKernelCreateRWLock: 0xB1877F5E
-          _sceKernelGetThreadInfo: 0xB373D8A1
-          _sceKernelGetEventInfo: 0xB395BBF1
-          _sceKernelTrySendMsgPipeVector: 0xB3D600AB
-          _sceKernelGetSystemTime: 0xB70EBAE9
-          _sceKernelCreateSema_16XX: 0xBD06F27C
-          _sceKernelStartThread: 0xC30B1745
-          _sceKernelSignalLwCond: 0xC37F6983
-          _sceKernelGetThreadRunStatus: 0xC7FB5497
-          _sceKernelCreateCond: 0xCC14FA59
-          _sceKernelRegisterThreadEventHandler: 0xCE6B49D8
-          _sceKernelCancelMsgPipe: 0xCE769C83
-          _sceKernelWaitSignalCB: 0xCEA3FC52
-          _sceKernelCancelRWLock: 0xD004EA15
-          _sceKernelGetThreadExitStatus: 0xD3210C08
-          _sceKernelSetThreadContextForVM: 0xD4785C41
-          _sceKernelGetLwCondInfoById: 0xD9E78D30
-          _sceKernelPollEventFlag: 0xDAB1B1C8
-          _sceKernelLockMutexCB: 0xDB9F5333
-          _sceKernelLockWriteRWLockCB: 0xDBD09B09
-          _sceKernelSetTimerEvent: 0xE2C0BFEF
-          _sceKernelGetMutexInfo: 0xE8CC3DF0
-          _sceKernelWaitThreadEnd: 0xEA5C52F5
           sceKernelWaitThreadEnd_089: 0xF3489EF4
-          _sceKernelSendMsgPipeVectorCB: 0xF6D515DC
-          _sceKernelCancelEventFlag: 0xF76F3056
-          _sceKernelWaitSemaCB: 0xF8E06784
-          _sceKernelWaitThreadEndCB: 0xFA3D4491
-          _sceKernelWaitEventFlag: 0xFCE2F728
-          _sceKernelGetLwMutexInfoById: 0xFEC9E946
-          _sceKernelSetTimerTime: 0xFF738CD9
-          sceKernelGetThreadCpuAffinityMask: 0xF1AE5654
       SceThreadmgrCoredumpTime:
         kernel: false
         nid: 0x5E8D0E22
@@ -2868,8 +2868,8 @@ modules:
         functions:
           ksceKernelCheckDipsw: 0xA98FC2FD
           ksceKernelClearDipsw: 0xF1F3E9FE
-          ksceKernelSetDipsw: 0x82E45FBF
           ksceKernelGetDipswInfo: 0xB2AD48BE
+          ksceKernelSetDipsw: 0x82E45FBF
   SceKernelModulemgr:
     nid: 0x726C6635
     libraries:
@@ -2877,6 +2877,7 @@ modules:
         kernel: true
         nid: 0xC445FA63
         functions:
+          ksceKernelFinalizeKbl: 0xFDD7F646
           ksceKernelGetModuleInfo: 0xD269F915
           ksceKernelGetModuleInfo2: 0x6A655255
           ksceKernelGetModuleInternal: 0xFE303863
@@ -2890,14 +2891,13 @@ modules:
           ksceKernelLoadModuleForPid: 0xFA21D8CB
           ksceKernelLoadPreloadingModules: 0x3AD26B43
           ksceKernelLoadProcessImage: 0xAC4EABDB
+          ksceKernelLoadPtLoadSegForFwloader: 0x448810D5
           ksceKernelMountBootfs: 0x01360661
+          ksceKernelRegisterSyscall: 0xB427025E
           ksceKernelStartModuleForPid: 0x6DF745D5
           ksceKernelStopModuleForPid: 0x7BB4CE54
           ksceKernelUmountBootfs: 0x9C838A6B
           ksceKernelUnloadModuleForPid: 0x5972E2CC
-          ksceKernelLoadPtLoadSegForFwloader: 0x448810D5
-          ksceKernelFinalizeKbl: 0xFDD7F646
-          ksceKernelRegisterSyscall: 0xB427025E
           ksceKernelUnloadProcessModules: 0x0E33258E
       SceModulemgrForDriver:
         kernel: true
@@ -2908,19 +2908,27 @@ modules:
           ksceKernelLoadStartModule: 0x189BFBBB
           ksceKernelLoadStartModuleForPid: 0x9D953C22
           ksceKernelLoadStartSharedModuleForPid: 0xE2ADEF8D
+          ksceKernelRegisterLibary: 0x861638AD
+          ksceKernelReleaseLibary: 0x0975B104
           ksceKernelSearchModuleByName: 0xBBE1771C
           ksceKernelStartModule: 0x0675B682
           ksceKernelStopModule: 0x100DAEB9
           ksceKernelStopUnloadModule: 0x03B30B7E
           ksceKernelStopUnloadModuleForPid: 0x49A3EDC7
-          ksceKernelUnloadModule: 0x728E72A6
-          ksceKernelRegisterLibary: 0x861638AD
-          ksceKernelReleaseLibary: 0x0975B104
           ksceKernelStopUnloadSharedModuleForPid: 0x02D3D0C1
+          ksceKernelUnloadModule: 0x728E72A6
       SceModulemgr:
         kernel: false
         nid: 0xEAED1616
         functions:
+          _sceKernelCloseModule: 0x849E78BE
+          _sceKernelLoadModule: 0xB4C5EF9E
+          _sceKernelLoadStartModule: 0x60647592
+          _sceKernelOpenModule: 0x9D674F45
+          _sceKernelStartModule: 0x72CD301F
+          _sceKernelStopModule: 0x086867A8
+          _sceKernelStopUnloadModule: 0x86EAEA0A
+          _sceKernelUnloadModule: 0x8E4A7716
           sceKernelGetAllowedSdkVersionOnSystem: 0x4397FC4E
           sceKernelGetLibraryInfoByNID: 0xEAEB1312
           sceKernelGetModuleIdByAddr: 0xF5798C7C
@@ -2929,14 +2937,6 @@ modules:
           sceKernelGetSystemSwVersion: 0x5182E212
           sceKernelInhibitLoadingModule: 0x6CED1F63
           sceKernelIsCalledFromSysModule: 0x85E6D2BB
-          _sceKernelStopModule: 0x086867A8
-          _sceKernelLoadStartModule: 0x60647592
-          _sceKernelStartModule: 0x72CD301F
-          _sceKernelCloseModule: 0x849E78BE
-          _sceKernelStopUnloadModule: 0x86EAEA0A
-          _sceKernelUnloadModule: 0x8E4A7716
-          _sceKernelOpenModule: 0x9D674F45
-          _sceKernelLoadModule: 0xB4C5EF9E
       SceBacktrace:
         nid: 0xB07B6A3F
         kernel: false
@@ -2956,108 +2956,146 @@ modules:
         functions:
           ksceIoCancel: 0x6D59658D
           ksceIoChstat: 0x7D42B8DC
+          ksceIoChstatAsync: 0x7EC442BF
           ksceIoChstatByFd: 0xDF57A75F
+          ksceIoChstatByFdAsync: 0xEC974400
+          ksceIoChstatForDriver_2: 0x1F98BD50
           ksceIoClearErrorEvent: 0x40B933C7
           ksceIoClose: 0xF99DD8A3
           ksceIoCloseAsync: 0x11C57CC6
           ksceIoCreateErrorEvent: 0x3C0343DB
           ksceIoCreateMountEvent: 0x2DFA192F
           ksceIoDclose: 0x19C81DD6
+          ksceIoDcloseAsync: 0xC08F199F
           ksceIoDeleteErrorEvent: 0xC6158F8D
           ksceIoDeleteMountEvent: 0x43DB0AE4
           ksceIoDevctl: 0x16882FC4
+          ksceIoDevctlAsync: 0xA9302946
           ksceIoDopen: 0x463B25CC
+          ksceIoDopenAsync: 0x72F06BDE
           ksceIoDread: 0x20CF5FC7
+          ksceIoDreadAsync: 0x5982B0E3
+          ksceIoDreadForDriver_2: 0x03051B02
           ksceIoFlock: 0x16336A0D
+          ksceIoGetMediaType: 0x9C220246
           ksceIoGetProcessDefaultPriorityForSystem: 0xCE397158
           ksceIoGetstat: 0x75C96D25
+          ksceIoGetstatAsync: 0x94A5304A
           ksceIoGetstatByFd: 0x462F059B
+          ksceIoGetstatByFdAsync: 0x0FEE1238
+          ksceIoGetstatForDriver_2: 0xD6503624
+          ksceIoIoctl: 0x161CD33F
+          ksceIoIoctlAsync: 0xB761E91B
           ksceIoLseek: 0x62090481
           ksceIoLseekAsync: 0x541BAABD
           ksceIoMkdir: 0x7F710B25
+          ksceIoMkdirAsync: 0x27003443
           ksceIoMount: 0xD070BC48
           ksceIoOpen: 0x75192972
           ksceIoOpenAsync: 0x451001DE
+          ksceIoOpenForPid: 0xC3D34965
           ksceIoPread: 0x2A17515D
+          ksceIoPreadAsync: 0x64A46A2C
           ksceIoPwrite: 0x5F1512C8
+          ksceIoPwriteAsync: 0x202CDDE3
           ksceIoRead: 0xE17EFC03
           ksceIoReadAsync: 0x69047C81
           ksceIoRemove: 0x0D7BB3E1
+          ksceIoRemoveAsync: 0xF9D6507D
           ksceIoRename: 0xDC0C4997
+          ksceIoRenameAsync: 0xAACBC47A
           ksceIoRmdir: 0x1CC9C634
+          ksceIoRmdirAsync: 0xF5B0B36C
+          ksceIoSetPathMappingFunction: 0xCFAECF18
           ksceIoSetProcessDefaultPriorityForSystem: 0xABE65071
           ksceIoSync: 0xDDF78594
+          ksceIoSyncAsync: 0x4F9EA8B0
           ksceIoSyncByFd: 0x338DCD68
           ksceIoSyncByFd2: 0x43170575
           ksceIoSyncByFdAsync: 0x041209CF
           ksceIoUmount: 0x20574100
           ksceIoWrite: 0x21EE91F0
           ksceIoWriteAsync: 0xA1BD13D0
-          ksceVopIoctl: 0x333C904D
-          ksceVopGetstat: 0x50A63ACF
-          ksceVopOpen: 0x76B79BEC
-          ksceVopCreate: 0x9E347C7D
-          ksceVopClsoe: 0x40944C2E
-          ksceVopRead: 0x570388A5
-          ksceVopWrite: 0x9A68378D
-          ksceVopPread: 0xABBC80E3
-          ksceVopPwrite: 0xA53C040D
-          ksceVopLseek: 0xB2B13818
-          ksceVopMkdir: 0x2F3F8C70
-          ksceVopRmdir: 0x1D551105
-          ksceVopDopen: 0x00C9C2DD
-          ksceVopDread: 0x77584C8F
-          ksceVopDclose: 0x1350F5C7
-          ksceVopChstat: 0x1974FA92
-          ksceVopRename: 0x36A794C7
-          ksceVopSync: 0x9CD96406
-          ksceVfsOpDevctl: 0xB07B307D
-          ksceVfsOpDecodePathElem: 0xF7DAC0F5
           kscePfsMgrVfsMount: 0xFEEE44A9
           kscePfsMgrVfsUmount: 0xD220539D
-          ksceVfsNodeWaitEventFlag: 0xAA45010B
-          ksceVfsNodeSetEventFlag: 0x6048F245
-          ksceVfsUnmount: 0x9C7E7B76
-          ksceVfsDeleteVfs: 0x9CBFA725
           ksceVfsAddVfs: 0x673D2FCD
-          ksceVfsMount: 0xB62DE9A6
+          ksceVfsDeleteVfs: 0x9CBFA725
           ksceVfsGetNewNode: 0xD60B5C63
-          ksceIoDreadForDriver_2: 0x03051B02
-          ksceIoOpenForPid: 0xC3D34965
-          ksceIoChstatForDriver_2: 0x1F98BD50
-          ksceIoGetstatForDriver_2: 0xD6503624
-          ksceIoChstatAsync: 0x7EC442BF
-          ksceIoChstatByFdAsync: 0xEC974400
-          ksceIoDevctlAsync: 0xA9302946
-          ksceIoGetstatByFdAsync: 0x0FEE1238
-          ksceIoGetstatAsync: 0x94A5304A
-          ksceIoIoctlAsync: 0xB761E91B
-          ksceIoIoctl: 0x161CD33F
-          ksceIoMkdirAsync: 0x27003443
-          ksceIoPreadAsync: 0x64A46A2C
-          ksceIoPwriteAsync: 0x202CDDE3
-          ksceIoRemoveAsync: 0xF9D6507D
-          ksceIoRenameAsync: 0xAACBC47A
-          ksceIoRmdirAsync: 0xF5B0B36C
-          ksceIoSyncAsync: 0x4F9EA8B0
-          ksceIoDopenAsync: 0x72F06BDE
-          ksceIoDcloseAsync: 0xC08F199F
-          ksceIoDreadAsync: 0x5982B0E3
-          ksceIoSetPathMappingFunction: 0xCFAECF18
-          ksceIoGetMediaType: 0x9C220246
+          ksceVfsMount: 0xB62DE9A6
+          ksceVfsNodeSetEventFlag: 0x6048F245
+          ksceVfsNodeWaitEventFlag: 0xAA45010B
+          ksceVfsOpDecodePathElem: 0xF7DAC0F5
+          ksceVfsOpDevctl: 0xB07B307D
+          ksceVfsUnmount: 0x9C7E7B76
+          ksceVopChstat: 0x1974FA92
+          ksceVopClsoe: 0x40944C2E
+          ksceVopCreate: 0x9E347C7D
+          ksceVopDclose: 0x1350F5C7
+          ksceVopDopen: 0x00C9C2DD
+          ksceVopDread: 0x77584C8F
+          ksceVopGetstat: 0x50A63ACF
+          ksceVopIoctl: 0x333C904D
+          ksceVopLseek: 0xB2B13818
+          ksceVopMkdir: 0x2F3F8C70
+          ksceVopOpen: 0x76B79BEC
+          ksceVopPread: 0xABBC80E3
+          ksceVopPwrite: 0xA53C040D
+          ksceVopRead: 0x570388A5
+          ksceVopRename: 0x36A794C7
+          ksceVopRmdir: 0x1D551105
+          ksceVopSync: 0x9CD96406
+          ksceVopWrite: 0x9A68378D
       SceIofilemgr:
         kernel: false
         nid: 0xF2FF276E
         functions:
+          _sceIoChstat: 0xD2EE455F
+          _sceIoChstatAsync: 0xB4B021D9
+          _sceIoChstatByFd: 0xE0BE2A30
+          _sceIoCompleteMultiple: 0x9111D004
+          _sceIoDevctl: 0x515AC017
+          _sceIoDevctlAsync: 0x3EE3F66E
+          _sceIoDopen: 0xE6E614B5
+          _sceIoDread: 0x8713D662
+          _sceIoGetstat: 0x8E7E11F2
+          _sceIoGetstatAsync: 0xD414C89F
+          _sceIoGetstatByFd: 0xE6C53567
+          _sceIoIoctl: 0x1D2988F1
+          _sceIoIoctlAsync: 0xE00DC256
+          _sceIoLseek: 0xA604764A
+          _sceIoLseekAsync: 0x2300858E
+          _sceIoMkdir: 0x8F1ACC32
+          _sceIoMkdirAsync: 0xF5C58B21
+          _sceIoOpen: 0xCC67B6FD
+          _sceIoOpenAsync: 0x09CD0FC8
+          _sceIoPread: 0x539FD5C4
+          _sceIoPreadAsync: 0xBCF5684D
+          _sceIoPwrite: 0x9654094B
+          _sceIoPwriteAsync: 0xB2D0B2F4
+          _sceIoRemove: 0x78955C65
+          _sceIoRemoveAsync: 0x5FFA47E2
+          _sceIoRename: 0x4912F748
+          _sceIoRenameAsync: 0x81794921
+          _sceIoRmdir: 0xFFFB4D76
+          _sceIoRmdirAsync: 0x13DC3244
+          _sceIoSync: 0x5DD867F7
+          _sceIoSyncAsync: 0x86DB0C0E
           sceIoCancel: 0xCEF48835
+          sceIoChstatByFdAsync: 0xA9F89275
           sceIoClose: 0xC70B8886
           sceIoCloseAsync: 0x8EA3616A
           sceIoComplete: 0xD1C49D2F
           sceIoDclose: 0x422A221A
+          sceIoDcloseAsync: 0xDC2D7D38
+          sceIoDopenAsync: 0xC49C312F
+          sceIoDreadAsync: 0xF59F37B0
           sceIoFlockForSystem: 0x3E98E422
           sceIoGetPriority: 0xF2A472A1
+          sceIoGetPriorityForSystem: 0xEF5432ED
           sceIoGetProcessDefaultPriority: 0x0DC4F1BB
           sceIoGetThreadDefaultPriority: 0xA176CD03
+          sceIoGetThreadDefaultPriorityForSystem: 0xFCBCEAED
+          sceIoGetstatByFdAsync: 0x5167AC1E
           sceIoLseek32: 0x49252B9B
           sceIoRead: 0xFDB32293
           sceIoReadAsync: 0x773EBD45
@@ -3070,44 +3108,6 @@ modules:
           sceIoSyncByFdAsync: 0x7E1367CB
           sceIoWrite: 0x34EFD876
           sceIoWriteAsync: 0xE0D63D2A
-          _sceIoOpenAsync: 0x09CD0FC8
-          _sceIoRmdirAsync: 0x13DC3244
-          _sceIoIoctl: 0x1D2988F1
-          _sceIoLseekAsync: 0x2300858E
-          _sceIoDevctlAsync: 0x3EE3F66E
-          _sceIoRename: 0x4912F748
-          _sceIoDevctl: 0x515AC017
-          sceIoGetstatByFdAsync: 0x5167AC1E
-          _sceIoPread: 0x539FD5C4
-          _sceIoSync: 0x5DD867F7
-          _sceIoRemoveAsync: 0x5FFA47E2
-          _sceIoRemove: 0x78955C65
-          _sceIoRenameAsync: 0x81794921
-          _sceIoSyncAsync: 0x86DB0C0E
-          _sceIoDread: 0x8713D662
-          _sceIoGetstat: 0x8E7E11F2
-          _sceIoMkdir: 0x8F1ACC32
-          _sceIoCompleteMultiple: 0x9111D004
-          _sceIoPwrite: 0x9654094B
-          _sceIoLseek: 0xA604764A
-          sceIoChstatByFdAsync: 0xA9F89275
-          _sceIoPwriteAsync: 0xB2D0B2F4
-          _sceIoChstatAsync: 0xB4B021D9
-          _sceIoPreadAsync: 0xBCF5684D
-          sceIoDopenAsync: 0xC49C312F
-          _sceIoOpen: 0xCC67B6FD
-          _sceIoChstat: 0xD2EE455F
-          _sceIoGetstatAsync: 0xD414C89F
-          sceIoDcloseAsync: 0xDC2D7D38
-          _sceIoIoctlAsync: 0xE00DC256
-          _sceIoChstatByFd: 0xE0BE2A30
-          _sceIoGetstatByFd: 0xE6C53567
-          _sceIoDopen: 0xE6E614B5
-          sceIoGetPriorityForSystem: 0xEF5432ED
-          sceIoDreadAsync: 0xF59F37B0
-          _sceIoMkdirAsync: 0xF5C58B21
-          sceIoGetThreadDefaultPriorityForSystem: 0xFCBCEAED
-          _sceIoRmdir: 0xFFFB4D76
   SceOled:
     nid: 0x5410837A
     libraries:
@@ -3130,6 +3130,9 @@ modules:
         kernel: false
         nid: 0x2DD91812
         functions:
+          _sceKernelExitProcessForUser: 0xC053DC6B
+          _sceKernelGetTimer5Reg: 0x2F73D72F
+          _sceKernelRegisterLibkernelAddresses: 0x56C2E8FF
           sceKernelCDialogSessionClose: 0xDB4CC1D0
           sceKernelCDialogSetLeaseLimit: 0xEC8DDAAD
           sceKernelCallAbortHandler: 0xEB6E50BB
@@ -3158,23 +3161,20 @@ modules:
           sceKernelPowerUnlock: 0x466C0CBD
           sceKernelRegisterProcessTerminationCallback: 0x5EC77870
           sceKernelUnregisterProcessTerminationCallback: 0x973A4527
-          _sceKernelGetTimer5Reg: 0x2F73D72F
-          _sceKernelRegisterLibkernelAddresses: 0x56C2E8FF
-          _sceKernelExitProcessForUser: 0xC053DC6B
       SceProcessmgrForKernel:
         kernel: true
         nid: 0x7A69DE86
         functions:
           ksceKernelExitProcess: 0x4CA7DC42
+          ksceKernelGetClassForUid: 0xC6820972
           ksceKernelGetProcessAuthid: 0xE4C83B0D
           ksceKernelGetProcessKernelBuf: 0xB9E68092
           ksceKernelGetProcessMainThread: 0x95F9ED94
           ksceKernelLaunchApp: 0x71CF71FD
+          ksceKernelLibcGettimeofday: 0xDE8B8B5E
+          ksceKernelLibcTime: 0x9E38C556
           ksceKernelResumeProcess: 0x080CDC59
           ksceKernelSuspendProcess: 0x6AECE4CD
-          ksceKernelLibcTime: 0x9E38C556
-          ksceKernelLibcGettimeofday: 0xDE8B8B5E
-          ksceKernelGetClassForUid: 0xC6820972
       SceProcessmgrForDriver:
         kernel: true
         nid: 0x746EC971
@@ -3198,6 +3198,8 @@ modules:
         nid: 0x2254E1B2
         functions:
           _ksceSblPostSsMgrExecutePmSmF00dCommandForDriver: 0xFE92A318
+          ksceSblLicMgrGetActivationKey: 0xF7F1015B
+          ksceSblLicMgrGetLicenseStatus: 0x15F37282
           ksceSblPostSsMgrActivateForDriver: 0x0298382B
           ksceSblPostSsMgrDebugDecryptKeystoneForDriver: 0xCC5AA5A5
           ksceSblPostSsMgrDebugEncryptKeystoneForDriver: 0x42474C8B
@@ -3213,16 +3215,14 @@ modules:
           ksceSblPostSsMgrVerifyKeystoneForDriver: 0xDDA6FA6D
           ksceSblPostSsMgrVerifyKeystoneWithPasscodeForDriver: 0xF86F1452
           ksceSblPostSsMgrVerifySpfsoCtxForDriver: 0x686B9461
+          ksceSblRtcMgrGetCpRtcLogical: 0xDE5150FE
+          ksceSblRtcMgrGetCpRtcPhysical: 0x942010A0
           ksceSblUtMgrExecuteUtokenSmCommand1ForDriver: 0xC2E58CE3
+          ksceSblUtMgrGetTrilithiumBuffer: 0xABDD68CD
           ksceSblUtMgrHasComTestFlagForDriver: 0x7ACCAA50
           ksceSblUtMgrHasNpTestFlagForDriver: 0x9FD835B0
           ksceSblUtMgrHasStoreFlagForDriver: 0x9D2E2D39
           ksceSblUtMgrResetUtokenFileForDriver: 0x1FF699DD
-          ksceSblLicMgrGetActivationKey: 0xF7F1015B
-          ksceSblLicMgrGetLicenseStatus: 0x15F37282
-          ksceSblUtMgrGetTrilithiumBuffer: 0xABDD68CD
-          ksceSblRtcMgrGetCpRtcPhysical: 0x942010A0
-          ksceSblRtcMgrGetCpRtcLogical: 0xDE5150FE
       SceSblPmMgr:
         kernel: false
         nid: 0xA9CE5795
@@ -3259,11 +3259,11 @@ modules:
         kernel: false
         nid: 0x000DF81A
         functions:
-          sceSblUtMgrResetUtokenFile: 0x1CD57182
-          sceSblUtMgrUpdateUtoken: 0xBDE74645
-          sceSblUtMgrReadUtoken: 0xD2836E0D
           sceSblUtMgrGetCurrentSecureTick: 0xCFCB1355
           sceSblUtMgrIsTrilithiumFlagEnabled: 0x04CA1311
+          sceSblUtMgrReadUtoken: 0xD2836E0D
+          sceSblUtMgrResetUtokenFile: 0x1CD57182
+          sceSblUtMgrUpdateUtoken: 0xBDE74645
   SceLibKernel:
     nid: 0xF9C9C52F
     libraries:
@@ -3332,6 +3332,7 @@ modules:
           sceIoChstat: 0x29482F7F
           sceIoChstatAsync: 0x9739A5E2
           sceIoChstatByFd: 0x6E903AB2
+          sceIoClose: 0xF5C6F098
           sceIoCompleteMultiple: 0xA792C404
           sceIoDevctl: 0x04B30CB2
           sceIoDevctlAsync: 0x950F78EB
@@ -3352,6 +3353,7 @@ modules:
           sceIoPreadAsync: 0xA010141E
           sceIoPwrite: 0x8FFFF5A8
           sceIoPwriteAsync: 0xED25BEEF
+          sceIoRead: 0x713523E1
           sceIoRemove: 0xE20ED0F3
           sceIoRemoveAsync: 0x446A60AC
           sceIoRename: 0xF737E369
@@ -3360,6 +3362,7 @@ modules:
           sceIoRmdirAsync: 0x9694D00F
           sceIoSync: 0x98ACED6D
           sceIoSyncAsync: 0xF7C7FBFE
+          sceIoWrite: 0x11FED231
           sceKernelAtomicAddAndGet16: 0x495C52EC
           sceKernelAtomicAddAndGet32: 0x2E84A93B
           sceKernelAtomicAddAndGet64: 0xB6CE9B9A
@@ -3566,9 +3569,6 @@ modules:
           sceSblGcAuthMgrMsSaveBBCipherFinal: 0xEB02F15D
           sceSblGcAuthMgrMsSaveBBMacUpdate: 0xEE2D40F7
           sceSblGcAuthMgrPcactActivation: 0x17C0CEF4
-          sceIoClose: 0xF5C6F098
-          sceIoRead: 0x713523E1
-          sceIoWrite: 0x11FED231
       SceLibRng:
         kernel: false
         nid: 0xF9AC7CF8
@@ -6648,13 +6648,13 @@ modules:
           ksceNpDrmGetRifPspKey: 0xDACB71F4
           ksceNpDrmGetRifVitaKey: 0x723322B5
           ksceNpDrmIsLooseAccountBind: 0xFC84CA1A
+          ksceNpDrmPackageSetGameExist: 0x3BFD2850
           ksceNpDrmPresetRifProvisionalFlag: 0xC070FE89
           ksceNpDrmPspEbootSigGen: 0xEF387FC4
           ksceNpDrmPspEbootVerify: 0xB6CA3A2C
           ksceNpDrmRemoveActData: 0x8B85A509
           ksceNpDrmUpdateAccountId: 0x116FC0D6
           ksceNpDrmUpdateDebugSettings: 0xA91C7443
-          ksceNpDrmPackageSetGameExist: 0x3BFD2850
       ScePsmDrm:
         nid: 0x3F2B0888
         kernel: false
@@ -7200,12 +7200,15 @@ modules:
           kscePowerGetIdleTimer: 0xEDC13FE5
           kscePowerGetPowerSwMode: 0x165CE085
           kscePowerGetResumeCount: 0x0074EF9B
+          kscePowerGetVenezia: 0x0E58FCDF
           kscePowerGetWakeupFactor: 0x9F26222A
           kscePowerIsBatteryCharging: 0x1E490401
           kscePowerIsBatteryExist: 0x0AFD0D8B
           kscePowerIsLowBattery: 0xD3075926
           kscePowerIsPowerOnline: 0x87440F5E
           kscePowerIsRequest: 0x7FA406DD
+          kscePowerIsSomethingBattery: 0x0D56C601
+          kscePowerIsSomethingBattery2: 0x627A89C6
           kscePowerIsSuspendRequired: 0x78A1A796
           kscePowerRegisterCallback: 0x04B7766E
           kscePowerRequestColdReset: 0x0442D852
@@ -7228,18 +7231,15 @@ modules:
           kscePowerSetIdleCallback: 0x1BA2FCAE
           kscePowerSetIdleTimer: 0x6BC26FC7
           kscePowerSetPowerSwMode: 0xC1853BA7
+          kscePowerSetPowerSwMode2: 0x0CD21B1F
           kscePowerSetProcessIdleCallback: 0x0856FD0A
           kscePowerSetPsButtonPushTime: 0xCF8F0529
           kscePowerSetStandbyButtonPushTime: 0x675A84ED
+          kscePowerSetVenezia: 0xE5573571
           kscePowerTick: 0xEFD3C963
           kscePowerUnregisterCallback: 0xDFA8BAF8
           kscePowerWlanActivate: 0x6D2CA84B
           kscePowerWlanDeactivate: 0x23BB0A60
-          kscePowerSetPowerSwMode2: 0x0CD21B1F
-          kscePowerIsSomethingBattery: 0x0D56C601
-          kscePowerIsSomethingBattery2: 0x627A89C6
-          kscePowerGetVenezia: 0x0E58FCDF
-          kscePowerSetVenezia: 0xE5573571
       SceLedForDriver:
         kernel: true
         nid: 0x282C1323
@@ -7433,13 +7433,13 @@ modules:
         kernel: false
         nid: 0x0B351269
         functions:
+          sceRegMgrSystemIsBlueScreen: 0x169A0D1D
           sceRegMgrSystemParamGetBin: 0x7FFE2CDF
           sceRegMgrSystemParamGetInt: 0x347C1BDB
           sceRegMgrSystemParamGetStr: 0x877ADB3F
           sceRegMgrSystemParamSetBin: 0xD5A73557
           sceRegMgrSystemParamSetInt: 0xC8F73311
           sceRegMgrSystemParamSetStr: 0xCB3246E3
-          sceRegMgrSystemIsBlueScreen: 0x169A0D1D
       SceRegMgrForSDK:
         kernel: false
         nid: 0x67E45817
@@ -7541,9 +7541,13 @@ modules:
           sceRtcFormatRFC2822LocalTime: 0x42CA8EB5
           sceRtcFormatRFC3339: 0xCCEA2B54
           sceRtcFormatRFC3339LocalTime: 0x742250A9
+          sceRtcGetCurrentAdNetworkTick: 0x5612AF12
           sceRtcGetCurrentClock: 0x70FDE8F1
           sceRtcGetCurrentClockLocalTime: 0x0572EDDC
+          sceRtcGetCurrentDebugNetworkTick: 0x4ED6BA6C
+          sceRtcGetCurrentGpsTick: 0xBB92534F
           sceRtcGetCurrentNetworkTick: 0xCDDD25FE
+          sceRtcGetCurrentRetainedNetworkTick: 0xA086AE18
           sceRtcGetCurrentTick: 0x23F79274
           sceRtcGetDayOfWeek: 0x2F3531EB
           sceRtcGetDayOfYear: 0xB5C4E95F
@@ -7573,10 +7577,6 @@ modules:
           sceRtcTickAddTicks: 0x4559E2DB
           sceRtcTickAddWeeks: 0xE713C640
           sceRtcTickAddYears: 0xDF6C3E1B
-          sceRtcGetCurrentAdNetworkTick: 0x5612AF12
-          sceRtcGetCurrentDebugNetworkTick: 0x4ED6BA6C
-          sceRtcGetCurrentGpsTick: 0xBB92534F
-          sceRtcGetCurrentRetainedNetworkTick: 0xA086AE18
   SceRudp:
     nid: 0x0B6F819A
     libraries:
@@ -8052,6 +8052,7 @@ modules:
           sceTouchGetDeviceInfo: 0xD7889B91
           sceTouchGetPanelInfo: 0x10A2CA25
           sceTouchGetPixelDensity: 0xF0704CF3
+          sceTouchGetPixelDensity2: 0xE0C1DB92
           sceTouchGetProcessInfo: 0xAB364C23
           sceTouchGetSamplingState: 0x26531526
           sceTouchGetSamplingStateExt: 0xDC8671EA
@@ -8068,7 +8069,6 @@ modules:
           sceTouchSetRegionAttr: 0x08DD4C7C
           sceTouchSetSamplingState: 0x1B9C5D14
           sceTouchSetSamplingStateExt: 0x13CDFC43
-          sceTouchGetPixelDensity2: 0xE0C1DB92
       SceTouchForDriver:
         kernel: true
         nid: 0xA4A7DAFC
@@ -8530,70 +8530,70 @@ modules:
         functions:
           ksceKernelGetRandomNumber: 0x4F9BFBE5
           ksceSblAimgrGetConsoleId: 0xFC6CDD68
+          ksceSblAimgrGetOpenPsId: 0xA5B5D269
           ksceSblAimgrGetPscode: 0xE0DC2587
           ksceSblAimgrGetPscode2: 0x9A9676D0
           ksceSblAimgrGetVisibleId: 0x04843835
+          ksceSblDmac5AEsCbcDec: 0x121FA69F
+          ksceSblDmac5AesCbcDecNP: 0x1901CB5E
+          ksceSblDmac5AesCbcEnc: 0xE6E1AD15
+          ksceSblDmac5AesCbcEncNP: 0x711C057A
+          ksceSblDmac5AesEcbDec: 0x7C978BE7
+          ksceSblDmac5AesEcbDecNP: 0x197ACF6F
+          ksceSblDmac5AesEcbEnc: 0xC517770D
+          ksceSblDmac5AesEcbEncNP: 0x0F7D28AF
+          ksceSblDmac5Rnd: 0x4DD1B2E5
+          ksceSblDmac5Sha1HmacTransform: 0x6704D985
           ksceSblSsCreatePassPhrase: 0xB8B298FD
           ksceSblSsDecryptWithPortability: 0x934DB6B5
           ksceSblSsEncryptWithPortability: 0x21EC51F6
           ksceSblSsGetNvsData: 0xFDD6D5DE
-          ksceSblSsSetNvsData: 0x249ADB07
-          ksceSblSsMgrGetRandomData: 0xAC57F4F0
-          ksceSblDmac5Rnd: 0x4DD1B2E5
-          ksceSblDmac5AesEcbEnc: 0xC517770D
-          ksceSblDmac5AesEcbDec: 0x7C978BE7
-          ksceSblSsMgrAESECBEncrypt: 0x01BE0374
-          ksceSblSsMgrAESECBDecrypt: 0x8B4700CB
-          ksceSblDmac5AesEcbEncNP: 0x0F7D28AF
-          ksceSblDmac5AesEcbDecNP: 0x197ACF6F
-          ksceSblSsMgrDES64ECBEncrypt: 0x37DD5CBF
-          ksceSblSsMgrDES64ECBDecrypt: 0x8EAFB18A
-          ksceSblSsMgrDES64CBCEncrypt: 0x05B38698
-          ksceSblSsMgrDES64CBCDecrypt: 0x926BCCF0
-          ksceSblDmac5AesCbcEnc: 0xE6E1AD15
-          ksceSblDmac5AEsCbcDec: 0x121FA69F
-          ksceSblDmac5AesCbcEncNP: 0x711C057A
-          ksceSblDmac5AesCbcDecNP: 0x1901CB5E
-          ksceSblSsMgrAESCTREncrypt: 0x82B5DCEF
-          ksceSblSsMgrAESCTRDecrypt: 0x7D46768C
-          ksceSblSsMgrSHA1: 0xEB3AF9B5
-          ksceSblDmac5Sha1HmacTransform: 0x6704D985
-          ksceSblSsMgrHMACSHA1WithKeygen: 0x92E37656
-          ksceSblSsMgrHMACSHA256: 0x79F38554
           ksceSblSsMgrAESCMAC: 0xEA6ACB6D
           ksceSblSsMgrAESCMACWithKeygen: 0x83B058F5
+          ksceSblSsMgrAESCTRDecrypt: 0x7D46768C
+          ksceSblSsMgrAESCTREncrypt: 0x82B5DCEF
+          ksceSblSsMgrAESECBDecrypt: 0x8B4700CB
+          ksceSblSsMgrAESECBEncrypt: 0x01BE0374
+          ksceSblSsMgrDES64CBCDecrypt: 0x926BCCF0
+          ksceSblSsMgrDES64CBCEncrypt: 0x05B38698
+          ksceSblSsMgrDES64ECBDecrypt: 0x8EAFB18A
+          ksceSblSsMgrDES64ECBEncrypt: 0x37DD5CBF
           ksceSblSsMgrExecuteDmac5HashCommand: 0x9641374E
-          ksceSblAimgrGetOpenPsId: 0xA5B5D269
+          ksceSblSsMgrGetRandomData: 0xAC57F4F0
+          ksceSblSsMgrHMACSHA1WithKeygen: 0x92E37656
+          ksceSblSsMgrHMACSHA256: 0x79F38554
           ksceSblSsMgrMemset: 0xCD98CC92
+          ksceSblSsMgrSHA1: 0xEB3AF9B5
+          ksceSblSsSetNvsData: 0x249ADB07
       SceSblDmac5Mgr:
         nid: 0x437366A2
         kernel: false
         functions:
-          sceSblDmac5HashTransform: 0x09EBC6EF
-          sceSblDmac5EncDecKeyGen: 0x5BF4F924
-          sceSblDmac5HmacKeyGen: 0xCCE57D33
           sceSblDmac5EncDec: 0xD0B1F759
+          sceSblDmac5EncDecKeyGen: 0x5BF4F924
+          sceSblDmac5HashTransform: 0x09EBC6EF
+          sceSblDmac5HmacKeyGen: 0xCCE57D33
       SceSblQafMgr:
         nid: 0x756B7E89
         kernel: false
         functions:
+          sceSblQafManagerDeleteQafTokenForUser: 0xD542583F
           sceSblQafManagerGetQafNameForUser: 0x0F7EA8C2
           sceSblQafManagerIsAllowKernelDebugForUser: 0x11D30766
           sceSblQafManagerSetQafTokenForUser: 0x56A16392
           sceSblQafMgrDeleteQafToken2: 0x62E30BF4
-          sceSblQafMgrIsAllowForceUpdate: 0x63F29BA0
-          sceSblQafMgrIsAllowAllDebugMenuDisplay: 0x66843305
-          sceSblQafMgrIsAllowNpFullTest: 0x72168C6E
-          sceSblQafMgrIsAllowMinimumDebugMenuDisplay: 0xA156BBD2
-          sceSblQafMgrIsAllowNpTest: 0xA9EBCBAC
-          sceSblQafMgrIsAllowNonQAPup: 0xB5621615
-          sceSblQafMgrGetQafToken: 0xB6BAE81D
-          sceSblQafMgrIsAllowLimitedDebugMenuDisplay: 0xC456212D
-          sceSblQafMgrIsAllowScreenShotAlways: 0xD22A8731
-          sceSblQafManagerDeleteQafTokenForUser: 0xD542583F
-          sceSblQafMgrGetQafToken2: 0xDFBA8569
           sceSblQafMgrGetQafName: 0xF0CA8766
+          sceSblQafMgrGetQafToken: 0xB6BAE81D
+          sceSblQafMgrGetQafToken2: 0xDFBA8569
+          sceSblQafMgrIsAllowAllDebugMenuDisplay: 0x66843305
+          sceSblQafMgrIsAllowForceUpdate: 0x63F29BA0
+          sceSblQafMgrIsAllowLimitedDebugMenuDisplay: 0xC456212D
+          sceSblQafMgrIsAllowMinimumDebugMenuDisplay: 0xA156BBD2
+          sceSblQafMgrIsAllowNonQAPup: 0xB5621615
+          sceSblQafMgrIsAllowNpFullTest: 0x72168C6E
+          sceSblQafMgrIsAllowNpTest: 0xA9EBCBAC
           sceSblQafMgrIsAllowRemoteSysmoduleLoad: 0xF45AA706
+          sceSblQafMgrIsAllowScreenShotAlways: 0xD22A8731
           sceSblQafMgrSetQafToken2: 0xF4B5C8A5
       SceSblAimgr:
         nid: 0xD473F968
@@ -8620,28 +8620,28 @@ modules:
         kernel: true
         nid: 0x9AD8E213
         functions:
+          ksceSblACMgrGetPathId: 0x4322F188
+          ksceSblACMgrGetSelfAuthInfo: 0x96AF69BD
           ksceSblACMgrHasCapability: 0xC2D1F2FC
+          ksceSblACMgrIsAllowedExtendedMemory: 0x4DB7F512
           ksceSblACMgrIsAllowedUsbSerial: 0x062CAEB2
+          ksceSblACMgrIsAllowedVirtualMachine: 0x2A29453C
           ksceSblACMgrIsDevelopmentMode: 0xE87D1777
+          ksceSblACMgrIsFself: 0x426A4E8C
           ksceSblACMgrIsGameProgram: 0x1298C647
+          ksceSblACMgrIsMiniSettingsForQA: 0xD0E11C89
+          ksceSblACMgrIsNonGameOrGameProgram: 0x8A54DF3A
           ksceSblACMgrIsNonGameProgram: 0x6C5AB07F
+          ksceSblACMgrIsNotSandboxed: 0x0B6E6CD7
+          ksceSblACMgrIsPSMDevAssistant: 0xC98D82EE
+          ksceSblACMgrIsPSMRuntime: 0x091F7247
           ksceSblACMgrIsPspEmu: 0xFD00C72A
+          ksceSblACMgrIsSIEApp: 0xA67E8E5B
+          ksceSblACMgrIsSceShell: 0x991FDC15
           ksceSblACMgrIsShell: 0x8612B243
           ksceSblACMgrIsSystem: 0x0948F41C
-          ksceSblACMgrIsWebCoreOrWebKitProcess: 0x0139FC20
-          ksceSblACMgrIsPSMRuntime: 0x091F7247
-          ksceSblACMgrIsNotSandboxed: 0x0B6E6CD7
-          ksceSblACMgrIsAllowedVirtualMachine: 0x2A29453C
-          ksceSblACMgrIsFself: 0x426A4E8C
-          ksceSblACMgrGetPathId: 0x4322F188
-          ksceSblACMgrIsAllowedExtendedMemory: 0x4DB7F512
-          ksceSblACMgrIsNonGameOrGameProgram: 0x8A54DF3A
           ksceSblACMgrIsUpdaterUISetupperOrPkgInstallerSpawn: 0x962CD237
-          ksceSblACMgrGetSelfAuthInfo: 0x96AF69BD
-          ksceSblACMgrIsSceShell: 0x991FDC15
-          ksceSblACMgrIsSIEApp: 0xA67E8E5B
-          ksceSblACMgrIsPSMDevAssistant: 0xC98D82EE
-          ksceSblACMgrIsMiniSettingsForQA: 0xD0E11C89
+          ksceSblACMgrIsWebCoreOrWebKitProcess: 0x0139FC20
       SceSblACMgr:
         kernel: false
         nid: 0xF069F219
@@ -8651,28 +8651,28 @@ modules:
         nid: 0x11F9B314
         kernel: true
         functions:
-          ksceSblACMgrIsGameProgram: 0x05FDC646
           kscePfsACSetFSAttrByMode: 0x2AE6CF27
-          ksceSblACMgrIsSystem: 0x31C23B66
-          ksceSblACMgrIsSIEApp: 0x3388F595
-          ksceSblACMgrIsAllowedExtendedMemory: 0x384D20FD
-          ksceSblACMgrIsNonGameProgram: 0x3F99279F
-          ksceSblACMgrIsPspEmu: 0x47B67F72
-          ksceSblACMgrIsNonGameOrGameProgram: 0x570D6AD3
-          ksceSblACMgrIsFself: 0x5AC59172
-          ksceSblACMgrGetSelfAuthInfo: 0x7C2AF978
           ksceSblACIsSystemProgram: 0x930CD037
-          ksceSblACMgrIsAllowedVirtualMachine: 0x96403142
-          ksceSblACMgrIsPSMRuntime: 0x966B3738
-          ksceSblACMgrIsUpdaterUISetupperOrPkgInstallerSpawn: 0x98B28671
-          ksceSblACMgrHasCapability: 0x9EDAF856
-          ksceSblACMgrIsWebCoreOrWebKitProcess: 0xA7C3001D
-          ksceSblACMgrIsMiniSettingsForQA: 0xAF6F208E
-          ksceSblACMgrIsDevelopmentMode: 0xBBA13D9C
-          ksceSblACMgrIsPSMDevAssistant: 0xC90A9216
           ksceSblACMgrGetMediaType: 0xD442962E
+          ksceSblACMgrGetSelfAuthInfo: 0x7C2AF978
+          ksceSblACMgrHasCapability: 0x9EDAF856
+          ksceSblACMgrIsAllowedExtendedMemory: 0x384D20FD
+          ksceSblACMgrIsAllowedVirtualMachine: 0x96403142
+          ksceSblACMgrIsDevelopmentMode: 0xBBA13D9C
+          ksceSblACMgrIsFself: 0x5AC59172
+          ksceSblACMgrIsGameProgram: 0x05FDC646
+          ksceSblACMgrIsMiniSettingsForQA: 0xAF6F208E
+          ksceSblACMgrIsNonGameOrGameProgram: 0x570D6AD3
+          ksceSblACMgrIsNonGameProgram: 0x3F99279F
           ksceSblACMgrIsNotSandboxed: 0xF5AD56E4
+          ksceSblACMgrIsPSMDevAssistant: 0xC90A9216
+          ksceSblACMgrIsPSMRuntime: 0x966B3738
+          ksceSblACMgrIsPspEmu: 0x47B67F72
+          ksceSblACMgrIsSIEApp: 0x3388F595
           ksceSblACMgrIsSceShell: 0xF9FEF5F0
+          ksceSblACMgrIsSystem: 0x31C23B66
+          ksceSblACMgrIsUpdaterUISetupperOrPkgInstallerSpawn: 0x98B28671
+          ksceSblACMgrIsWebCoreOrWebKitProcess: 0xA7C3001D
   SceSblUpdateMgr:
     nid: 0x528F6BF5
     libraries:
@@ -8853,9 +8853,9 @@ modules:
           scePromoterUtilityPromoteImport: 0x4B37808F
           scePromoterUtilityPromotePkg: 0x716C81F4
           scePromoterUtilityPromotePkgWithRif: 0x86641BC6
+          scePromoterUtilityRemoveSavedata: 0xCB0A59B0
           scePromoterUtilityUpdateLiveArea: 0x17D73ECA
           scePromoterUtilityUpdateUpgradableStatus: 0x82E69783
-          scePromoterUtilityRemoveSavedata: 0xCB0A59B0
   SceMtpIfDriver:
     nid: 0xEA885947
     libraries:
@@ -8893,23 +8893,23 @@ modules:
           ksceKernelGetIntrTarget: 0x353CFAAE
           ksceKernelIsIntrAllowedInCurrentContext: 0x182EE3E3
           ksceKernelIsIntrPending: 0xA269003D
+          ksceKernelIsSubInterruptOccurred: 0x950B864B
           ksceKernelMaskIntr: 0x180435EC
           ksceKernelRegisterIntrHandler: 0x5C1FEB29
+          ksceKernelRegisterIntrHookHandler: 0x99048AEC
           ksceKernelRegisterSubIntrHandler: 0x96576C18
           ksceKernelReleaseIntrHandler: 0xD6009B98
+          ksceKernelReleaseIntrHookHandler: 0xA0B7F44E
           ksceKernelReleaseSubIntrHandler: 0x7B9657B3
+          ksceKernelResumeIntr: 0xA4C772AF
+          ksceKernelResumeSubIntr: 0x957023D0
           ksceKernelSetIntrMasked: 0x7117E827
           ksceKernelSetIntrPriority: 0x71020E29
           ksceKernelSetIntrTarget: 0x973BACCC
+          ksceKernelSuspendSubIntr: 0x3A9EA7D1
           ksceKernelTriggerSGI: 0x29F62500
           ksceKernelTriggerSubIntr: 0xCC94B294
           ksceKernelUnmaskIntr: 0x7117E827
-          ksceKernelIsSubInterruptOccurred: 0x950B864B
-          ksceKernelResumeIntr: 0xA4C772AF
-          ksceKernelSuspendSubIntr: 0x3A9EA7D1
-          ksceKernelResumeSubIntr: 0x957023D0
-          ksceKernelRegisterIntrHookHandler: 0x99048AEC
-          ksceKernelReleaseIntrHookHandler: 0xA0B7F44E
       SceIntrmgrForKernel:
         nid: 0x07AC5E3A
         kernel: true
@@ -8962,6 +8962,8 @@ modules:
           ksceSysconIduModeClear: 0x34574496
           ksceSysconIduModeSet: 0x956D07CB
           ksceSysconIsDownLoaderMode: 0x9ADD60D2
+          ksceSysconIsLowBatteryInhibitUpdateDownload: 0x1E3130EE
+          ksceSysconIsLowBatteryInhibitUpdateReboot: 0x1A0C140F
           ksceSysconJigClosePort: 0x483FAE05
           ksceSysconJigOpenPort: 0x44A173F5
           ksceSysconJigSetConfig: 0xD24BF916
@@ -8989,8 +8991,6 @@ modules:
           ksceSysconUpdaterSetSegment: 0x9B00BC7F
           ksceSysconVerifyConfigstorageScript: 0xCC6F90A8
           ksceSysconWaitInitialized: 0x55DF1C9B
-          ksceSysconIsLowBatteryInhibitUpdateReboot: 0x1A0C140F
-          ksceSysconIsLowBatteryInhibitUpdateDownload: 0x1E3130EE
   SceLcd:
     nid: 0x32FDD1BB
     libraries:
@@ -9082,10 +9082,10 @@ modules:
         nid: 0xCAFCFE50
         functions:
           ksceIftuCsc: 0x67E37EFC
+          ksceIftuDisable: 0xC11F30B3
           ksceIftuEnable: 0x0D7C02F7
           ksceIftuSetInputFrameBuffer: 0x7CE0C4DA
           ksceIftuSetMergeSetting: 0xAF19FD85
-          ksceIftuDisable: 0xC11F30B3
           ksceIftuSetOutputFormat: 0xE6EE2C6B
   SceSblAuthMgr:
     nid: 0x1773372D
@@ -9094,20 +9094,20 @@ modules:
         kernel: true
         nid: 0x7ABF5135
         functions:
-          ksceSblAuthMgrClearDmac5Key: 0xF2BB723E
-          ksceSblAuthMgrSetDmac5Key: 0x122ACDEA
-          ksceSblAuthMgrOpen: 0xA9CD2A09
-          ksceSblAuthMgrClose: 0x026ACBAD
           ksceSblAuthMgrAuthHeader: 0xF3411881
-          ksceSblAuthMgrSetupAuthSegment: 0x89CCDA2C
-          ksceSblAuthMgrLoadBlock: 0xBC422443
+          ksceSblAuthMgrClearDmac5Key: 0xF2BB723E
+          ksceSblAuthMgrClose: 0x026ACBAD
           ksceSblAuthMgrCompareSwVersion: 0xABAB8466
+          ksceSblAuthMgrLoadBlock: 0xBC422443
+          ksceSblAuthMgrOpen: 0xA9CD2A09
+          ksceSblAuthMgrSetDmac5Key: 0x122ACDEA
+          ksceSblAuthMgrSetupAuthSegment: 0x89CCDA2C
       SceSblAuthMgrForDriver:
         kernel: true
         nid: 0x4EB2B1BB
         functions:
-          ksceSblAuthMgrGetEKc: 0x868B9E9A
           ksceSblAuthMgrDecBindData: 0x41DAEA12
+          ksceSblAuthMgrGetEKc: 0x868B9E9A
           ksceSblAuthMgrVerifySpfsoCtx: 0x24C4CE64
   SceMotionDev:
     nid: 0x466A97BD
@@ -9152,7 +9152,10 @@ modules:
         kernel: true
         nid: 0xA501409A
         functions:
+          ksceMotionDevGetCalibrationData: 0xF0251700
+          ksceMotionDevGetCalibrationHeader: 0x3B23DF55
           ksceMotionDevGetDeviceInfo: 0x3E4BCBC0
+          ksceMotionDevGetEvaInfo: 0x5B53AC26
           ksceMotionDevIsReady: 0x10AAC8EA
           ksceMotionDevNoiseFilterIsAvailable: 0x11A17A96
           ksceMotionDevRead: 0x3A3407B5
@@ -9160,9 +9163,6 @@ modules:
           ksceMotionDevSamplingStart: 0xC02C85AB
           ksceMotionDevSamplingStop: 0xFD0B0785
           ksceMotionDevSetSamplingMode: 0xDBAF611A
-          ksceMotionDevGetCalibrationData: 0xF0251700
-          ksceMotionDevGetCalibrationHeader: 0x3B23DF55
-          ksceMotionDevGetEvaInfo: 0x5B53AC26
   ScePaf:
     nid: 0xCD679177
     libraries:
@@ -9314,15 +9314,15 @@ modules:
           ksceDmacMemset: 0x4BAC049B
           ksceKernelDmaOpAlloc: 0x7CD5088A
           ksceKernelDmaOpAssign: 0xFCE4171A
-          ksceKernelDmaOpFree: 0xADFF1186
-          ksceKernelDmaOpSetupChain: 0x167079FC
-          ksceKernelDmaOpQuit: 0x03052D0D
           ksceKernelDmaOpConcatenate: 0xA4454DEA
-          ksceKernelDmaOpEnQueue: 0x543F54CF
           ksceKernelDmaOpDeQueue: 0x7433F70F
+          ksceKernelDmaOpEnQueue: 0x543F54CF
+          ksceKernelDmaOpFree: 0xADFF1186
+          ksceKernelDmaOpQuit: 0x03052D0D
           ksceKernelDmaOpSetCallback: 0xCF627CFD
-          ksceKernelDmaOpSync: 0x397A917C
+          ksceKernelDmaOpSetupChain: 0x167079FC
           ksceKernelDmaOpSetupDirect: 0x01A599E0
+          ksceKernelDmaOpSync: 0x397A917C
   SceCompat:
     nid: 0x8F2D0378
     libraries:
@@ -9599,20 +9599,20 @@ modules:
         nid: 0x5C9EE5B9
         functions:
           _sceCodecEngineAllocMemoryFromUnmapMemBlock: 0x03DCBDCA
+          _sceCodecEngineChangeNumWorkerCores: 0x7E5E1F38
+          _sceCodecEngineChangeNumWorkerCoresDefault: 0x362E9415
+          _sceCodecEngineChangeNumWorkerCoresMax: 0x04BA9415
           _sceCodecEngineCloseUnmapMemBlock: 0xAD30912D
           _sceCodecEngineFreeMemoryFromUnmapMemBlock: 0x489FF965
-          _sceCodecEngineOpenUnmapMemBlock: 0xB0E654EE
-          _sceCodecEngineChangeNumWorkerCoresMax: 0x04BA9415
-          _sceCodecEnginePmonStop: 0x04D5F36B
           _sceCodecEngineGetMemoryState: 0x1E9E5A79
-          _sceCodecEngineGetProcessorLoad: 0x241B194B
-          _sceCodecEngineChangeNumWorkerCoresDefault: 0x362E9415
-          _sceCodecEnginePmonGetProcessorLoad: 0x3EBA4982
-          _sceCodecEnginePmonStart: 0x6AF71F08
-          _sceCodecEngineChangeNumWorkerCores: 0x7E5E1F38
-          _sceCodecEngineResetNumRpcCalled: 0x8EFF2DAA
           _sceCodecEngineGetNumRpcCalled: 0x9B157692
+          _sceCodecEngineGetProcessorLoad: 0x241B194B
+          _sceCodecEngineOpenUnmapMemBlock: 0xB0E654EE
+          _sceCodecEnginePmonGetProcessorLoad: 0x3EBA4982
           _sceCodecEnginePmonReset: 0xCA79BFC4
+          _sceCodecEnginePmonStart: 0x6AF71F08
+          _sceCodecEnginePmonStop: 0x04D5F36B
+          _sceCodecEngineResetNumRpcCalled: 0x8EFF2DAA
           _sceCodecEngineSetClockFrequency: 0xDE5EF6CC
   SceExcpmgr:
     nid: 0xF3D9E37C
@@ -9631,21 +9631,21 @@ modules:
         nid: 0x15F25C84
         functions:
           ksceSblSmSchedCallFunc: 0x723B382F
-          ksceSblSmSchedProxyGetStatus: 0x27EB92F1
-          ksceSblSmSchedProxyInvoke: 0x1916509B
-          ksceSblSmSchedProxyWait: 0xF35EFC1A
-          ksceSblSmSchedProxyInitialize: 0xA488D604
           ksceSblSmSchedProxyChangeF00DStatus: 0xDE4EAC3C
+          ksceSblSmSchedProxyDisableCry2ArmInterrupt: 0x85EDA5FC
+          ksceSblSmSchedProxyEnableCry2ArmInterrupt: 0x8B84AC2A
+          ksceSblSmSchedProxyExecuteF00DCommand: 0x7894B6F0
+          ksceSblSmSchedProxyGetCommandF00DRegister: 0xF70C04EC
+          ksceSblSmSchedProxyGetStatus: 0x27EB92F1
+          ksceSblSmSchedProxyGetUnknownF00DRegister: 0x3CE17233
+          ksceSblSmSchedProxyInitialize: 0xA488D604
+          ksceSblSmSchedProxyInvoke: 0x1916509B
           ksceSblSmSchedProxyNotImplementedMaybeSMC0x131: 0x984EC9D1
           ksceSblSmSchedProxyNotImplementedMaybeSMC0x132: 0x1DFC8624
-          ksceSblSmSchedProxyGetCommandF00DRegister: 0xF70C04EC
-          ksceSblSmSchedProxyGetUnknownF00DRegister: 0x3CE17233
-          ksceSblSmSchedProxyWriteCry2Arm: 0x15B0E4DF
           ksceSblSmSchedProxyReadCry2Arm: 0x973A4A7D
-          ksceSblSmSchedProxyEnableCry2ArmInterrupt: 0x8B84AC2A
-          ksceSblSmSchedProxyDisableCry2ArmInterrupt: 0x85EDA5FC
           ksceSblSmSchedProxyUninitialize: 0x33A3A1E2
-          ksceSblSmSchedProxyExecuteF00DCommand: 0x7894B6F0
+          ksceSblSmSchedProxyWait: 0xF35EFC1A
+          ksceSblSmSchedProxyWriteCry2Arm: 0x15B0E4DF
   SceSblSsSmComm:
     nid: 0xBB4B5D92
     libraries:
@@ -9698,9 +9698,9 @@ modules:
         kernel: true
         functions:
           ksceDbgpGetDTraceBreakpointHandler: 0x01D7C7BF
+          ksceDbgpGetDTraceUsdtHandler: 0x9CD5EE8C
           ksceDbgpSetDTraceBreakpointHandler: 0x0509AC51
           ksceDbgpSetDTraceUsdtHandler: 0x7251789E
-          ksceDbgpGetDTraceUsdtHandler: 0x9CD5EE8C
   SceFios2Kernel:
     nid: 0x10ECF2D0
     libraries:
@@ -9708,26 +9708,26 @@ modules:
         nid: 0x8757B742
         kernel: false
         functions:
-          _sceFiosKernelOverlayDHCloseSync: 0x021B4AF7
-          _sceFiosKernelOverlayAddForProcess: 0x2A381357
-          _sceFiosKernelOverlayDHSyncSync: 0x2A9724C9
-          _sceFiosKernelOverlayDHReadSync: 0x2F06ADC6
-          _sceFiosKernelOverlayThreadSetDisabled: 0x3E9172EA
-          _sceFiosKernelOverlayDHOpenSync: 0x5D6A1CCE
-          _sceFiosKernelOverlayThreadIsDisabled: 0x629F4FE4
-          _sceFiosKernelOverlayModify: 0x6D6CDE05
           _sceFiosKernelOverlayAdd: 0x6DBCF0B2
-          _sceFiosKernelOverlayModifyForProcess: 0x6DF2FC05
+          _sceFiosKernelOverlayAddForProcess: 0x2A381357
+          _sceFiosKernelOverlayDHChstatSync: 0xF6A3E335
+          _sceFiosKernelOverlayDHCloseSync: 0x021B4AF7
+          _sceFiosKernelOverlayDHOpenSync: 0x5D6A1CCE
+          _sceFiosKernelOverlayDHReadSync: 0x2F06ADC6
           _sceFiosKernelOverlayDHStatSync: 0x759EBEE6
-          _sceFiosKernelOverlayResolveWithRangeSync: 0x8CCA471A
+          _sceFiosKernelOverlayDHSyncSync: 0x2A9724C9
+          _sceFiosKernelOverlayGetInfo: 0xF44F3505
+          _sceFiosKernelOverlayGetInfoForProcess: 0xBC6B3CC5
           _sceFiosKernelOverlayGetList: 0x9379E2D5
           _sceFiosKernelOverlayGetRecommendedScheduler: 0xB02E0B26
+          _sceFiosKernelOverlayModify: 0x6D6CDE05
+          _sceFiosKernelOverlayModifyForProcess: 0x6DF2FC05
           _sceFiosKernelOverlayRemove: 0xB4927173
-          _sceFiosKernelOverlayGetInfoForProcess: 0xBC6B3CC5
-          _sceFiosKernelOverlayResolveSync: 0xE9AE60FB
-          _sceFiosKernelOverlayGetInfo: 0xF44F3505
-          _sceFiosKernelOverlayDHChstatSync: 0xF6A3E335
           _sceFiosKernelOverlayRemoveForProcess: 0xF8277E07
+          _sceFiosKernelOverlayResolveSync: 0xE9AE60FB
+          _sceFiosKernelOverlayResolveWithRangeSync: 0x8CCA471A
+          _sceFiosKernelOverlayThreadIsDisabled: 0x629F4FE4
+          _sceFiosKernelOverlayThreadSetDisabled: 0x3E9172EA
       SceFios2KernelForDriver:
         nid: 0x54D6B9EB
         kernel: true
@@ -9767,40 +9767,40 @@ modules:
         nid: 0x7B13BCF7
         kernel: false
         functions:
-          _sceSblGcAuthMgrPcactActivation: 0x032E7CEA
-          _sceSblGcAuthMgrMsSaveBBCipherInit: 0x064BA38A
-          _sceSblGcAuthMgrAdhocBB160Shutdown: 0x076ADAB3
-          _sceSblGcAuthMgrAdhocBB160UniCastEncrypt: 0x08C4EE5F
+          _sceSblGcAuthMgrAdhocBB160Auth1: 0x5E56F845
+          _sceSblGcAuthMgrAdhocBB160Auth2: 0xD2218A6E
+          _sceSblGcAuthMgrAdhocBB160Auth3: 0xD1777A14
+          _sceSblGcAuthMgrAdhocBB160Auth4: 0x7F33DE86
+          _sceSblGcAuthMgrAdhocBB160Auth5: 0xD84C2E0C
+          _sceSblGcAuthMgrAdhocBB160BroadCastDecrypt: 0x2193A7CB
+          _sceSblGcAuthMgrAdhocBB160BroadCastEncrypt: 0x6125C3D9
           _sceSblGcAuthMgrAdhocBB160GetKeys: 0x09E1E270
+          _sceSblGcAuthMgrAdhocBB160Init: 0xE4AA1BB2
+          _sceSblGcAuthMgrAdhocBB160Shutdown: 0x076ADAB3
+          _sceSblGcAuthMgrAdhocBB160UniCastDecrypt: 0xD79A1B31
+          _sceSblGcAuthMgrAdhocBB160UniCastEncrypt: 0x08C4EE5F
+          _sceSblGcAuthMgrAdhocBB224Auth1: 0x307FD67C
+          _sceSblGcAuthMgrAdhocBB224Auth2: 0x788C0517
+          _sceSblGcAuthMgrAdhocBB224Auth3: 0xD3F95259
+          _sceSblGcAuthMgrAdhocBB224Auth4: 0x5CCC216C
+          _sceSblGcAuthMgrAdhocBB224Auth5: 0x459F5503
+          _sceSblGcAuthMgrAdhocBB224GetKeys: 0xC236FB28
+          _sceSblGcAuthMgrAdhocBB224Init: 0x5AB126A7
+          _sceSblGcAuthMgrAdhocBB224Shutdown: 0x8ECEACF9
           _sceSblGcAuthMgrGetMediaIdType01: 0x0AC64154
           _sceSblGcAuthMgrMsSaveBBCipherFinal: 0x18EAAD73
-          _sceSblGcAuthMgrAdhocBB160BroadCastDecrypt: 0x2193A7CB
-          _sceSblGcAuthMgrPsmactVerifyR1: 0x2B604356
-          _sceSblGcAuthMgrAdhocBB224Auth1: 0x307FD67C
-          _sceSblGcAuthMgrMsSaveBBMacInit: 0x3A92780D
-          _sceSblGcAuthMgrPsmactCreateC1: 0x3BD8B007
-          _sceSblGcAuthMgrPkgVry: 0x3E168BC4
-          _sceSblGcAuthMgrAdhocBB224Auth5: 0x459F5503
-          _sceSblGcAuthMgrAdhocBB224Init: 0x5AB126A7
-          _sceSblGcAuthMgrAdhocBB224Auth4: 0x5CCC216C
-          _sceSblGcAuthMgrAdhocBB160Auth1: 0x5E56F845
-          _sceSblGcAuthMgrAdhocBB160BroadCastEncrypt: 0x6125C3D9
-          _sceSblGcAuthMgrMsSaveBBMacUpdate: 0x716C0C3B
-          _sceSblGcAuthMgrAdhocBB224Auth2: 0x788C0517
-          _sceSblGcAuthMgrAdhocBB160Auth4: 0x7F33DE86
-          _sceSblGcAuthMgrSclkSetData2: 0x837D0FB6
-          _sceSblGcAuthMgrSclkGetData1: 0x8A3AF1E8
-          _sceSblGcAuthMgrAdhocBB224Shutdown: 0x8ECEACF9
-          _sceSblGcAuthMgrPcactGetChallenge: 0x98153286
-          _sceSblGcAuthMgrAdhocBB224GetKeys: 0xC236FB28
-          _sceSblGcAuthMgrAdhocBB160Auth3: 0xD1777A14
-          _sceSblGcAuthMgrAdhocBB160Auth2: 0xD2218A6E
-          _sceSblGcAuthMgrAdhocBB224Auth3: 0xD3F95259
-          _sceSblGcAuthMgrAdhocBB160UniCastDecrypt: 0xD79A1B31
-          _sceSblGcAuthMgrAdhocBB160Auth5: 0xD84C2E0C
-          _sceSblGcAuthMgrAdhocBB160Init: 0xE4AA1BB2
+          _sceSblGcAuthMgrMsSaveBBCipherInit: 0x064BA38A
           _sceSblGcAuthMgrMsSaveBBCipherUpdate: 0xF6FECCE0
           _sceSblGcAuthMgrMsSaveBBMacFinal: 0xFDDDD1D4
+          _sceSblGcAuthMgrMsSaveBBMacInit: 0x3A92780D
+          _sceSblGcAuthMgrMsSaveBBMacUpdate: 0x716C0C3B
+          _sceSblGcAuthMgrPcactActivation: 0x032E7CEA
+          _sceSblGcAuthMgrPcactGetChallenge: 0x98153286
+          _sceSblGcAuthMgrPkgVry: 0x3E168BC4
+          _sceSblGcAuthMgrPsmactCreateC1: 0x3BD8B007
+          _sceSblGcAuthMgrPsmactVerifyR1: 0x2B604356
+          _sceSblGcAuthMgrSclkGetData1: 0x8A3AF1E8
+          _sceSblGcAuthMgrSclkSetData2: 0x837D0FB6
   SceBbmc:
     nid: 0x858FDE3E
     libraries:
@@ -9808,83 +9808,83 @@ modules:
         nid: 0xEB0B15B7
         kernel: false
         functions:
-          sceBbmcVerifyPin: 0x057B2157
-          sceBbmcNetworkScanStart: 0x061AFC8C
-          sceBbmcSMSGetListDone: 0x0A67866B
-          sceBbmcDLQGetCurrentFwDone: 0x118CDC1C
-          sceBbmcIsAbleToRunUnderCurrentVoltage: 0x197B5917
-          sceBbmcUnblockPin: 0x1B1015D0
-          sceBbmcIsAbleToRunUnderCurrentTemp: 0x1BC93FE5
-          sceBbmcDLQConfirmChangePartition: 0x1D381E0E
-          sceBbmcSimGetPLMNModeBit: 0x1F2BECDC
-          sceBbmcSetupSetValue: 0x265332ED
-          sceBbmcSetupGetValueDone: 0x3776D173
-          sceBbmcDLQGetCurrentFwStart: 0x3BB8A8DE
-          sceBbmcSMSReadAck: 0x3D366DF3
-          sceBbmcUsbExtIfWrite: 0x4034E750
-          sceBbmcDLUpdaterGetLatestArchiveVersion: 0x4564777A
-          sceBbmcReadSimContentStart: 0x4734B7EB
-          sceBbmcUsbExtIfStart: 0x4ACC9A83
-          sceBbmcGetNetworkInfo: 0x4BF09F40
-          sceBbmcGetComFirmVersion: 0x4F76ACC2
-          sceBbmcResumeSubscriberCallback: 0x53D836E6
-          sceBbmcDLQGetFwListStart: 0x55DE9889
-          sceBbmcDLUpdaterCheckComVersion: 0x5711AE28
-          sceBbmcDLQRestoreEFSNV: 0x5A3CBF5D
-          sceBbmcGpsCellGetLocationInfoStart: 0x5D5096F2
-          sceBbmcDepersonalizeCK: 0x63318445
-          sceBbmcSMSGetListStart: 0x6669D937
-          sceBbmcDebugSelectOutMedia: 0x72FADFFD
-          sceBbmcDLQBackupEFSNV: 0x73E76F56
-          sceBbmcSMSReadStart: 0x74172AD5
-          sceBbmcEnvelopeCmd: 0x768A8471
-          sceBbmcPacketGetLastCallEndReason: 0x794F5690
-          sceBbmcNetworkAttach: 0x7AC350C7
-          sceBbmcDLUpdaterFin: 0x7CC2E683
-          sceBbmcDebugOutString: 0x80E029FE
-          sceBbmcSMSReadDone: 0x86A4ADE4
           sceBbmcClearEvent: 0x8A586895
-          sceBbmcGetFileRefreshDetail: 0x8DE4A529
-          sceBbmcReserveOperationMode: 0x8DEDBFE9
+          sceBbmcDLGetSwdlError: 0xCF5593A1
+          sceBbmcDLQAbort: 0xFD1B5B45
+          sceBbmcDLQBackupEFSNV: 0x73E76F56
+          sceBbmcDLQConfirmChangePartition: 0x1D381E0E
           sceBbmcDLQDownloadSafeImage: 0x8E1E5AAF
-          sceBbmcUsbExtIfRead: 0x91EE6FAB
-          sceBbmcGetIdStorageFrom3GModule: 0x924FD942
-          sceBbmcFileRefreshResponse: 0x9537AAAE
-          sceBbmcGetFailureInfo: 0x9831C17B
-          sceBbmcGpsCellGetLocationInfoDone: 0x98718027
-          sceBbmcDLUpdaterStart: 0xAF066666
-          sceBbmcSMSSend: 0xB2B9BE63
           sceBbmcDLQDownloadSlotImage: 0xB323A5C4
-          sceBbmcPacketReleasePDPContext: 0xB63E07B2
-          sceBbmcGetDriverInfo: 0xB888B51C
-          sceBbmcPacketIfSetControlFlag: 0xB9C53628
-          sceBbmcSetLPMMode: 0xBCA35FC0
+          sceBbmcDLQGetCurrentFwDone: 0x118CDC1C
+          sceBbmcDLQGetCurrentFwStart: 0x3BB8A8DE
           sceBbmcDLQGetFwListDone: 0xBD2A2EA8
+          sceBbmcDLQGetFwListStart: 0x55DE9889
+          sceBbmcDLQRestoreEFSNV: 0x5A3CBF5D
+          sceBbmcDLUpdaterCheckComVersion: 0x5711AE28
+          sceBbmcDLUpdaterContinue: 0xC10A5913
+          sceBbmcDLUpdaterFin: 0x7CC2E683
+          sceBbmcDLUpdaterGetArchiveVersion: 0xEE284EBE
+          sceBbmcDLUpdaterGetLatestArchiveVersion: 0x4564777A
+          sceBbmcDLUpdaterGetPkgId: 0xDCD146FD
           sceBbmcDLUpdaterGetSequence: 0xBDD26F9D
+          sceBbmcDLUpdaterStart: 0xAF066666
+          sceBbmcDebugOutString: 0x80E029FE
+          sceBbmcDebugSelectOutMedia: 0x72FADFFD
+          sceBbmcDepersonalizeCK: 0x63318445
+          sceBbmcEnvelopeCmd: 0x768A8471
+          sceBbmcFileRefreshResponse: 0x9537AAAE
+          sceBbmcGetCKStatus: 0xFFB454D9
+          sceBbmcGetComFirmVersion: 0x4F76ACC2
+          sceBbmcGetDriverInfo: 0xB888B51C
+          sceBbmcGetFailureInfo: 0x9831C17B
+          sceBbmcGetFileRefreshDetail: 0x8DE4A529
+          sceBbmcGetIdStorageFrom3GModule: 0x924FD942
+          sceBbmcGetNetworkInfo: 0x4BF09F40
+          sceBbmcGetPinStatus: 0xE8CB543C
+          sceBbmcGetProactiveCmd: 0xC3910F00
+          sceBbmcGpsCellGetLocationInfoDone: 0x98718027
+          sceBbmcGpsCellGetLocationInfoStart: 0x5D5096F2
+          sceBbmcIsAbleToRunUnderCurrentTemp: 0x1BC93FE5
+          sceBbmcIsAbleToRunUnderCurrentVoltage: 0x197B5917
+          sceBbmcIsPowerConfigForbiddenMode: 0xD31680C9
+          sceBbmcNetGetRejectCause: 0xE794FCE6
+          sceBbmcNetworkAttach: 0x7AC350C7
+          sceBbmcNetworkScanAbort: 0xE9548598
+          sceBbmcNetworkScanDone: 0xC4639A16
+          sceBbmcNetworkScanStart: 0x061AFC8C
+          sceBbmcPacketGetCurrentBearerTech: 0xEAAEC538
+          sceBbmcPacketGetLastCallEndReason: 0x794F5690
           sceBbmcPacketIfClearControlFlag: 0xBE889D60
           sceBbmcPacketIfGetControlFlag: 0xBF18905C
-          sceBbmcDLUpdaterContinue: 0xC10A5913
-          sceBbmcGetProactiveCmd: 0xC3910F00
-          sceBbmcNetworkScanDone: 0xC4639A16
-          sceBbmcUnblockCK: 0xC70DF0B8
-          sceBbmcSetupGetValueStart: 0xC946287D
-          sceBbmcDLGetSwdlError: 0xCF5593A1
-          sceBbmcIsPowerConfigForbiddenMode: 0xD31680C9
-          sceBbmcUnsubscribeFeature: 0xD4C16C0A
-          sceBbmcTerminalResponseCmd: 0xD878F761
-          sceBbmcDLUpdaterGetPkgId: 0xDCD146FD
-          sceBbmcSubscribeFeatureId: 0xE13ACE9A
-          sceBbmcNetGetRejectCause: 0xE794FCE6
+          sceBbmcPacketIfSetControlFlag: 0xB9C53628
+          sceBbmcPacketReleasePDPContext: 0xB63E07B2
           sceBbmcReadSimContentDone: 0xE8471E88
-          sceBbmcGetPinStatus: 0xE8CB543C
-          sceBbmcNetworkScanAbort: 0xE9548598
-          sceBbmcPacketGetCurrentBearerTech: 0xEAAEC538
-          sceBbmcDLUpdaterGetArchiveVersion: 0xEE284EBE
+          sceBbmcReadSimContentStart: 0x4734B7EB
+          sceBbmcReserveOperationMode: 0x8DEDBFE9
+          sceBbmcResumeSubscriberCallback: 0x53D836E6
+          sceBbmcSMSGetListDone: 0x0A67866B
+          sceBbmcSMSGetListStart: 0x6669D937
+          sceBbmcSMSReadAck: 0x3D366DF3
+          sceBbmcSMSReadDone: 0x86A4ADE4
+          sceBbmcSMSReadStart: 0x74172AD5
+          sceBbmcSMSSend: 0xB2B9BE63
+          sceBbmcSetLPMMode: 0xBCA35FC0
+          sceBbmcSetupGetValueDone: 0x3776D173
+          sceBbmcSetupGetValueStart: 0xC946287D
+          sceBbmcSetupSetValue: 0x265332ED
+          sceBbmcSimGetPLMNModeBit: 0x1F2BECDC
+          sceBbmcSubscribeFeatureId: 0xE13ACE9A
+          sceBbmcTerminalResponseCmd: 0xD878F761
           sceBbmcTurnOff: 0xEE731598
           sceBbmcTurnOn: 0xF1B7B34C
+          sceBbmcUnblockCK: 0xC70DF0B8
+          sceBbmcUnblockPin: 0x1B1015D0
+          sceBbmcUnsubscribeFeature: 0xD4C16C0A
+          sceBbmcUsbExtIfRead: 0x91EE6FAB
+          sceBbmcUsbExtIfStart: 0x4ACC9A83
           sceBbmcUsbExtIfStop: 0xF82F293A
-          sceBbmcDLQAbort: 0xFD1B5B45
-          sceBbmcGetCKStatus: 0xFFB454D9
+          sceBbmcUsbExtIfWrite: 0x4034E750
+          sceBbmcVerifyPin: 0x057B2157
   SceUlobjMgr:
     nid: 0xAC99A848
     libraries:
@@ -9892,8 +9892,8 @@ modules:
         nid: 0xDB18BB68
         kernel: false
         functions:
-          _sceUlobjMgrStartSupportingUserlevelObject: 0x08769991
           _sceUlobjMgrRegisterLibultProtocolRevision: 0x50F2F2AA
+          _sceUlobjMgrStartSupportingUserlevelObject: 0x08769991
           _sceUlobjMgrStopSupportingUserlevelObject: 0xEF09284B
   SceGps:
     nid: 0x7ECD5642
@@ -9902,16 +9902,16 @@ modules:
         nid: 0x0B6F33FE
         kernel: false
         functions:
-          _sceGpsResumeCallback: 0x0A4882B3
-          _sceGpsIsDevice: 0x0EE1BC7B
-          _sceGpsStart: 0x2914F243
-          _sceGpsSelectDevice: 0x2D4D8788
-          _sceGpsOpen: 0x6EAC2C6D
           _sceGpsClose: 0x73EE0ED1
-          _sceGpsGetDeviceInfo: 0x7F1DFADB
           _sceGpsGetData: 0x9BAF9579
-          _sceGpsIoctl: 0xB11E674D
+          _sceGpsGetDeviceInfo: 0x7F1DFADB
           _sceGpsGetState: 0xB8001499
+          _sceGpsIoctl: 0xB11E674D
+          _sceGpsIsDevice: 0x0EE1BC7B
+          _sceGpsOpen: 0x6EAC2C6D
+          _sceGpsResumeCallback: 0x0A4882B3
+          _sceGpsSelectDevice: 0x2D4D8788
+          _sceGpsStart: 0x2914F243
           _sceGpsStop: 0xE1ABB52D
   ScePamgr:
     nid: 0xA6771119
@@ -9920,37 +9920,37 @@ modules:
         nid: 0xAB606F3F
         kernel: false
         functions:
-          sceKernelPaGetTraceBufferSize: 0x0DD84F31
-          _sceKernelPaAddBusTraceByKey: 0x0F05045B
-          _sceKernelPaAddGpuTraceByKey: 0x174F2500
-          sceKernelPaRemoveCounterTraceByKey: 0x1FDDEBF0
-          sceKernelPaStartByKey: 0x28D43BE5
           _sceKernelPaAddArmTraceByKey: 0x2CB10FD0
-          sceKernelPaUnregister: 0x2DE1E55C
-          sceKernelPaRemoveGpuTraceByKey: 0x300258EE
-          sceKernelPaGetSharedKey: 0x30043A1F
-          _sceKernelPaGetGpuSampledData: 0x39096D8F
-          sceKernelPaGetTimebaseValue: 0x3FD2C5F5
-          sceKernelPaInsertBookmark: 0x53B16517
-          sceKernelPaRegisterShared: 0x556105AA
+          _sceKernelPaAddBusTraceByKey: 0x0F05045B
           _sceKernelPaAddCounterTraceByKey: 0x5F050AAF
-          sceKernelPaGetTraceBufferStatus: 0x78B19CDE
-          sceKernelPerfArmPmonReset: 0x7B9CF258
+          _sceKernelPaAddGpuTraceByKey: 0x174F2500
+          _sceKernelPaGetGpuSampledData: 0x39096D8F
           _sceKernelPaSetupTraceBufferByKey: 0x7BD1B4A3
-          sceKernelPerfArmPmonOpen: 0x7F5A960E
-          sceKernelPaRegister: 0x822E0719
-          sceKernelPaStopByKey: 0x8252E671
-          sceKernelPerfArmPmonSelectEvent: 0x9E55649C
-          sceKernelPerfArmPmonStop: 0xA42BDD17
           sceKernelPaGetIoBaseAddress: 0xA4EE9025
-          sceKernelPerfArmPmonStart: 0xAAE516BC
-          sceKernelPaRemoveBusTraceByKey: 0xBFE73BEB
-          sceKernelPerfArmPmonClose: 0xC9F72613
-          sceKernelPaGetWritePointer: 0xCA0D64C8
+          sceKernelPaGetSharedKey: 0x30043A1F
           sceKernelPaGetTimebaseFrequency: 0xCAEE6AF2
+          sceKernelPaGetTimebaseValue: 0x3FD2C5F5
+          sceKernelPaGetTraceBufferSize: 0x0DD84F31
+          sceKernelPaGetTraceBufferStatus: 0x78B19CDE
+          sceKernelPaGetWritePointer: 0xCA0D64C8
+          sceKernelPaInsertBookmark: 0x53B16517
+          sceKernelPaRegister: 0x822E0719
+          sceKernelPaRegisterShared: 0x556105AA
           sceKernelPaRemoveArmTraceByKey: 0xDD4D0A27
+          sceKernelPaRemoveBusTraceByKey: 0xBFE73BEB
+          sceKernelPaRemoveCounterTraceByKey: 0x1FDDEBF0
+          sceKernelPaRemoveGpuTraceByKey: 0x300258EE
           sceKernelPaSetBookmarkChannelEnableByKey: 0xF8D02FF4
+          sceKernelPaStartByKey: 0x28D43BE5
+          sceKernelPaStopByKey: 0x8252E671
+          sceKernelPaUnregister: 0x2DE1E55C
+          sceKernelPerfArmPmonClose: 0xC9F72613
+          sceKernelPerfArmPmonOpen: 0x7F5A960E
+          sceKernelPerfArmPmonReset: 0x7B9CF258
+          sceKernelPerfArmPmonSelectEvent: 0x9E55649C
           sceKernelPerfArmPmonSetCounterValue: 0xFC954C07
+          sceKernelPerfArmPmonStart: 0xAAE516BC
+          sceKernelPerfArmPmonStop: 0xA42BDD17
   SceUsbServ:
     nid: 0xAE54F579
     libraries:
@@ -9958,8 +9958,8 @@ modules:
         nid: 0xDA3C0EF0
         kernel: false
         functions:
-          sceUsbServAccessoryDeactivate: 0x154246A9
           sceUsbServAccessoryActivate: 0xB33AA2EB
+          sceUsbServAccessoryDeactivate: 0x154246A9
   SceWlanBt:
     nid: 0x99052D93
     libraries:
@@ -9967,19 +9967,19 @@ modules:
         nid: 0x22821EA3
         kernel: false
         functions:
-          sceWlanGetWakeOnTargetProcess: 0x18E6AFB2
           sceWlanGetConfiguration: 0x70AF9BD6
-          sceWlanUnregisterCallback: 0x826DC04F
+          sceWlanGetWakeOnTargetProcess: 0x18E6AFB2
           sceWlanRegisterCallback: 0xAA2E46F6
           sceWlanSetConfiguration: 0xDBE8AEF2
+          sceWlanUnregisterCallback: 0x826DC04F
       SceWlanBtForDriver:
         nid: 0xFD94FCE9
         kernel: true
         functions:
-          ksceWlanBtDetachMonitor: 0xA7FDE9DC
-          ksceWlanBtSetConfiguration: 0x4C96C3B7
-          ksceWlanBtGetConfiguration: 0x0FC89113
           ksceWlanBtAttachMonitor: 0xC5AA6F43
+          ksceWlanBtDetachMonitor: 0xA7FDE9DC
+          ksceWlanBtGetConfiguration: 0x0FC89113
+          ksceWlanBtSetConfiguration: 0x4C96C3B7
   SceError:
     nid: 0x8713337B
     libraries:
@@ -9987,12 +9987,12 @@ modules:
         nid: 0x5CD2CAD1
         kernel: false
         functions:
-          _sceErrorHistoryUpdateSequenceInfo: 0x6FBE4BDC
-          _sceErrorHistoryPostError: 0x70F9D872
           _sceErrorGetExternalString: 0x85747003
-          _sceErrorHistorySetDefaultFormat: 0xB94DAA2F
           _sceErrorHistoryClearError: 0xC88F479E
           _sceErrorHistoryGetError: 0xF16DF981
+          _sceErrorHistoryPostError: 0x70F9D872
+          _sceErrorHistorySetDefaultFormat: 0xB94DAA2F
+          _sceErrorHistoryUpdateSequenceInfo: 0x6FBE4BDC
   SceSystimer:
     nid: 0x9A1E946B
     libraries:
@@ -10008,12 +10008,12 @@ modules:
         nid: 0xD401318D
         kernel: true
         functions:
-          ksceErrorHistoryUpdateSequenceInfo: 0x1AA2E39E
-          ksceErrorHistorySetDefaultFormat: 0x395240A1
-          ksceErrorHistoryClearError: 0x7DF547D1
           ksceErrorGetExternalString: 0xA4DE5B69
+          ksceErrorHistoryClearError: 0x7DF547D1
           ksceErrorHistoryGetError: 0xB908B17F
           ksceErrorHistoryPostError: 0xBC416CFA
+          ksceErrorHistorySetDefaultFormat: 0x395240A1
+          ksceErrorHistoryUpdateSequenceInfo: 0x1AA2E39E
       SceDrmBridgeUser:
         nid: 0x91AFEB43
         kernel: true
@@ -10037,12 +10037,12 @@ modules:
         nid: 0xA067B56F
         kernel: true
         functions:
+          kscePfsAcidDirApprove: 0x8CDA249A
+          kscePfsAcidDirMount: 0x4A4A8243
+          kscePfsAcidDirSet: 0xB0CC0A1A
+          kscePfsAcidDirUnmount: 0x00C8AF80
+          kscePfsApprove: 0xD8D0FEE5
+          kscePfsDisapprove: 0x2D67D8CA
           kscePfsMount: 0xA772209C
           kscePfsMount2: 0x2D48AEA2
           kscePfsUnmount: 0x680BC384
-          kscePfsApprove: 0xD8D0FEE5
-          kscePfsDisapprove: 0x2D67D8CA
-          kscePfsAcidDirMount: 0x4A4A8243
-          kscePfsAcidDirUnmount: 0x00C8AF80
-          kscePfsAcidDirApprove: 0x8CDA249A
-          kscePfsAcidDirSet: 0xB0CC0A1A


### PR DESCRIPTION
I'm using [`db_lookup.yml`](https://gist.github.com/devnoname120/2975ef91ed5180fe8cf680424ebbde66) as a reference for library and module names and nids.

# PSVita 3.60 NIDs from syslibtrace

https://pastebin.com/ZAfpHwEH

```
./dbtools.py mergenids

[error] Function sceTestBridgeThreadMgrFastMutexStop with NID 0x00fddd35 not found in lookup, ignoring...
[error] Function sceKernelCheckSystemStatus with NID 0x082f7880 not found in lookup, ignoring...
[error] Function sceKernelSaveSystemStatus with NID 0x09ea2915 not found in lookup, ignoring...
[error] Function sceSblFIWNandFirmInitUpdateForUser with NID 0x11b6b931 not found in lookup, ignoring...
[error] Function sceTestBridgeThreadMgrSetAndDeleteSuspendThreadEvf with NID 0x1693f1f0 not found in lookup, ignoring...
[warning] Function sceKernelLockMutex_089 found with different name in db: ksceKernelLockMutex , skipping...
[error] Function sceTestBridgeThreadMgrSuspendThread with NID 0x1cdc85ca not found in lookup, ignoring...
[warning] Function sceKernelUnlockMutex_089 found with different name in db: ksceKernelUnlockMutex , skipping...
[error] Function sceTestBridgeThreadMgrIsCoredumpHandlerRegistered with NID 0x210fc3dd not found in lookup, ignoring...
[error] Function sceSblFIWReadNVSForUser with NID 0x219f1973 not found in lookup, ignoring...
[warning] Function sceKernelStartThread_089 found with different name in db: ksceKernelStartThread , skipping...
[warning] Function sceKernelTryLockMutex_089 found with different name in db: ksceKernelTryLockMutex , skipping...
[error] Function sceSblFIWConfigurePartitionsForUser with NID 0x3153dc53 not found in lookup, ignoring...
[error] Function sceTestBridgeThreadMgrUnregisterCoredumpHandler with NID 0x34f35b3e not found in lookup, ignoring...
[error] Function sceTestBridgeThreadMgrDeleteStopThreadEvf with NID 0x4081ad59 not found in lookup, ignoring...
[error] Function sceTestBridgeProcessmgrCreateProcess with NID 0x436fb111 not found in lookup, ignoring...
[error] Function sceTestbridgeApi with NID 0x486e7dea not found in lookup, ignoring...
[error] Function sceSblFIWWriteForUser with NID 0x4fc7cd2e not found in lookup, ignoring...
[error] Function sceTestBridgeThreadMgrStopThread with NID 0x50906ff4 not found in lookup, ignoring...
[error] Function sceTestBridgeProcessmgrWaitProcessEnd with NID 0x5107ac90 not found in lookup, ignoring...
[error] Function sceTestBridgeGetKermitRevision with NID 0x5273d5bb not found in lookup, ignoring...
[error] Function sceTestBridgeProcessmgrStartProcess with NID 0x57a21be9 not found in lookup, ignoring...
[error] Function sceSblFIWReleaseForUser with NID 0x57be2b8e not found in lookup, ignoring...
[error] Function sceTestBridgeThreadMgrGetLwMutexInfoAll with NID 0x62a6cc7a not found in lookup, ignoring...
[warning] Function sceKernelGetMutexInfo_089 found with different name in db: ksceKernelGetMutexInfo , skipping...
[error] Function sceTestBridgeThreadMgrSetThreadMgrTestMode with NID 0x6e39c613 not found in lookup, ignoring...
[error] Function sceTestBridgeThreadMgrRegisterCoredumpHandler with NID 0x7023dafe not found in lookup, ignoring...
[error] Function _sceHttpStorageLoadCertFromFlash with NID 0x71847621 not found in lookup, ignoring...
[warning] Function sceKernelCancelMutex_089 found with different name in db: ksceKernelCancelMutex , skipping...
[error] Function sceTestBridgeThreadMgrFastMutexLockUnlock with NID 0x7486b25a not found in lookup, ignoring...
[error] Function sceTestBridgeThreadMgrFastMutexStart with NID 0x8004b3c7 not found in lookup, ignoring...
[error] Function sceSblFIWCheckPartitionInfoForUser with NID 0x89836bbd not found in lookup, ignoring...
[error] Function sceTestBridgeProcessmgrSpawnProcess with NID 0x8a8ec18b not found in lookup, ignoring...
[warning] Function sceNgsRackGetVoiceHandleInternal found with different name in db: sceNgsRackGetVoiceHandleInternal6 , skipping...
[error] Function sceTestBridgeThreadMgrRunningInSyscall with NID 0x91c4fbe1 not found in lookup, ignoring...
[error] Function sceTestBridgeThreadMgrCallCoredumpHandler with NID 0x97cc180a not found in lookup, ignoring...
[error] Function sceSblFIWReadForUser with NID 0x9e8077dd not found in lookup, ignoring...
[error] Function sceSblFIWShutdownForUser with NID 0x9ffdcfbd not found in lookup, ignoring...
[warning] Function _sceSysmoduleUnloadModuleInternalWithArg found with different name in db: sceSysmoduleUnloadModuleInternalWithArg , skipping...
[error] Function sceSblFIWNandFirmGetVersionForUser with NID 0xa3083962 not found in lookup, ignoring...
[error] Function sceSblFIWSetPSLedForUser with NID 0xa33657c1 not found in lookup, ignoring...
[error] Function sceSblFIWWriteNVSForUser with NID 0xab5f962a not found in lookup, ignoring...
[error] Function sceTestBridgeThreadMgrFastMutexShowStat with NID 0xac598142 not found in lookup, ignoring...
[error] Function sceKernelGetCpuId with NID 0xad80d00b not found in lookup, ignoring...
[error] Function sceSblFIWIsSupportPartitioningForUser with NID 0xaf5b3335 not found in lookup, ignoring...
[error] Function sceTestBridgeBacktraceFromIntr with NID 0xb3a66fc3 not found in lookup, ignoring...
[error] Function sceTestBridgeProcessmgrDeleteBudget with NID 0xb621ef09 not found in lookup, ignoring...
[error] Function sceTestBridgeNull with NID 0xb807f887 not found in lookup, ignoring...
[error] Function sceTestBridgeProcessmgrCreateBudget with NID 0xbab02e9a not found in lookup, ignoring...
[warning] Function _sceKernelGetThreadTLSAddr found with different name in db: sceKernelGetThreadTLSAddr , skipping...
[error] Function sceSblFIWGetVendorIdForUser with NID 0xbcf565f4 not found in lookup, ignoring...
[error] Function sceSblFIWNandFirmDoUpdateForUser with NID 0xc191b38e not found in lookup, ignoring...
[error] Function sceTestBridgeThreadMgrWaitInSyscall2 with NID 0xc36bf4ce not found in lookup, ignoring...
[warning] Function _sceSysmoduleLoadModuleInternalWithArg found with different name in db: sceSysmoduleLoadModuleInternalWithArg , skipping...
[warning] Function sceUsbdGetDeviceLocationForUser found with different name in db: sceUsbdGetDeviceAddress , skipping...
[error] Function sceTestBridgeThreadMgrResumeThread with NID 0xc820a39c not found in lookup, ignoring...
[error] Function sceTestBridgeThreadMgrWaitInSyscall with NID 0xcbd75741 not found in lookup, ignoring...
[error] Function sceTestBridgeThreadMgrClearThreadMgrTestMode with NID 0xd32ea1d8 not found in lookup, ignoring...
[error] Function sceTestBridgeThreadMgrSpawnPriorityThread with NID 0xd5d9c3a4 not found in lookup, ignoring...
[error] Function sceSblFIWAllocateForUser with NID 0xd6b1133b not found in lookup, ignoring...
[error] Function sceSblFIWDoPersonalizeForUser with NID 0xdf227d6b not found in lookup, ignoring...
[error] Function sceTestBridgeThreadMgrExitDeleteThreadInSyscall with NID 0xe847175f not found in lookup, ignoring...
[error] Function sceSblFIWGetCIDForUser with NID 0xeb7b3e97 not found in lookup, ignoring...
[error] Function sceSblFIWGetstatForUser with NID 0xf3a56598 not found in lookup, ignoring...
[warning] Ignoring entry 0xFFFFFFFF because it's not a valid 'nid name'
```



# 3.60 Vita NIDs
https://pastebin.com/G0q01WjB

**This nid list didn't add any NIDs in `db.yml` which is why there is no commit for this**.

```
./dbtools.py mergenids
[error] Function sceSha512Digest with NID 0x5DC0B916 not found in lookup, ignoring...
[error] Function sceSha512BlockResult with NID 0x26146A16 not found in lookup, ignoring...
[error] Function sceSha512BlockInit with NID 0xE017A9CD not found in lookup, ignoring...
[error] Function sceSha512BlockUpdate with NID 0x669281E8 not found in lookup, ignoring...
[error] Function sceSmartSceneMappingStart with NID 0xA3A82B99 not found in lookup, ignoring...
[error] Function sceSmartSceneMappingGetNodePointInfo with NID 0x607AACB5 not found in lookup, ignoring...
[error] Function sceSmartSceneMappingDispatchAndQueryWithMask with NID 0x4D9EA817 not found in lookup, ignoring...
[error] Function sceSmartSceneMappingStop with NID 0x52EB57E4 not found in lookup, ignoring...
[error] Function sceSmartCreateLearnedImageTarget with NID 0x5A31446E not found in lookup, ignoring...
[error] Function sceSmartSceneMappingEnableMask with NID 0x7C4731E2 not found in lookup, ignoring...
[error] Function sceSmartSceneMappingReset with NID 0xC1AD43BC not found in lookup, ignoring...
[error] Function sceSmartTargetTrackingRegisterTarget with NID 0x8ACADD54 not found in lookup, ignoring...
[error] Function sceSmartSceneMappingDispatchAndQuery with NID 0xF10FDDD1 not found in lookup, ignoring...
[error] Function sceSmartGetTargetInfo with NID 0x23EDFA9A not found in lookup, ignoring...
[error] Function sceSmartSceneMappingGetNumLandmarks with NID 0x2260E8BB not found in lookup, ignoring...
[error] Function sceSmartSceneMappingGetNumInitializationPoints with NID 0xDF900B29 not found in lookup, ignoring...
[error] Function sceSmartSceneMappingSetDenseMapMode with NID 0xE7867558 not found in lookup, ignoring...
[error] Function sceSmartTargetTrackingRun with NID 0xBFD87F61 not found in lookup, ignoring...
[error] Function sceSmartSceneMappingPropagateResult with NID 0x5A9EC64D not found in lookup, ignoring...
[error] Function sceSmartSceneMappingRun with NID 0xC7EBD753 not found in lookup, ignoring...
[error] Function sceSmartSceneMappingForceLocalize with NID 0x6D4081D3 not found in lookup, ignoring...
[error] Function sceSmartSceneMappingUnregisterTarget with NID 0x6807CA97 not found in lookup, ignoring...
[error] Function sceSmartTargetTrackingDispatchAndQuery with NID 0x7FE71305 not found in lookup, ignoring...
[error] Function sceSmartTargetTrackingQuery with NID 0x2808C8CB not found in lookup, ignoring...
[error] Function sceSmartRelease with NID 0x43DF6D9C not found in lookup, ignoring...
[error] Function sceSmartSceneMappingFixMap with NID 0xA96B997B not found in lookup, ignoring...
[error] Function sceSmartTargetTrackingStop with NID 0xC4C607C0 not found in lookup, ignoring...
[error] Function sceSmartSceneMappingRegisterTarget with NID 0x55C37F31 not found in lookup, ignoring...
[error] Function sceSmartTargetTrackingRun2 with NID 0x245EC28A not found in lookup, ignoring...
[error] Function sceSmartTargetTrackingRunWorker with NID 0x8AE7354A not found in lookup, ignoring...
[error] Function sceSmartSceneMappingRunCore with NID 0xCB30BD4D not found in lookup, ignoring...
[error] Function sceSmartSceneMappingGetInitializationPointInfo with NID 0x9A578A29 not found in lookup, ignoring...
[error] Function sceSmartSceneMappingGetNumNodePoints with NID 0x3159D38C not found in lookup, ignoring...
[error] Function sceSmartSceneMappingRemoveLandmark with NID 0x9F30C12A not found in lookup, ignoring...
[error] Function sceSmartSceneMappingLoadMap with NID 0x961367D3 not found in lookup, ignoring...
[error] Function sceSmartTargetTrackingSetSearchPolicy with NID 0x35344A8E not found in lookup, ignoring...
[error] Function sceSmartSceneMappingSaveMap with NID 0x4907021F not found in lookup, ignoring...
[error] Function sceSmartTargetTrackingReset with NID 0xA4A155B5 not found in lookup, ignoring...
[error] Function sceSmartSceneMappingGetLandmarkInfo with NID 0xB17057EA not found in lookup, ignoring...
[error] Function sceSmartTargetTrackingGetResults with NID 0x648C7E15 not found in lookup, ignoring...
[error] Function sceSmartDestroyTarget with NID 0x0C6A1DA8 not found in lookup, ignoring...
[error] Function sceSmartInit with NID 0x58979C84 not found in lookup, ignoring...
[error] Function sceSmartTargetTrackingUnregisterTarget with NID 0x6EE07829 not found in lookup, ignoring...
[error] Function sceSmartTargetTrackingStart with NID 0x5A121F6C not found in lookup, ignoring...
[error] Function sceSha512tBlockResult with NID 0x66425DB6 not found in lookup, ignoring...
[error] Function sceSha512tBlockUpdate with NID 0xC5359DF8 not found in lookup, ignoring...
[error] Function sceSha512tDigest with NID 0x00E52720 not found in lookup, ignoring...
[error] Function sceSha512tBlockInit with NID 0x79065BB2 not found in lookup, ignoring...
[error] Function _pLibPerfCaptureFlagPtr with NID 0x936A5F31 not found in lookup, ignoring...
[error] Function sceMd5BlockInit with NID 0x4D6436F9 not found in lookup, ignoring...
[error] Function sceMd5BlockResult with NID 0xB94ABF83 not found in lookup, ignoring...
[error] Function sceMd5BlockUpdate with NID 0x094A4902 not found in lookup, ignoring...
[error] Function sceMd5Digest with NID 0xB845BCCB not found in lookup, ignoring...
[error] Function sceMt19937UInt with NID 0x29E43BB5 not found in lookup, ignoring...
[error] Function sceMt19937Init with NID 0xEE5BA27C not found in lookup, ignoring...
[error] Function sqlite3_version with NID 0xB80D43C7 not found in lookup, ignoring...
[error] Function sqlite3_temp_directory with NID 0x1AEC1F74 not found in lookup, ignoring...
[error] Function sceSha256BlockResult with NID 0x9B5BB4BA not found in lookup, ignoring...
[error] Function sceSha256BlockUpdate with NID 0xDAECA1F8 not found in lookup, ignoring...
[error] Function sceSha256Digest with NID 0xA337079C not found in lookup, ignoring...
[error] Function sceSha256BlockInit with NID 0xE281374F not found in lookup, ignoring...
[error] Function sceSfmt86243InitGenRand with NID 0x2FF42588 not found in lookup, ignoring...
[error] Function sceSfmt86243FillArray32 with NID 0xC297E6B1 not found in lookup, ignoring...
[error] Function sceSfmt86243GenRand64 with NID 0x8E25CBA8 not found in lookup, ignoring...
[error] Function sceSfmt86243InitByArray with NID 0x81B67AB5 not found in lookup, ignoring...
[error] Function sceSfmt86243FillArray64 with NID 0xF7FFE87C not found in lookup, ignoring...
[error] Function sceSfmt86243GenRand32 with NID 0x569BF903 not found in lookup, ignoring...
[error] Function sceSha0BlockInit with NID 0xBCF6DB3A not found in lookup, ignoring...
[error] Function sceSha0Digest with NID 0xD19A9AA8 not found in lookup, ignoring...
[error] Function sceSha0BlockResult with NID 0xBF0158C4 not found in lookup, ignoring...
[error] Function sceSha0BlockUpdate with NID 0x37EF2AFC not found in lookup, ignoring...
[error] Function sceSha1Digest with NID 0xE1215C9D not found in lookup, ignoring...
[error] Function sceSha1BlockUpdate with NID 0x9007205E not found in lookup, ignoring...
[error] Function sceSha1BlockResult with NID 0x0195DADF not found in lookup, ignoring...
[error] Function sceSha1BlockInit with NID 0xB13D65AA not found in lookup, ignoring...
[error] Function sceGzipGetInfo with NID 0x1B8E5862 not found in lookup, ignoring...
[error] Function sceDeflateDecompressPartial with NID 0x25B8C7A2 not found in lookup, ignoring...
[error] Function sceGzipGetComment with NID 0xBABCF5CF not found in lookup, ignoring...
[error] Function sceZlibIsValid with NID 0x14A0698D not found in lookup, ignoring...
[error] Function sceGzipCrc32 with NID 0xF720A8F6 not found in lookup, ignoring...
[error] Function sceZlibGetCompressedData with NID 0xE680A65A not found in lookup, ignoring...
[error] Function sceZlibDecompress with NID 0xE38F754D not found in lookup, ignoring...
[error] Function sceDeflateDecompress with NID 0x110D5050 not found in lookup, ignoring...
[error] Function sceGzipGetCompressedData with NID 0xE1844802 not found in lookup, ignoring...
[error] Function sceZlibAdler32 with NID 0xCD83A464 not found in lookup, ignoring...
[error] Function sceZlibGetInfo with NID 0x4C0A685D not found in lookup, ignoring...
[error] Function sceGzipIsValid with NID 0xDEDADC31 not found in lookup, ignoring...
[error] Function sceGzipDecompress with NID 0xE3CB51A3 not found in lookup, ignoring...
[error] Function sceGzipGetName with NID 0xAEBAABE6 not found in lookup, ignoring...
[error] Function sceZipGetInfo with NID 0xDA404FE4 not found in lookup, ignoring...
[error] Function sceHeapReallocHeapMemory with NID 0x9E6716BA not found in lookup, ignoring...
[error] Function sceHeapAllocHeapMemoryWithOption with NID 0xD4C09869 not found in lookup, ignoring...
[error] Function sceHeapIsAllocatedHeapMemory with NID 0xAA50462F not found in lookup, ignoring...
[error] Function sceHeapFreeHeapMemory with NID 0xD09FFC11 not found in lookup, ignoring...
[error] Function sceHeapDeleteHeap with NID 0xA130D00C not found in lookup, ignoring...
[error] Function sceHeapAllocHeapMemory with NID 0xB6FC0BA1 not found in lookup, ignoring...
[error] Function sceHeapCreateHeap with NID 0xA7571AD8 not found in lookup, ignoring...
[error] Function sceHeapReallocHeapMemoryWithOption with NID 0x00BE8FC3 not found in lookup, ignoring...
[error] Function sceHeapGetTotalFreeSize with NID 0x76C5B003 not found in lookup, ignoring...
[error] Function sceHeapGetMallinfo with NID 0xAD2645B0 not found in lookup, ignoring...
[error] Function sceSfmt216091FillArray64 with NID 0xA1CE5628 not found in lookup, ignoring...
[error] Function sceSfmt216091GenRand32 with NID 0x4A972DCD not found in lookup, ignoring...
[error] Function sceSfmt216091InitGenRand with NID 0x86DDE4A7 not found in lookup, ignoring...
[error] Function sceSfmt216091GenRand64 with NID 0x23369ABF not found in lookup, ignoring...
[error] Function sceSfmt216091InitByArray with NID 0xA9CF6616 not found in lookup, ignoring...
[error] Function sceSfmt216091FillArray32 with NID 0xDD4256F0 not found in lookup, ignoring...
[error] Function __stack_chk_guard with NID 0x93B8AA67 not found in lookup, ignoring...
[error] Function SceKernelStackChkGuard with NID 0x4458BCF3 not found in lookup, ignoring...
[error] Function sceSfmt4253InitGenRand with NID 0xE9F8CB9A not found in lookup, ignoring...
[error] Function sceSfmt4253FillArray64 with NID 0x01683CDD not found in lookup, ignoring...
[error] Function sceSfmt4253GenRand32 with NID 0x8791E2EF not found in lookup, ignoring...
[error] Function sceSfmt4253GenRand64 with NID 0x6C0E5E3C not found in lookup, ignoring...
[error] Function sceSfmt4253FillArray32 with NID 0x59A1B9FC not found in lookup, ignoring...
[error] Function sceSfmt4253InitByArray with NID 0xC4D7AA2D not found in lookup, ignoring...
[warning] Function sceBtGetVidPid found with different name in db: sceBtGetDeviceId , skipping...
[error] Function sceSfmt1279InitByArray with NID 0xC25D9ACE not found in lookup, ignoring...
[error] Function sceSfmt1279FillArray64 with NID 0xDB3832EB not found in lookup, ignoring...
[error] Function sceSfmt1279GenRand32 with NID 0x9B4A48DF not found in lookup, ignoring...
[error] Function sceSfmt1279InitGenRand with NID 0x02E8D906 not found in lookup, ignoring...
[error] Function sceSfmt1279FillArray32 with NID 0xE7F63838 not found in lookup, ignoring...
[error] Function sceSfmt1279GenRand64 with NID 0xA2C5EE14 not found in lookup, ignoring...
[error] Function sceSfmt607InitGenRand with NID 0x76A5D8CA not found in lookup, ignoring...
[error] Function sceSfmt607GenRand64 with NID 0x5E880862 not found in lookup, ignoring...
[error] Function sceSfmt607FillArray64 with NID 0x1520D408 not found in lookup, ignoring...
[error] Function sceSfmt607GenRand32 with NID 0x8A0BF859 not found in lookup, ignoring...
[error] Function sceSfmt607FillArray32 with NID 0xA288ADB9 not found in lookup, ignoring...
[error] Function sceSfmt607InitByArray with NID 0xCC6DABA0 not found in lookup, ignoring...
[warning] Setting k prefix to function with unknown prefix: SceSblAuthMgrForKernel_0x026ACBAD
[warning] Setting k prefix to function with unknown prefix: SceSblAuthMgrForKernel_0xBC422443
[error] Function SceSblAuthMgrForKernel_0x15248FB4 with NID 0x15248FB4 not found in lookup, ignoring...
[warning] Setting k prefix to function with unknown prefix: SceSblAuthMgrForKernel_0xF3411881
[warning] Setting k prefix to function with unknown prefix: SceSblAuthMgrForKernel_0x89CCDA2C
[warning] Setting k prefix to function with unknown prefix: SceSblAuthMgrForKernel_0xA9CD2A09
[error] Function sceSfmt11213FillArray64 with NID 0x7A412A29 not found in lookup, ignoring...
[error] Function sceSfmt11213InitGenRand with NID 0x8FF464C9 not found in lookup, ignoring...
[error] Function sceSfmt11213GenRand32 with NID 0xFB281CD7 not found in lookup, ignoring...
[error] Function sceSfmt11213GenRand64 with NID 0xAFEDD6E1 not found in lookup, ignoring...
[error] Function sceSfmt11213InitByArray with NID 0xBAF5F058 not found in lookup, ignoring...
[error] Function sceSfmt11213FillArray32 with NID 0xFD696585 not found in lookup, ignoring...
[warning] Function ksceNetRecv found with different name in db: ksceNetRecvfrom , skipping...
[warning] Function ksceNetSend found with different name in db: ksceNetSendto , skipping...
[warning] Function ksceNetSocketClose found with different name in db: ksceNetClose , skipping...
[warning] Function ksceKernelUnmaskIntr found with different name in db: ksceKernelSetIntrMasked , skipping...
[error] Function sceSfmt19937GenRand32 with NID 0xF0557157 not found in lookup, ignoring...
[error] Function sceSfmt19937InitGenRand with NID 0x2AFACB0B not found in lookup, ignoring...
[error] Function sceSfmt19937GenRand64 with NID 0xE66F2502 not found in lookup, ignoring...
[error] Function sceSfmt19937FillArray64 with NID 0xE74BA81C not found in lookup, ignoring...
[error] Function sceSfmt19937InitByArray with NID 0xAC496C8C not found in lookup, ignoring...
[error] Function sceSfmt19937FillArray32 with NID 0xA1C654D8 not found in lookup, ignoring...
[error] Function sceSfmt132049InitGenRand with NID 0xDC6B23B0 not found in lookup, ignoring...
[error] Function sceSfmt132049GenRand64 with NID 0xBBD80AC4 not found in lookup, ignoring...
[error] Function sceSfmt132049InitByArray with NID 0xDC69294A not found in lookup, ignoring...
[error] Function sceSfmt132049FillArray32 with NID 0xD891A99F not found in lookup, ignoring...
[error] Function sceSfmt132049FillArray64 with NID 0x68AD7866 not found in lookup, ignoring...
[error] Function sceSfmt132049GenRand32 with NID 0x795F9644 not found in lookup, ignoring...
[error] Function sceHmacSha1Digest with NID 0x55871D87 not found in lookup, ignoring...
[error] Function sceHmacSha384BlockUpdate with NID 0xC16D8AB6 not found in lookup, ignoring...
[error] Function sceHmacSha0BlockResult with NID 0x05AE1466 not found in lookup, ignoring...
[error] Function sceHmacMd5Digest with NID 0x6EEB05D3 not found in lookup, ignoring...
[error] Function sceHmacSha224Digest with NID 0x359ED31E not found in lookup, ignoring...
[error] Function sceHmacSha512BlockUpdate with NID 0xECA83992 not found in lookup, ignoring...
[error] Function sceHmacSha384BlockResult with NID 0xBA308CDA not found in lookup, ignoring...
[error] Function sceHmacSha512BlockInit with NID 0x272FEFFE not found in lookup, ignoring...
[error] Function sceHmacSha224BlockUpdate with NID 0xB77629EB not found in lookup, ignoring...
[error] Function sceHmacSha256BlockInit with NID 0x96AD3A67 not found in lookup, ignoring...
[error] Function sceHmacMd5BlockResult with NID 0x9BCCC484 not found in lookup, ignoring...
[error] Function sceHmacSha1BlockUpdate with NID 0x6EF06490 not found in lookup, ignoring...
[error] Function sceHmacSha1BlockResult with NID 0xD0AF51C6 not found in lookup, ignoring...
[error] Function sceHmacSha1BlockInit with NID 0xA2285A9A not found in lookup, ignoring...
[error] Function sceHmacMd5BlockUpdate with NID 0x9FD439E9 not found in lookup, ignoring...
[error] Function sceHmacSha512BlockResult with NID 0x64219FF5 not found in lookup, ignoring...
[error] Function sceHmacSha256BlockResult with NID 0x5A52150F not found in lookup, ignoring...
[error] Function sceHmacSha224BlockInit with NID 0x393FF6BC not found in lookup, ignoring...
[error] Function sceHmacSha256Digest with NID 0xE254D9A1 not found in lookup, ignoring...
[error] Function sceHmacSha384BlockInit with NID 0xB786F59F not found in lookup, ignoring...
[error] Function sceHmacMd5BlockInit with NID 0xD6E232CD not found in lookup, ignoring...
[error] Function sceHmacSha0Digest with NID 0xCCB91784 not found in lookup, ignoring...
[error] Function sceHmacSha0BlockInit with NID 0xD44F6B32 not found in lookup, ignoring...
[error] Function sceHmacSha384Digest with NID 0x9C3B4844 not found in lookup, ignoring...
[error] Function sceHmacSha224BlockResult with NID 0x2AB46BB5 not found in lookup, ignoring...
[error] Function sceHmacSha0BlockUpdate with NID 0x9CB7F0EF not found in lookup, ignoring...
[error] Function sceHmacSha512Digest with NID 0x8FDFCE5B not found in lookup, ignoring...
[error] Function sceHmacSha256BlockUpdate with NID 0x0C9FA657 not found in lookup, ignoring...
[error] Function sceSfmt44497FillArray64 with NID 0x908F1122 not found in lookup, ignoring...
[error] Function sceSfmt44497InitGenRand with NID 0xCF1C8C38 not found in lookup, ignoring...
[error] Function sceSfmt44497GenRand32 with NID 0xF869DFDC not found in lookup, ignoring...
[error] Function sceSfmt44497GenRand64 with NID 0xD411A9A6 not found in lookup, ignoring...
[error] Function sceSfmt44497InitByArray with NID 0x16D8AA5E not found in lookup, ignoring...
[error] Function sceSfmt44497FillArray32 with NID 0x1C38322A not found in lookup, ignoring...
[error] Function monoeg_g_dir_read_name with NID 0x4600943C not found in lookup, ignoring...
[error] Function pss_create_semaphore with NID 0x5F969729 not found in lookup, ignoring...
[error] Function monoeg_g_str_hash with NID 0x475CAF76 not found in lookup, ignoring...
[error] Function monoeg_g_slist_reverse with NID 0xF1985656 not found in lookup, ignoring...
[error] Function monoeg_g_unichar_tolower with NID 0x1B7586C3 not found in lookup, ignoring...
[error] Function pthread_mutex_lock with NID 0xEB44087F not found in lookup, ignoring...
[error] Function monoeg_g_slist_remove with NID 0x2ACD677F not found in lookup, ignoring...
[error] Function pthread_getspecific_for_thread with NID 0x6581D5BB not found in lookup, ignoring...
[error] Function monoeg_g_slist_length with NID 0x3C4FA9AB not found in lookup, ignoring...
[error] Function pss_alloc_mem with NID 0x1A2E441F not found in lookup, ignoring...
[error] Function pss_net_sendto with NID 0x4A101C16 not found in lookup, ignoring...
[error] Function monoeg_g_ascii_xdigit_value with NID 0x522CF60A not found in lookup, ignoring...
[error] Function pss_io_write with NID 0xAF972DF7 not found in lookup, ignoring...
[error] Function monoeg_g_markup_parse_context_free with NID 0x828CA4F4 not found in lookup, ignoring...
[error] Function monoeg_g_list_prepend with NID 0x1BCA4E9C not found in lookup, ignoring...
[error] Function monoeg_g_timer_stop with NID 0xD2C1FCA7 not found in lookup, ignoring...
[error] Function pss_get_win32_filetime with NID 0x440F10FA not found in lookup, ignoring...
[error] Function monoeg_g_spaced_primes_closest with NID 0x0DC3FEE9 not found in lookup, ignoring...
[error] Function pthread_mutex_init with NID 0xBD7EAD04 not found in lookup, ignoring...
[error] Function pss_io_chstat with NID 0x0827A135 not found in lookup, ignoring...
[error] Function monoeg_g_slist_find with NID 0x91EF3384 not found in lookup, ignoring...
[error] Function monoeg_g_ptr_array_remove_index with NID 0x2BD1603F not found in lookup, ignoring...
[error] Function pthread_mutex_trylock with NID 0xF52A345B not found in lookup, ignoring...
[error] Function monoeg_g_filename_from_uri with NID 0x08AD58AF not found in lookup, ignoring...
[error] Function monoeg_g_slist_delete_link with NID 0xF745BBBD not found in lookup, ignoring...
[error] Function pss_free_raw with NID 0xB9EFB986 not found in lookup, ignoring...
[error] Function pss_net_epoll_ctl with NID 0x335C5433 not found in lookup, ignoring...
[error] Function monoeg_g_filename_to_uri with NID 0xB8A330FA not found in lookup, ignoring...
[error] Function monoeg_g_list_insert_before with NID 0x75BD1C5D not found in lookup, ignoring...
[error] Function pss_get_thread_context with NID 0x6ABAA310 not found in lookup, ignoring...
[error] Function monoeg_g_hash_table_insert_replace with NID 0x0C466869 not found in lookup, ignoring...
[error] Function monoeg_g_slist_free_1 with NID 0xFF75E8C2 not found in lookup, ignoring...
[error] Function monoeg_g_slist_copy with NID 0x7966B92E not found in lookup, ignoring...
[error] Function monoeg_g_list_foreach with NID 0xF6A02E4F not found in lookup, ignoring...
[error] Function pss_code_mem_flush_icache with NID 0x110F567B not found in lookup, ignoring...
[error] Function pss_code_mem_alloc with NID 0xF466ABEC not found in lookup, ignoring...
[error] Function monoeg_g_utf8_strdown with NID 0x6ED9113B not found in lookup, ignoring...
[error] Function monoeg_g_unsetenv with NID 0x2B391E9F not found in lookup, ignoring...
[error] Function pthread_mutexattr_init with NID 0x3A3B7447 not found in lookup, ignoring...
[error] Function pss_net_setsockopt with NID 0xD3FED467 not found in lookup, ignoring...
[error] Function pthread_vita_tls_get_np with NID 0xD479D238 not found in lookup, ignoring...
[error] Function pss_net_gethostname with NID 0xB34921E5 not found in lookup, ignoring...
[error] Function pss_net_resolver_create with NID 0x8FFCD9A4 not found in lookup, ignoring...
[error] Function monoeg_g_hash_table_iter_init with NID 0x8FF97526 not found in lookup, ignoring...
[error] Function pss_io_mkdir with NID 0xE9C00064 not found in lookup, ignoring...
[error] Function monoeg_g_list_nth_data with NID 0xA53BD200 not found in lookup, ignoring...
[error] Function monoeg_g_build_path with NID 0x85453290 not found in lookup, ignoring...
[error] Function pss_usb_transport_send with NID 0xFBC177AA not found in lookup, ignoring...
[error] Function pss_usb_transport_connect with NID 0x971CB35B not found in lookup, ignoring...
[error] Function monoeg_g_string_free with NID 0x8CAF3F55 not found in lookup, ignoring...
[error] Function monoeg_g_path_get_basename with NID 0x3858FDD0 not found in lookup, ignoring...
[error] Function pss_getpagesize with NID 0xB5135219 not found in lookup, ignoring...
[error] Function pss_get_prng_provider with NID 0x88496636 not found in lookup, ignoring...
[error] Function monoeg_g_get_charset with NID 0xF6BEC9D3 not found in lookup, ignoring...
[error] Function pthread_detach with NID 0x2A6A6980 not found in lookup, ignoring...
[error] Function monoeg_g_get_tmp_dir with NID 0x60DDC771 not found in lookup, ignoring...
[error] Function pss_prng_fill with NID 0x7EA1D46F not found in lookup, ignoring...
[error] Function pss_disable_ftz with NID 0x2E9C2A4B not found in lookup, ignoring...
[error] Function pthread_attr_init with NID 0x027417DD not found in lookup, ignoring...
[error] Function pss_code_mem_lock with NID 0x53D03181 not found in lookup, ignoring...
[error] Function monoeg_g_log with NID 0xCA6DB761 not found in lookup, ignoring...
[error] Function monoeg_g_error_free with NID 0x47C11F1D not found in lookup, ignoring...
[error] Function pss_get_ticks_64 with NID 0xBE8FF7BE not found in lookup, ignoring...
[error] Function monoeg_g_log_set_always_fatal with NID 0x8E19519B not found in lookup, ignoring...
[error] Function monoeg_g_print with NID 0x2A5C197D not found in lookup, ignoring...
[error] Function monoeg_g_str_has_prefix with NID 0xA3BAF580 not found in lookup, ignoring...
[error] Function monoeg_g_list_sort with NID 0xC15FBB62 not found in lookup, ignoring...
[error] Function monoeg_g_slist_insert_sorted with NID 0x96D0944D not found in lookup, ignoring...
[error] Function pss_io_rename with NID 0xB673FE93 not found in lookup, ignoring...
[error] Function monoeg_g_logv with NID 0xACC0E109 not found in lookup, ignoring...
[error] Function __modsi3 with NID 0x3F8F26A3 not found in lookup, ignoring...
[error] Function monoeg_g_direct_equal with NID 0x8148B339 not found in lookup, ignoring...
[error] Function monoeg_g_snprintf with NID 0xC3BE1A9A not found in lookup, ignoring...
[error] Function pss_usb_transport_close2 with NID 0x02FDCC52 not found in lookup, ignoring...
[error] Function pss_usb_transport_close1 with NID 0xF7FB1E6F not found in lookup, ignoring...
[error] Function pss_net_send with NID 0xDFAF1FB3 not found in lookup, ignoring...
[error] Function monoeg_g_queue_is_empty with NID 0x26A85739 not found in lookup, ignoring...
[error] Function pss_delay_thread with NID 0x018524DD not found in lookup, ignoring...
[error] Function pthread_equal with NID 0x88C5C1DC not found in lookup, ignoring...
[error] Function pss_delete_semaphore with NID 0x6148DE4D not found in lookup, ignoring...
[error] Function monoeg_g_strsplit with NID 0x7EA1C500 not found in lookup, ignoring...
[error] Function pss_net_resolver_start_ntoa with NID 0x51B4211B not found in lookup, ignoring...
[error] Function pthread_vita_tls_create_np with NID 0x7E433BEA not found in lookup, ignoring...
[error] Function monoeg_g_slist_last with NID 0x9E82ACA3 not found in lookup, ignoring...
[error] Function monoeg_g_list_alloc with NID 0xEB6A82FC not found in lookup, ignoring...
[error] Function monoeg_g_string_append_printf with NID 0x9067DA1C not found in lookup, ignoring...
[error] Function pthread_cleanup_push_ with NID 0x8774E2F3 not found in lookup, ignoring...
[error] Function monoeg_g_utf16_to_ucs4 with NID 0x19420152 not found in lookup, ignoring...
[error] Function monoeg_g_ptr_array_remove_index_fast with NID 0x9CB8D947 not found in lookup, ignoring...
[error] Function pthread_vita_tls_set_np with NID 0x483C96B2 not found in lookup, ignoring...
[error] Function monoeg_g_slist_nth_data with NID 0x38665E1F not found in lookup, ignoring...
[error] Function pss_net_htons with NID 0xFD3EF366 not found in lookup, ignoring...
[error] Function monoeg_g_list_length with NID 0xDFA458D2 not found in lookup, ignoring...
[error] Function monoeg_g_strndup with NID 0x11E3A3A4 not found in lookup, ignoring...
[error] Function monoeg_g_path_get_dirname with NID 0x760267A0 not found in lookup, ignoring...
[error] Function pss_net_htonl with NID 0x1C2F65E7 not found in lookup, ignoring...
[error] Function __divsi3 with NID 0x48A5D6B6 not found in lookup, ignoring...
[error] Function monoeg_g_file_get_contents with NID 0x05AE6764 not found in lookup, ignoring...
[error] Function monoeg_g_hash_table_remove with NID 0x4A9D45E3 not found in lookup, ignoring...
[error] Function monoeg_g_strconcat with NID 0xB1550CDA not found in lookup, ignoring...
[error] Function pthread_mutex_destroy with NID 0x11A10230 not found in lookup, ignoring...
[error] Function monoeg_g_string_new with NID 0x4A9791FF not found in lookup, ignoring...
[error] Function monoeg_g_slist_foreach with NID 0xC4178ED9 not found in lookup, ignoring...
[error] Function monoeg_g_strreverse with NID 0x5EA4F9C0 not found in lookup, ignoring...
[error] Function monoeg_g_timer_destroy with NID 0x0B133D2A not found in lookup, ignoring...
[error] Function monoeg_g_unichar_xdigit_value with NID 0x61F79239 not found in lookup, ignoring...
[error] Function monoeg_g_hash_table_foreach with NID 0xC23C4881 not found in lookup, ignoring...
[error] Function pss_net_getsockopt with NID 0xBEA8F2D8 not found in lookup, ignoring...
[error] Function monoeg_g_string_append_len with NID 0xDE912E45 not found in lookup, ignoring...
[error] Function monoeg_g_ptr_array_remove_fast with NID 0xC551D9F7 not found in lookup, ignoring...
[error] Function g_file_vita_set_current_dir with NID 0x01EE0837 not found in lookup, ignoring...
[error] Function pss_set_thread_context with NID 0x5E5A5A9C not found in lookup, ignoring...
[error] Function monoeg_g_dir_open with NID 0x6F92241A not found in lookup, ignoring...
[error] Function monoeg_g_list_reverse with NID 0x67095A4A not found in lookup, ignoring...
[error] Function monoeg_g_hash_table_size with NID 0x2DB584C2 not found in lookup, ignoring...
[error] Function pss_alloc_raw with NID 0x599AEA5E not found in lookup, ignoring...
[error] Function monoeg_g_timer_elapsed with NID 0x9D0017DA not found in lookup, ignoring...
[error] Function __udivsi3 with NID 0xFF10AAE9 not found in lookup, ignoring...
[error] Function pss_net_getsockname with NID 0x92AB54A3 not found in lookup, ignoring...
[error] Function pthread_getspecific with NID 0x30835413 not found in lookup, ignoring...
[error] Function pss_net_ntohs with NID 0xD48BC6B5 not found in lookup, ignoring...
[error] Function monoeg_g_queue_new with NID 0x75D3CADA not found in lookup, ignoring...
[error] Function pss_crypto_fread with NID 0x184E21BC not found in lookup, ignoring...
[error] Function monoeg_g_ptr_array_free with NID 0x66743D4C not found in lookup, ignoring...
[error] Function pss_net_ntohl with NID 0xF8DDBAF5 not found in lookup, ignoring...
[error] Function monoeg_g_getenv with NID 0x0A4ADADF not found in lookup, ignoring...
[error] Function monoeg_g_string_printf with NID 0xACA22DB3 not found in lookup, ignoring...
[error] Function monoeg_g_array_free with NID 0x075935E0 not found in lookup, ignoring...
[error] Function monoeg_g_hash_table_foreach_remove with NID 0x4977120A not found in lookup, ignoring...
[error] Function pss_net_bind with NID 0xD1E93EEF not found in lookup, ignoring...
[error] Function monoeg_g_get_home_dir with NID 0x7DF9817E not found in lookup, ignoring...
[error] Function monoeg_g_list_delete_link with NID 0xE05B869F not found in lookup, ignoring...
[error] Function pss_net_socket_close with NID 0x64DD5EB6 not found in lookup, ignoring...
[error] Function monoeg_g_queue_pop_head with NID 0x8D16FC46 not found in lookup, ignoring...
[error] Function g_file_vita_get_current_dir with NID 0x545F9DA8 not found in lookup, ignoring...
[error] Function monoeg_g_strchug with NID 0x87433486 not found in lookup, ignoring...
[error] Function pss_getpid with NID 0xF90E4DD2 not found in lookup, ignoring...
[error] Function monoeg_assertion_message with NID 0xA0D78B57 not found in lookup, ignoring...
[error] Function pthread_join with NID 0xB90F817A not found in lookup, ignoring...
[error] Function pss_io_rmdir with NID 0x1F1764AD not found in lookup, ignoring...
[error] Function unlink with NID 0x7BBCA340 not found in lookup, ignoring...
[error] Function monoeg_g_shell_quote with NID 0x91944CB3 not found in lookup, ignoring...
[error] Function pss_crypto_close with NID 0x37483E03 not found in lookup, ignoring...
[error] Function pss_net_socket with NID 0xCAB1666C not found in lookup, ignoring...
[error] Function pss_crypto_open with NID 0x6B4125E4 not found in lookup, ignoring...
[error] Function monoeg_g_list_remove_link with NID 0x1CCAF27B not found in lookup, ignoring...
[error] Function pss_net_resolver_start_aton with NID 0x5E72FC36 not found in lookup, ignoring...
[error] Function pss_io_getstat with NID 0x5C2090C1 not found in lookup, ignoring...
[error] Function monoeg_g_str_equal with NID 0x343BBAEC not found in lookup, ignoring...
[error] Function monoeg_g_utf8_validate with NID 0xC80A22F9 not found in lookup, ignoring...
[error] Function monoeg_g_ascii_strncasecmp with NID 0x7CDD24DB not found in lookup, ignoring...
[error] Function monoeg_g_setenv with NID 0x9E6BFE8B not found in lookup, ignoring...
[error] Function monoeg_g_markup_parse_context_parse with NID 0xCAAB6479 not found in lookup, ignoring...
[error] Function monoeg_g_printerr with NID 0xA7A44394 not found in lookup, ignoring...
[error] Function pss_code_mem_terminate with NID 0x6899C39C not found in lookup, ignoring...
[error] Function pss_net_accept with NID 0xD3F85D07 not found in lookup, ignoring...
[error] Function monoeg_g_strdup_vprintf with NID 0xA7042BC2 not found in lookup, ignoring...
[error] Function pss_code_mem_unlock with NID 0x50E8F8FF not found in lookup, ignoring...
[error] Function pss_crypto_read with NID 0x32BA8444 not found in lookup, ignoring...
[error] Function monoeg_g_hash_table_new with NID 0x378448E9 not found in lookup, ignoring...
[error] Function monoeg_g_locale_to_utf8 with NID 0x68463D0C not found in lookup, ignoring...
[error] Function monoeg_g_timer_start with NID 0x06358F60 not found in lookup, ignoring...
[error] Function monoeg_g_string_append with NID 0x84305AEE not found in lookup, ignoring...
[error] Function monoeg_g_utf8_to_utf16 with NID 0x5627BFFE not found in lookup, ignoring...
[error] Function monoeg_g_get_user_name with NID 0x93FF7030 not found in lookup, ignoring...
[error] Function pss_resume_thread with NID 0x15C51A57 not found in lookup, ignoring...
[error] Function monoeg_g_strfreev with NID 0x3EB1E49C not found in lookup, ignoring...
[error] Function monoeg_g_hash_table_iter_next with NID 0xA1F2C7E0 not found in lookup, ignoring...
[error] Function pthread_cleanup_pop_ with NID 0x57B0ED8C not found in lookup, ignoring...
[error] Function monoeg_g_array_append_vals with NID 0x38EC545B not found in lookup, ignoring...
[error] Function pss_net_epoll_destroy with NID 0xCFFBBBF8 not found in lookup, ignoring...
[error] Function pss_io_remove with NID 0x70FD542F not found in lookup, ignoring...
[error] Function monoeg_g_slist_prepend with NID 0xAA813145 not found in lookup, ignoring...
[error] Function monoeg_g_hash_table_lookup_extended with NID 0x8CBE093B not found in lookup, ignoring...
[error] Function __umodsi3 with NID 0x35BC7C65 not found in lookup, ignoring...
[error] Function monoeg_g_unichar_type with NID 0x4F9A3D81 not found in lookup, ignoring...
[error] Function pss_io_dclose with NID 0x5528F7F1 not found in lookup, ignoring...
[error] Function monoeg_g_set_prgname with NID 0xEBF04548 not found in lookup, ignoring...
[error] Function monoeg_g_ptr_array_remove with NID 0x09D8A3F8 not found in lookup, ignoring...
[error] Function monoeg_g_string_append_c with NID 0x5B130D35 not found in lookup, ignoring...
[error] Function monoeg_g_path_is_absolute with NID 0x37BD3E1B not found in lookup, ignoring...
[error] Function pss_gettimeofday with NID 0xE65366F3 not found in lookup, ignoring...
[error] Function monoeg_g_strdup_printf with NID 0x4E6EE5A0 not found in lookup, ignoring...
[error] Function __aeabi_unwind_cpp_pr1 with NID 0x6B008191 not found in lookup, ignoring...
[error] Function __aeabi_unwind_cpp_pr0 with NID 0xD172A1F6 not found in lookup, ignoring...
[error] Function __umoddi3 with NID 0x66FCF225 not found in lookup, ignoring...
[error] Function pss_net_init with NID 0x96D8FAE6 not found in lookup, ignoring...
[error] Function monoeg_g_ptr_array_new with NID 0x33A7FA42 not found in lookup, ignoring...
[error] Function monoeg_g_array_insert_vals with NID 0xEDCCA472 not found in lookup, ignoring...
[error] Function pthread_cond_signal with NID 0x4B212329 not found in lookup, ignoring...
[error] Function monoeg_g_hash_table_lookup with NID 0xA9AD9AEF not found in lookup, ignoring...
[error] Function monoeg_g_queue_push_head with NID 0x30F35337 not found in lookup, ignoring...
[error] Function pss_net_epoll_create with NID 0xB18343A4 not found in lookup, ignoring...
[error] Function pthread_create with NID 0xCBB5464C not found in lookup, ignoring...
[error] Function __divdi3 with NID 0xC9DBA402 not found in lookup, ignoring...
[error] Function pthread_cond_wait with NID 0x397C681E not found in lookup, ignoring...
[error] Function monoeg_g_free with NID 0x0FDB0CDD not found in lookup, ignoring...
[error] Function monoeg_realloc with NID 0x8FA807B1 not found in lookup, ignoring...
[error] Function monoeg_g_ptr_array_sized_new with NID 0x20464DB5 not found in lookup, ignoring...
[error] Function pthread_key_delete with NID 0xA7992EEF not found in lookup, ignoring...
[error] Function monoeg_g_filename_from_utf8 with NID 0xDB1AD82A not found in lookup, ignoring...
[error] Function pthread_setspecific with NID 0xED99821B not found in lookup, ignoring...
[error] Function pss_io_open with NID 0xEA977352 not found in lookup, ignoring...
[error] Function pthread_attr_setstacksize with NID 0xF33D87CE not found in lookup, ignoring...
[error] Function pss_code_mem_free with NID 0xB468C313 not found in lookup, ignoring...
[error] Function monoeg_g_list_nth with NID 0x1A2AD677 not found in lookup, ignoring...
[error] Function pthread_exit with NID 0x48B49C9D not found in lookup, ignoring...
[error] Function monoeg_g_hash_table_new_full with NID 0xFABF5E38 not found in lookup, ignoring...
[error] Function monoeg_g_log_set_fatal_mask with NID 0x3F109D66 not found in lookup, ignoring...
[error] Function monoeg_malloc0 with NID 0x608D5D6D not found in lookup, ignoring...
[error] Function __udivdi3 with NID 0xD7F019CF not found in lookup, ignoring...
[error] Function monoeg_g_list_find with NID 0xB52FC668 not found in lookup, ignoring...
[error] Function pss_io_read with NID 0x37F6EDC2 not found in lookup, ignoring...
[error] Function monoeg_try_malloc with NID 0xA59B6183 not found in lookup, ignoring...
[error] Function pss_get_ticks_32 with NID 0xEC94BFCF not found in lookup, ignoring...
[error] Function __sce_aeabi_ldiv0 with NID 0x2AB3B87C not found in lookup, ignoring...
[error] Function pss_io_lseek with NID 0x295FF99D not found in lookup, ignoring...
[error] Function monoeg_g_direct_hash with NID 0xD8811B19 not found in lookup, ignoring...
[error] Function monoeg_g_strjoin with NID 0xF9A3EF51 not found in lookup, ignoring...
[error] Function monoeg_g_spawn_async_with_pipes with NID 0xB9C960E3 not found in lookup, ignoring...
[error] Function monoeg_g_list_append with NID 0x2BEBDAED not found in lookup, ignoring...
[error] Function pss_wait_semaphore with NID 0x755D09D8 not found in lookup, ignoring...
[error] Function monoeg_g_memdup with NID 0x3BF53203 not found in lookup, ignoring...
[error] Function monoeg_g_usleep with NID 0x591EDE3E not found in lookup, ignoring...
[error] Function monoeg_g_get_current_dir with NID 0xB6243709 not found in lookup, ignoring...
[error] Function pss_get_ticks_since_111 with NID 0x98E48D48 not found in lookup, ignoring...
[error] Function monoeg_g_hash_table_destroy with NID 0x931C06A1 not found in lookup, ignoring...
[error] Function pss_io_close with NID 0xA201DB2A not found in lookup, ignoring...
[error] Function monoeg_g_convert with NID 0xB27101E2 not found in lookup, ignoring...
[error] Function monoeg_g_list_copy with NID 0x35E0AE9D not found in lookup, ignoring...
[error] Function pss_supports_fast_tls with NID 0xDF2BE54B not found in lookup, ignoring...
[error] Function monoeg_g_find_program_in_path with NID 0xAA9C90DE not found in lookup, ignoring...
[error] Function monoeg_g_utf16_to_utf8 with NID 0xB4610791 not found in lookup, ignoring...
[error] Function pthread_key_create with NID 0xCC79246F not found in lookup, ignoring...
[error] Function pss_code_mem_initialize with NID 0xD67BC7AB not found in lookup, ignoring...
[error] Function monoeg_g_file_test with NID 0xCF8DCED3 not found in lookup, ignoring...
[error] Function pss_net_listen with NID 0x86CE8C7D not found in lookup, ignoring...
[error] Function pthread_mutexattr_destroy with NID 0x623CDEF8 not found in lookup, ignoring...
[error] Function pthread_cond_timedwait with NID 0x7F7610EE not found in lookup, ignoring...
[error] Function __lshrdi3 with NID 0x69B23762 not found in lookup, ignoring...
[error] Function pss_io_dopen with NID 0x1D93AA23 not found in lookup, ignoring...
[error] Function monoeg_g_file_open_tmp with NID 0x6B74C816 not found in lookup, ignoring...
[error] Function pss_suspend_thread with NID 0xC42D2F9E not found in lookup, ignoring...
[error] Function pss_net_connect with NID 0xB635E419 not found in lookup, ignoring...
[error] Function sched_yield with NID 0x473829B5 not found in lookup, ignoring...
[error] Function monoeg_g_slist_free with NID 0x3FBE8990 not found in lookup, ignoring...
[error] Function monoeg_g_list_free with NID 0x3240185B not found in lookup, ignoring...
[error] Function getenv with NID 0x2AEBA06E not found in lookup, ignoring...
[error] Function monoeg_g_slist_append with NID 0x1DCD3771 not found in lookup, ignoring...
[error] Function pthread_mutex_unlock with NID 0x1B6BDBB3 not found in lookup, ignoring...
[error] Function pss_free_prng_provider with NID 0xBBCF4B04 not found in lookup, ignoring...
[error] Function monoeg_g_locale_from_utf8 with NID 0xE84A2EED not found in lookup, ignoring...
[error] Function monoeg_g_strlcpy with NID 0x29426056 not found in lookup, ignoring...
[error] Function pss_set_win32_filetime with NID 0xF981589B not found in lookup, ignoring...
[error] Function g_file_vita_get_full_path with NID 0xC1F77924 not found in lookup, ignoring...
[error] Function monoeg_g_ptr_array_add with NID 0xDB4852CA not found in lookup, ignoring...
[error] Function pss_net_epoll_wait with NID 0x1942AA03 not found in lookup, ignoring...
[error] Function pss_signal_semaphore with NID 0xB9A41171 not found in lookup, ignoring...
[error] Function pss_net_recv with NID 0x0B508B0F not found in lookup, ignoring...
[error] Function monoeg_g_slist_nth with NID 0xE319844D not found in lookup, ignoring...
[error] Function pthread_mutexattr_settype with NID 0xD2A744DF not found in lookup, ignoring...
[error] Function __moddi3 with NID 0x9A2906FE not found in lookup, ignoring...
[error] Function pthread_cond_destroy with NID 0x4B570B63 not found in lookup, ignoring...
[error] Function pss_net_getpeername with NID 0xB46F9AEC not found in lookup, ignoring...
[error] Function __ashldi3 with NID 0x3FF08624 not found in lookup, ignoring...
[error] Function monoeg_g_dir_close with NID 0x52E9FEB1 not found in lookup, ignoring...
[error] Function monoeg_g_hash_table_foreach_steal with NID 0x9324F0E1 not found in lookup, ignoring...
[error] Function pss_get_errnoloc with NID 0x617F673C not found in lookup, ignoring...
[error] Function monoeg_g_queue_free with NID 0x3D41FF7E not found in lookup, ignoring...
[error] Function monoeg_g_markup_parse_context_new with NID 0x3472AD12 not found in lookup, ignoring...
[error] Function monoeg_malloc with NID 0x2D8238B7 not found in lookup, ignoring...
[error] Function monoeg_g_list_remove with NID 0x26E6587C not found in lookup, ignoring...
[error] Function environ with NID 0x97F0181A not found in lookup, ignoring...
[error] Function pss_net_shutdown with NID 0xDEDBF700 not found in lookup, ignoring...
[error] Function monoeg_g_markup_parse_context_end_parse with NID 0xF357A07C not found in lookup, ignoring...
[error] Function monoeg_g_ascii_strdown with NID 0x3B76B55A not found in lookup, ignoring...
[error] Function monoeg_try_realloc with NID 0xB1006CCC not found in lookup, ignoring...
[error] Function monoeg_g_timer_new with NID 0xB3C99F9F not found in lookup, ignoring...
[error] Function g_ascii_strcasecmp with NID 0xC653C249 not found in lookup, ignoring...
[error] Function pss_net_recvfrom with NID 0x71FFC585 not found in lookup, ignoring...
[error] Function monoeg_g_ascii_tolower with NID 0xF5C20E95 not found in lookup, ignoring...
[error] Function pthread_cond_broadcast with NID 0x5296E752 not found in lookup, ignoring...
[error] Function pss_nanosleep with NID 0x7FFBD866 not found in lookup, ignoring...
[error] Function pss_free_mem with NID 0x1C59A84B not found in lookup, ignoring...
[error] Function pthread_cond_init with NID 0x250A81B8 not found in lookup, ignoring...
[error] Function monoeg_g_ucs4_to_utf16 with NID 0x33FA7A53 not found in lookup, ignoring...
[error] Function monoeg_g_slist_concat with NID 0x569A32C4 not found in lookup, ignoring...
[error] Function __sce_aeabi_idiv0 with NID 0x1EBF97CC not found in lookup, ignoring...
[error] Function monoeg_g_strchomp with NID 0x45EF6509 not found in lookup, ignoring...
[error] Function monoeg_g_array_new with NID 0x05EDBCA5 not found in lookup, ignoring...
[error] Function pss_usb_transport_recv with NID 0xBC46D569 not found in lookup, ignoring...
[error] Function pthread_self with NID 0xE1DE206E not found in lookup, ignoring...
[error] Function monoeg_g_strerror with NID 0x980BB6C3 not found in lookup, ignoring...
[error] Function pss_threads_initialize with NID 0x406453D4 not found in lookup, ignoring...
[error] Function sceFacePartsResultCheck with NID 0xCC98B939 not found in lookup, ignoring...
[error] Function sceFaceShapeGetWorkingMemorySize with NID 0xC0812127 not found in lookup, ignoring...
[error] Function sceFaceDetectionGetWorkingMemorySize with NID 0xF24B851D not found in lookup, ignoring...
[error] Function sceFaceDetectionLocal with NID 0x7D71725D not found in lookup, ignoring...
[error] Function sceFaceDetection with NID 0xF3045394 not found in lookup, ignoring...
[error] Function sceFaceAttribute with NID 0x67F0585A not found in lookup, ignoring...
[error] Function sceFaceIdentifyGetWorkingMemorySize with NID 0x4468B054 not found in lookup, ignoring...
[error] Function sceFaceParts with NID 0x87550392 not found in lookup, ignoring...
[error] Function sceFaceShapeFit with NID 0x64F45021 not found in lookup, ignoring...
[error] Function sceFaceAttributeGetWorkingMemorySize with NID 0xA905A467 not found in lookup, ignoring...
[error] Function sceFaceAgeRangeEstimate with NID 0x17F3DC79 not found in lookup, ignoring...
[error] Function sceFaceAgeRangeIntegrate with NID 0xB794C6CB not found in lookup, ignoring...
[error] Function sceFaceIdentifyGetFeature with NID 0xF852E35D not found in lookup, ignoring...
[error] Function sceFaceAgeGetWorkingMemorySize with NID 0x73E9791D not found in lookup, ignoring...
[error] Function sceFacePartsEx with NID 0x70C9CF95 not found in lookup, ignoring...
[error] Function sceFaceShapeTrack with NID 0x37704DE9 not found in lookup, ignoring...
[error] Function sceFaceEstimatePoseRegion with NID 0xF7E4EC1F not found in lookup, ignoring...
[error] Function sceFaceAllPartsGetWorkingMemorySize with NID 0xCF07E1C4 not found in lookup, ignoring...
[error] Function sceFaceAllParts with NID 0xE521EB6F not found in lookup, ignoring...
[error] Function sceFaceIdentifySimilarity with NID 0x8F8E9FB1 not found in lookup, ignoring...
[error] Function sceFacePartsGetWorkingMemorySize with NID 0x707B9A1D not found in lookup, ignoring...
[error] Function sceSha384BlockInit with NID 0x037AABE7 not found in lookup, ignoring...
[error] Function sceSha384BlockResult with NID 0x30D5C919 not found in lookup, ignoring...
[error] Function sceSha384BlockUpdate with NID 0x4B99DBB8 not found in lookup, ignoring...
[error] Function sceSha384Digest with NID 0xA602C694 not found in lookup, ignoring...
[error] Function sceSfmt2281FillArray64 with NID 0x17C10E2D not found in lookup, ignoring...
[error] Function sceSfmt2281InitByArray with NID 0xAB3AD459 not found in lookup, ignoring...
[error] Function sceSfmt2281GenRand32 with NID 0x84BB4ADB not found in lookup, ignoring...
[error] Function sceSfmt2281InitGenRand with NID 0xB8E5A0BB not found in lookup, ignoring...
[error] Function sceSfmt2281FillArray32 with NID 0xBB89D8F0 not found in lookup, ignoring...
[error] Function sceSfmt2281GenRand64 with NID 0x3CC47146 not found in lookup, ignoring...
[error] Function sceSha224Digest with NID 0x1346D270 not found in lookup, ignoring...
[error] Function sceSha224BlockResult with NID 0xA36ECF65 not found in lookup, ignoring...
[error] Function sceSha224BlockInit with NID 0x538F04CE not found in lookup, ignoring...
[error] Function sceSha224BlockUpdate with NID 0xB5FD0160 not found in lookup, ignoring...
[warning] Function printf found with different name in db: ksceDebugPrintf , skipping...
[error] Function _Files with NID 0x855FC605 not found in lookup, ignoring...
[error] Function _LSnan with NID 0x48AEEF2A not found in lookup, ignoring...
[error] Function _Dbl with NID 0x338FE545 not found in lookup, ignoring...
[error] Function _Ldbl with NID 0x94CE931C not found in lookup, ignoring...
[error] Function _FSnan with NID 0x7D35108B not found in lookup, ignoring...
[error] Function _LNan with NID 0x036D0F07 not found in lookup, ignoring...
[error] Function _Stderr with NID 0xDDF9BB09 not found in lookup, ignoring...
[error] Function _Stdin with NID 0x66B7406C not found in lookup, ignoring...
[error] Function _LDenorm with NID 0x2C8DBEB7 not found in lookup, ignoring...
[error] Function __set_exidx_main with NID 0x1EFFBAC2 not found in lookup, ignoring...
[error] Function _Ctype with NID 0x3CE6109D not found in lookup, ignoring...
[error] Function _Denorm with NID 0xF708906E not found in lookup, ignoring...
[error] Function _FCbuild with NID 0xDEC462AB not found in lookup, ignoring...
[error] Function _LInf with NID 0x5289BBC0 not found in lookup, ignoring...
[error] Function _Inf with NID 0x710B5F33 not found in lookup, ignoring...
[error] Function _FNan with NID 0x415162DD not found in lookup, ignoring...
[error] Function _FDenorm with NID 0x01B05132 not found in lookup, ignoring...
[error] Function _FInf with NID 0x8A0F308C not found in lookup, ignoring...
[error] Function _Stdout with NID 0x5D8C1282 not found in lookup, ignoring...
[error] Function _Nan with NID 0x116F3DA9 not found in lookup, ignoring...
[error] Function _Snan with NID 0x677CDE35 not found in lookup, ignoring...
[error] Function _Touptab with NID 0x36878958 not found in lookup, ignoring...
[error] Function _Tolotab with NID 0xD662E07C not found in lookup, ignoring...
[error] Function _Flt with NID 0xE5620A03 not found in lookup, ignoring...
```

# NIDs from wiki.henkaku.xyz

Wiki was scraped using [this](https://github.com/devnoname120/vitasdk-db-tools) running `./henkaku_wiki_scraper.py aggressive > nids.txt`.

```
[Note] Ignoring function SceModulemgrForKernel_0053BA4A because it doesn't look legit
[error] Function sceKernelGetProcessEntryPointForKernel with NID 0xC72CA412 not found in lookup, ignoring...
[error] Function sceKernelLoadcoreKallocForKernel with NID 0xB4A1DE31 not found in lookup, ignoring...
[error] Function sceKernelRegisterSyscallForKernel with NID 0x2E4A10A0 not found in lookup, ignoring...
[warning] Function sceKernelDecryptSelfByPathForKernel found with different name in db: ksceKernelLoadPtLoadSegForFwloader , skipping...
[warning] Function sceKernelGetModuleListForKernel found with different name in db: ksceKernelGetModuleList , skipping...
[warning] Function sceKernelGetModuleList2ForKernel found with different name in db: ksceKernelGetModuleList2 , skipping...
[warning] Function sceKernelGetModuleUidForKernel found with different name in db: ksceKernelGetModuleUid , skipping...
[warning] Function sceKernelGetModuleUidListForKernel found with different name in db: ksceKernelGetModuleUidList , skipping...
[warning] Function sceKernelGetModuleInfoForKernel found with different name in db: ksceKernelGetModuleInfo , skipping...
[warning] Function sceKernelGetModuleInfo2ForKernel found with different name in db: ksceKernelGetModuleInfo2 , skipping...
[warning] Function sceKernelGetModuleInternalForKernel found with different name in db: ksceKernelGetModuleInternal , skipping...
[warning] Function sceKernelGetModuleLibraryInfoForKernel found with different name in db: ksceKernelGetModuleLibraryInfo , skipping...
[warning] Function sceKernelGetProcessMainModuleForKernel found with different name in db: ksceKernelGetProcessMainModule , skipping...
[warning] Function sceKernelGetProcessMainModulePathForKernel found with different name in db: ksceKernelGetProcessMainModulePath , skipping...
[warning] Function sceKernelMountBootfsForKernel found with different name in db: ksceKernelMountBootfs , skipping...
[warning] Function sceKernelUmountBootfsForKernel found with different name in db: ksceKernelUmountBootfs , skipping...
[warning] Function sceKernelLoadModuleForPidForKernel found with different name in db: ksceKernelLoadModuleForPid , skipping...
[warning] Function sceKernelStartModuleForPidForKernel found with different name in db: ksceKernelStartModuleForPid , skipping...
[warning] Function sceKernelStopModuleForPidForKernel found with different name in db: ksceKernelStopModuleForPid , skipping...
[warning] Function sceKernelUnloadModuleForPidForKernel found with different name in db: ksceKernelUnloadModuleForPid , skipping...
[warning] Function sceKernelLoadPreloadingModulesForKernel found with different name in db: ksceKernelLoadPreloadingModules , skipping...
[warning] Function sceKernelLoadProcessImageForKernel found with different name in db: ksceKernelLoadProcessImage , skipping...
[error] Function sceKernelLoadcoreKfreeForKernel with NID 0xF4B2D8B8 not found in lookup, ignoring...
[error] Function sceKernelCallModuleSuspendEntry with NID 0x829E1C94 not found in lookup, ignoring...
[Note] Ignoring function SceModulemgrForDriver_1D9E0F7E because it doesn't look legit
[warning] Function sceKernelGetModuleInfoForDriver found with different name in db: sceKernelGetModuleInfo , skipping...
[warning] Function sceKernelSearchModuleByNameForDriver found with different name in db: ksceKernelSearchModuleByName , skipping...
[warning] Function sceKernelGetSystemSwVersionForDriver found with different name in db: ksceKernelGetSystemSwVersion , skipping...
[error] Function sceKernelSetSystemSwVersionForDriver with NID 0x912AEB73 not found in lookup, ignoring...
[warning] Function sceKernelLoadStartModuleForDriver found with different name in db: ksceKernelLoadStartModule , skipping...
[warning] Function sceKernelLoadStartModuleForPidForDriver found with different name in db: ksceKernelLoadStartModuleForPid , skipping...
[warning] Function sceKernelLoadStartSharedModuleForPidForDriver found with different name in db: ksceKernelLoadStartSharedModuleForPid , skipping...
[warning] Function sceKernelStartModuleForDriver found with different name in db: ksceKernelStartModule , skipping...
[warning] Function sceKernelStopUnloadModuleForDriver found with different name in db: ksceKernelStopUnloadModule , skipping...
[warning] Function sceKernelStopUnloadModuleForPidForDriver found with different name in db: ksceKernelStopUnloadModuleForPid , skipping...
[warning] Function sceKernelStopModuleForDriver found with different name in db: ksceKernelStopModule , skipping...
[warning] Function sceKernelUnloadModuleForDriver found with different name in db: ksceKernelUnloadModule , skipping...
[error] Function __sceKernelLoadModuleWithoutStart with NID 0xA4E6DA4D not found in lookup, ignoring...
[error] Function __sceKernelStartModule with NID 0x1FD99C9F not found in lookup, ignoring...
[error] Function __sceKernelStopModule with NID 0xBA49EA5C not found in lookup, ignoring...
[error] Function __sceKernelUnloadModuleWithoutStop with NID 0xE439E26B not found in lookup, ignoring...
[error] Function __sceKernelOpenModule with NID 0x9C2A9A49 not found in lookup, ignoring...
[error] Function __sceKernelCloseModule with NID 0x5303C52F not found in lookup, ignoring...
[error] Function sceKernelKttyWrite with NID 0x4D76CF9E not found in lookup, ignoring...
[error] Function sceKernelPutc with NID 0x9D2FE122 not found in lookup, ignoring...
[error] Function sceKernelSetSystemSwVersion with NID 0x912AEB73 not found in lookup, ignoring...
[Note] Ignoring function SceBacktraceForDriver_7C878F90 because it doesn't look legit
[Note] Ignoring function SceBacktraceForDriver_888E99B8 because it doesn't look legit
[Note] Ignoring function unk_02422F1F because it doesn't look legit
[Note] Ignoring function unk_04C0ED3F because it doesn't look legit
[Note] Ignoring function unk_06BE9F0F because it doesn't look legit
[Note] Ignoring function unk_0E489631 because it doesn't look legit
[Note] Ignoring function unk_11C9158B because it doesn't look legit
[Note] Ignoring function unk_165C3C7A because it doesn't look legit
[Note] Ignoring function unk_1948E9DB_return0 because it doesn't look legit
[Note] Ignoring function unk_1B160234 because it doesn't look legit
[Note] Ignoring function unk_30575458 because it doesn't look legit
[Note] Ignoring function unk_356B9139 because it doesn't look legit
[Note] Ignoring function unk_410357AF because it doesn't look legit
[Note] Ignoring function unk_48F4D5EE because it doesn't look legit
[Note] Ignoring function unk_49509A83 because it doesn't look legit
[Note] Ignoring function unk_4C4B7D6B because it doesn't look legit
[Note] Ignoring function unk_5E6BA11C because it doesn't look legit
[Note] Ignoring function unk_7529E364 because it doesn't look legit
[Note] Ignoring function unk_75AAF981 because it doesn't look legit
[Note] Ignoring function unk_7F294A09 because it doesn't look legit
[Note] Ignoring function unk_8241AB5C because it doesn't look legit
[Note] Ignoring function unk_A50FDA27 because it doesn't look legit
[Note] Ignoring function unk_CCDBB74D_for_motoharu because it doesn't look legit
[Note] Ignoring function unk_DC49E160 because it doesn't look legit
[Note] Ignoring function unk_E273ED8C_for_motoharu because it doesn't look legit
[Note] Ignoring function unk_FBA1A256 because it doesn't look legit
[Note] Ignoring function unk_FB2AC5B4 because it doesn't look legit
[Note] Ignoring function unk_0606B87E because it doesn't look legit
[warning] Function sceSblACMgrIsAllowedUsbSerialForDriver found with different name in db: ksceSblACMgrIsAllowedUsbSerial , skipping...
[Note] Ignoring function unk_0924896F_for_motoharu because it doesn't look legit
[warning] Function sceSblACMgrIsSystemForDriver found with different name in db: ksceSblACMgrIsSystem , skipping...
[warning] Function sceSblACMgrIsGameProgramForDriver found with different name in db: ksceSblACMgrIsGameProgram , skipping...
[Note] Ignoring function unk_2E992B02 because it doesn't look legit
[Note] Ignoring function unk_3B356B98 because it doesn't look legit
[Note] Ignoring function unk_456DA7AC because it doesn't look legit
[Note] Ignoring function unk_48CFCEA2 because it doesn't look legit
[Note] Ignoring function unk_4CBD6156 because it doesn't look legit
[Note] Ignoring function unk_5C4BC352 because it doesn't look legit
[Note] Ignoring function unk_5F9AF49C because it doesn't look legit
[Note] Ignoring function unk_6210D745 because it doesn't look legit
[warning] Function sceSblACMgrIsNonGameProgramForDriver found with different name in db: ksceSblACMgrIsNonGameProgram , skipping...
[Note] Ignoring function unk_6D8A88B7 because it doesn't look legit
[Note] Ignoring function unk_84604EED because it doesn't look legit
[warning] Function sceSblACIsSystemProgramForDriver found with different name in db: ksceSblACMgrIsShell , skipping...
[Note] Ignoring function unk_A27E47A7 because it doesn't look legit
[Note] Ignoring function unk_A92CD636 because it doesn't look legit
[Note] Ignoring function unk_AD717E7A because it doesn't look legit
[Note] Ignoring function unk_AE1AF154 because it doesn't look legit
[Note] Ignoring function unk_B12CEAA8_for_motoharu because it doesn't look legit
[Note] Ignoring function unk_B836CF13 because it doesn't look legit
[Note] Ignoring function unk_BE5667C5 because it doesn't look legit
[warning] Function sceSblACMgrHasCapabilityForDriver found with different name in db: ksceSblACMgrHasCapability , skipping...
[Note] Ignoring function unk_D7AD8471 because it doesn't look legit
[Note] Ignoring function unk_E79C7A8D because it doesn't look legit
[warning] Function sceSblACMgrIsDevelopmentModeForDriver found with different name in db: ksceSblACMgrIsDevelopmentMode , skipping...
[Note] Ignoring function unk_F5AE24AC because it doesn't look legit
[warning] Function sceSblACMgrIsPspEmuForDriver found with different name in db: ksceSblACMgrIsPspEmu , skipping...
[Note] Ignoring function unk_FF7125DE because it doesn't look legit
[Note] Ignoring function SceSblAuthMgrForKernel_CAA38DF7 because it doesn't look legit
[Note] Ignoring function SceSblAuthMgrForKernel_6C1F5048 because it doesn't look legit
[error] Function sceSblAuthMgrLoadSegmentInternalForKernel with NID 0x15248FB4 not found in lookup, ignoring...
[warning] Function sceSblAuthMgrSetDmac5KeyForKernel found with different name in db: ksceSblAuthMgrSetDmac5Key , skipping...
[warning] Function sceSblAuthMgrClearDmac5KeyForKernel found with different name in db: ksceSblAuthMgrClearDmac5Key , skipping...
[Note] Ignoring function SceSblAuthMgrForKernel_2A83A012 because it doesn't look legit
[warning] Function sceDisplayCaptureFrameBufDMACForDriver found with different name in db: ksceDisplayCaptureFrameBufDMAC , skipping...
[warning] Function sceDisplayCaptureFrameBufIFTUForDriver found with different name in db: ksceDisplayCaptureFrameBufIFTU , skipping...
[warning] Function sceDisplayDisableHeadForDriver found with different name in db: ksceDisplayDisableHead , skipping...
[warning] Function sceDisplayEnableHeadForDriver found with different name in db: ksceDisplayEnableHead , skipping...
[warning] Function sceDisplayGetActualViewportConfForDriver found with different name in db: ksceDisplayGetActualViewportConf , skipping...
[warning] Function sceDisplayGetDeviceTypeForDriver found with different name in db: ksceDisplayGetDeviceType , skipping...
[warning] Function sceDisplayGetFrameBufForDriver found with different name in db: ksceDisplayGetFrameBuf , skipping...
[warning] Function sceDisplayGetFrameBufInfoForPidForDriver found with different name in db: ksceDisplayGetFrameBufInfoForPid , skipping...
[warning] Function sceDisplayGetFrameBufInternalForDriver found with different name in db: ksceDisplayGetFrameBufInternal , skipping...
[warning] Function sceDisplayGetMaximumFrameBufResolutionForDriver found with different name in db: ksceDisplayGetMaximumFrameBufResolution , skipping...
[warning] Function sceDisplayGetOutputModeForDriver found with different name in db: ksceDisplayGetOutputMode , skipping...
[warning] Function sceDisplayGetPrimaryHeadForDriver found with different name in db: ksceDisplayGetPrimaryHead , skipping...
[warning] Function sceDisplayGetRefreshRateInternalForDriver found with different name in db: ksceDisplayGetRefreshRateInternal , skipping...
[warning] Function sceDisplayGetResolutionInfoInternalForDriver found with different name in db: ksceDisplayGetResolutionInfoInternal , skipping...
[warning] Function sceDisplayGetVcountInternalForDriver found with different name in db: ksceDisplayGetVcountInternal , skipping...
[warning] Function sceDisplayRegisterFrameBufCallbackForDriver found with different name in db: ksceDisplayRegisterFrameBufCallback , skipping...
[warning] Function sceDisplayRegisterFrameBufCallbackInternalForDriver found with different name in db: ksceDisplayRegisterFrameBufCallbackInternal , skipping...
[warning] Function sceDisplayRegisterVblankStartCallbackForDriver found with different name in db: ksceDisplayRegisterVblankStartCallback , skipping...
[warning] Function sceDisplayRegisterVblankStartCallbackInternalForDriver found with different name in db: ksceDisplayRegisterVblankStartCallbackInternal , skipping...
[warning] Function sceDisplaySetBrightnessForDriver found with different name in db: ksceDisplaySetBrightness , skipping...
[warning] Function sceDisplaySetColorSpaceModeForDriver found with different name in db: ksceDisplaySetColorSpaceMode , skipping...
[warning] Function sceDisplaySetFrameBufForDriver found with different name in db: ksceDisplaySetFrameBuf , skipping...
[warning] Function sceDisplaySetFrameBufInternalForDriver found with different name in db: ksceDisplaySetFrameBufInternal , skipping...
[warning] Function sceDisplaySetInvertColorsForDriver found with different name in db: ksceDisplaySetInvertColors , skipping...
[warning] Function sceDisplaySetMergeConfForDriver found with different name in db: ksceDisplaySetMergeConf , skipping...
[warning] Function sceDisplaySetOutputModeForDriver found with different name in db: ksceDisplaySetOutputMode , skipping...
[warning] Function sceDisplaySetScaleConfForDriver found with different name in db: ksceDisplaySetScaleConf , skipping...
[warning] Function sceDisplaySetViewportConfForDriver found with different name in db: ksceDisplaySetViewportConf , skipping...
[warning] Function sceDisplayUnregisterVblankStartCallbackForDriver found with different name in db: ksceDisplayUnregisterVblankStartCallback , skipping...
[warning] Function sceDisplayUnregisterVblankStartCallbackInternalForDriver found with different name in db: ksceDisplayUnregisterVblankStartCallbackInternal , skipping...
[warning] Function sceDisplayWaitSetFrameBufCBForDriver found with different name in db: ksceDisplayWaitSetFrameBufCB , skipping...
[warning] Function sceDisplayWaitSetFrameBufCBInternalForDriver found with different name in db: ksceDisplayWaitSetFrameBufCBInternal , skipping...
[warning] Function sceDisplayWaitSetFrameBufForDriver found with different name in db: ksceDisplayWaitSetFrameBuf , skipping...
[warning] Function sceDisplayWaitSetFrameBufInternalForDriver found with different name in db: ksceDisplayWaitSetFrameBufInternal , skipping...
[warning] Function sceDisplayWaitSetFrameBufMultiCBForDriver found with different name in db: ksceDisplayWaitSetFrameBufMultiCB , skipping...
[warning] Function sceDisplayWaitSetFrameBufMultiCBInternalForDriver found with different name in db: ksceDisplayWaitSetFrameBufMultiCBInternal , skipping...
[warning] Function sceDisplayWaitSetFrameBufMultiForDriver found with different name in db: ksceDisplayWaitSetFrameBufMulti , skipping...
[warning] Function sceDisplayWaitSetFrameBufMultiInternalForDriver found with different name in db: ksceDisplayWaitSetFrameBufMultiInternal , skipping...
[warning] Function sceDisplayWaitVblankStartCBForDriver found with different name in db: ksceDisplayWaitVblankStartCB , skipping...
[warning] Function sceDisplayWaitVblankStartCBInternalForDriver found with different name in db: ksceDisplayWaitVblankStartCBInternal , skipping...
[warning] Function sceDisplayWaitVblankStartForDriver found with different name in db: ksceDisplayWaitVblankStart , skipping...
[warning] Function sceDisplayWaitVblankStartInternalForDriver found with different name in db: ksceDisplayWaitVblankStartInternal , skipping...
[warning] Function sceDisplayWaitVblankStartMultiCBForDriver found with different name in db: ksceDisplayWaitVblankStartMultiCB , skipping...
[warning] Function sceDisplayWaitVblankStartMultiCBInternalForDriver found with different name in db: ksceDisplayWaitVblankStartMultiCBInternal , skipping...
[warning] Function sceDisplayWaitVblankStartMultiForDriver found with different name in db: ksceDisplayWaitVblankStartMulti , skipping...
[warning] Function sceDisplayWaitVblankStartMultiInternalForDriver found with different name in db: ksceDisplayWaitVblankStartMultiInternal , skipping...
[Note] Ignoring function SceDisplayForDriver_unk_086DEFB6 because it doesn't look legit
[Note] Ignoring function SceDisplayForDriver_unk_332C5410 because it doesn't look legit
[Note] Ignoring function SceDisplayForDriver_unk_3D95D478 because it doesn't look legit
[warning] Function sceDisplayCaptureFrameBufDMACInternalForDriver found with different name in db: ksceDisplayCaptureFrameBufDMACInternal , skipping...
[warning] Function sceDisplaySetOwnerForDriver found with different name in db: ksceDisplaySetOwner , skipping...
[Note] Ignoring function SceDisplayForDriver_unk_BC76296A because it doesn't look legit
[warning] Function sceDisplayCaptureFrameBufIFTUInternalForDriver found with different name in db: ksceDisplayCaptureFrameBufIFTUInternal , skipping...
[warning] Function sceKernelDmaOpAllocForDriver found with different name in db: ksceKernelDmaOpAlloc , skipping...
[warning] Function sceKernelDmaOpAssignForDriver found with different name in db: ksceKernelDmaOpAssign , skipping...
[warning] Function sceKernelDmaOpFreeForDriver found with different name in db: ksceKernelDmaOpFree , skipping...
[warning] Function sceKernelDmacMemcpyForDriver found with different name in db: ksceDmacMemcpy , skipping...
[warning] Function sceKernelDmacMemsetForDriver found with different name in db: ksceDmacMemset , skipping...
[error] Function sceKernelDmacMemcpyAsyncForDriver with NID 0x6E81B8BF not found in lookup, ignoring...
[error] Function sceKernelDmacMemsetAsyncForDriver with NID 0x6FD7F708 not found in lookup, ignoring...
[Note] Ignoring function SceDmacmgrForDriver_BCBB5E85 because it doesn't look legit
[Note] Ignoring function SceDmacmgrForDriver_893FCB80_not_implemented because it doesn't look legit
[warning] Function sceKernelRegisterPriorityExceptionHandlerForKernel found with different name in db: ksceExcpmgrRegisterHandler , skipping...
[warning] Function sceExcpmgrGetDataForKernel found with different name in db: ksceExcpmgrGetData , skipping...
[Note] Ignoring function clear_context because it doesn't look legit
[Note] Ignoring function clear_context because it doesn't look legit
[Note] Ignoring function enc_dec because it doesn't look legit
[Note] Ignoring function error because it doesn't look legit
[Note] Ignoring function get_5018_data because it doesn't look legit
[Note] Ignoring function memcmp_5018_fast because it doesn't look legit
[Note] Ignoring function clear_sensitive_data because it doesn't look legit
[Note] Ignoring function clear_sensitive_data because it doesn't look legit
[Note] Ignoring function SceSblGcAuthMgrMlnpsnlForDriver_296ABD68 because it doesn't look legit
[Note] Ignoring function SceSblGcAuthMgrMlnpsnlForDriver_DABC01F5 because it doesn't look legit
[Note] Ignoring function SceSblGcAuthMgrPkgForDriver_E459A9A8 because it doesn't look legit
[Note] Ignoring function SceSblGcAuthMgrSclkForDriver_11D5570B because it doesn't look legit
[Note] Ignoring function SceSblGcAuthMgrSclkForDriver_F723A9BA because it doesn't look legit
[Note] Ignoring function cmd56_handshake because it doesn't look legit
[Note] Ignoring function get_act_data because it doesn't look legit
[Note] Ignoring function SceSblGcAuthMgrMsSaveBBForDriver_3C185A67 because it doesn't look legit
[Note] Ignoring function SceSblGcAuthMgrMsSaveBBForDriver_4A249828 because it doesn't look legit
[Note] Ignoring function SceSblGcAuthMgrMsSaveBBForDriver_79A9BE44 because it doesn't look legit
[Note] Ignoring function SceSblGcAuthMgrMsSaveBBForDriver_805C860B because it doesn't look legit
[Note] Ignoring function SceSblGcAuthMgrMsSaveBBForDriver_8E6626A0 because it doesn't look legit
[Note] Ignoring function SceSblGcAuthMgrMsSaveBBForDriver_F66D5F76 because it doesn't look legit
[error] Function sceKernelRegisterIntrHandlerForDriver with NID 0x6B84DA8F not found in lookup, ignoring...
[warning] Function sceKernelRegisterIntrHandlerForDriver found with different name in db: ksceKernelRegisterIntrHandler , skipping...
[warning] Function sceKernelReleaseIntrHandlerForDriver found with different name in db: ksceKernelReleaseIntrHandler , skipping...
[warning] Function sceKernelDisableIntrForDriver found with different name in db: ksceKernelMaskIntr , skipping...
[warning] Function sceKernelEnableIntrForDriver found with different name in db: ksceKernelSetIntrMasked , skipping...
[warning] Function sceKernelSuspendIntrForDriver found with different name in db: ksceKernelGetIntrMasked , skipping...
[warning] Function sceKernelGetIntrPendingStatusForDebuggerForDriver found with different name in db: ksceKernelIsIntrPending , skipping...
[warning] Function sceKernelClearIntrPendingStatusForDebuggerForDriver found with different name in db: ksceKernelClearIntrPending , skipping...
[warning] Function sceKernelSetIntrPriorityForDriver found with different name in db: ksceKernelSetIntrPriority , skipping...
[warning] Function sceKernelGetIntrPriorityForDriver found with different name in db: ksceKernelGetIntrPriority , skipping...
[warning] Function sceKernelSetIntrTargetCpuForDriver found with different name in db: ksceKernelSetIntrTarget , skipping...
[warning] Function sceKernelGetIntrTargetCpuForDriver found with different name in db: ksceKernelGetIntrTarget , skipping...
[warning] Function sceKernelGenerateSoftIntrForDriver found with different name in db: ksceKernelTriggerSGI , skipping...
[warning] Function sceKernelRegisterSubIntrHandlerForDriver found with different name in db: ksceKernelRegisterSubIntrHandler , skipping...
[warning] Function sceKernelReleaseSubIntrHandlerForDriver found with different name in db: ksceKernelReleaseSubIntrHandler , skipping...
[warning] Function sceKernelCallSubIntrHandlerForDriver found with different name in db: ksceKernelTriggerSubIntr , skipping...
[warning] Function sceKernelEnableSubIntrForDriver found with different name in db: ksceKernelEnableSubIntr , skipping...
[warning] Function sceKernelDisableSubIntrForDriver found with different name in db: ksceKernelDisableSubIntr , skipping...
[Note] Ignoring function SceIntrmgrForDriver_C568F145 because it doesn't look legit
[warning] Function sceKernelGetIntrPendingStatusForDebuggerForKernel found with different name in db: ksceKernelIsIntrPending , skipping...
[warning] Function sceKernelClearIntrPendingStatusForDebuggerForKernel found with different name in db: ksceKernelClearIntrPending , skipping...
[Note] Ignoring function allocate_syscall_table because it doesn't look legit
[Note] Ignoring function get_intr_logs because it doesn't look legit
[warning] Function sceIoMountForDriver found with different name in db: ksceIoMount , skipping...
[warning] Function sceIoUmountForDriver found with different name in db: ksceIoUmount , skipping...
[warning] Function sceIoDreadForDriver found with different name in db: ksceIoDread , skipping...
[warning] Function sceIoWriteForDriver found with different name in db: ksceIoWrite , skipping...
[warning] Function sceIoDopenForDriver found with different name in db: ksceIoDopen , skipping...
[warning] Function sceIoLseekForDriver found with different name in db: ksceIoLseek , skipping...
[warning] Function sceIoOpenForDriver found with different name in db: ksceIoOpen , skipping...
[warning] Function sceIoChstatForDriver found with different name in db: ksceIoChstat , skipping...
[warning] Function sceIoGetstatForDriver found with different name in db: ksceIoGetstat , skipping...
[warning] Function sceIoMkdirForDriver found with different name in db: ksceIoMkdir , skipping...
[warning] Function sceIoReadForDriver found with different name in db: ksceIoRead , skipping...
[warning] Function sceIoCloseForDriver found with different name in db: ksceIoClose , skipping...
[warning] Function sceIoRenameForDriver found with different name in db: ksceIoRename , skipping...
[warning] Function sceIoRemoveForDriver found with different name in db: ksceIoRemove , skipping...
[warning] Function sceIoCancelForDriver found with different name in db: ksceIoCancel , skipping...
[warning] Function sceIoChstatByFdForDriver found with different name in db: ksceIoChstatByFd , skipping...
[warning] Function sceIoCloseAsyncForDriver found with different name in db: ksceIoCloseAsync , skipping...
[warning] Function sceIoDevctlForDriver found with different name in db: ksceIoDevctl , skipping...
[warning] Function sceIoDcloseForDriver found with different name in db: ksceIoDclose , skipping...
[warning] Function sceIoFlockForDriver found with different name in db: ksceIoFlock , skipping...
[warning] Function sceIoGetstatByFdForDriver found with different name in db: ksceIoGetstatByFd , skipping...
[warning] Function sceIoLseekAsyncForDriver found with different name in db: ksceIoLseekAsync , skipping...
[warning] Function sceIoOpenAsyncForDriver found with different name in db: ksceIoOpenAsync , skipping...
[warning] Function sceIoPreadForDriver found with different name in db: ksceIoPread , skipping...
[warning] Function sceIoPwriteForDriver found with different name in db: ksceIoPwrite , skipping...
[warning] Function sceIoReadAsyncForDriver found with different name in db: ksceIoReadAsync , skipping...
[warning] Function sceIoRmdirForDriver found with different name in db: ksceIoRmdir , skipping...
[warning] Function sceIoSyncByFdAsyncForDriver found with different name in db: ksceIoSyncByFdAsync , skipping...
[warning] Function sceIoSyncForDriver found with different name in db: ksceIoSync , skipping...
[warning] Function sceIoWriteAsyncForDriver found with different name in db: ksceIoWriteAsync , skipping...
[Note] Ignoring function t_sceIoOpenForDriver because it doesn't look legit
[Note] Ignoring function t_sceIoCloseForDriver because it doesn't look legit
[Note] Ignoring function t_sceIoReadForDriver because it doesn't look legit
[Note] Ignoring function t_sceIoWriteForDriver because it doesn't look legit
[Note] Ignoring function t_sceIoIoctlForDriver because it doesn't look legit
[Note] Ignoring function t_sceIoChstatForDriver because it doesn't look legit
[Note] Ignoring function t_sceIoChstatByFdForDriver because it doesn't look legit
[Note] Ignoring function t_sceIoPreadForDriver because it doesn't look legit
[Note] Ignoring function t_sceIoPwriteForDriver because it doesn't look legit
[warning] Function sceIoCreateMountEventForDriver found with different name in db: ksceIoCreateMountEvent , skipping...
[warning] Function sceIoCreateErrorEventForDriver found with different name in db: ksceIoCreateErrorEvent , skipping...
[warning] Function sceIoClearErrorEventForDriver found with different name in db: ksceIoClearErrorEvent , skipping...
[warning] Function sceIoDeleteMountEventForDriver found with different name in db: ksceIoDeleteMountEvent , skipping...
[warning] Function sceIoDeleteErrorEventForDriver found with different name in db: ksceIoDeleteErrorEvent , skipping...
[Note] Ignoring function unk_39ABDB9E because it doesn't look legit
[Note] Ignoring function create_SceUIDVfsFileClass because it doesn't look legit
[error] Function _sceIoDcloseAsync with NID 0x00B13031 not found in lookup, ignoring...
[error] Function _sceIoComplete with NID 0x34E6A06E not found in lookup, ignoring...
[error] Function _sceIoGetThreadDefaultPriorityForSystem with NID 0x36CAF911 not found in lookup, ignoring...
[error] Function _sceIoSetThreadDefaultPriorityForSystem with NID 0x38FE853B not found in lookup, ignoring...
[error] Function _sceIoGetstatByFdAsync with NID 0x554292F0 not found in lookup, ignoring...
[error] Function _sceIoChstatByFdAsync with NID 0x58010F40 not found in lookup, ignoring...
[error] Function _sceIoGetThreadDefaultPriority with NID 0x5DC29460 not found in lookup, ignoring...
[error] Function _sceIoDreadAsync with NID 0x64B233B8 not found in lookup, ignoring...
[error] Function _sceIoSetThreadDefaultPriority with NID 0x654E27B1 not found in lookup, ignoring...
[error] Function _sceIoSyncByFdAsync with NID 0x6F78FAFE not found in lookup, ignoring...
[error] Function _sceIoGetPriorityForSystem with NID 0x70B7BB52 not found in lookup, ignoring...
[error] Function _sceIoWrite with NID 0x8C319CF0 not found in lookup, ignoring...
[error] Function _sceIoLseek32 with NID 0x92BDA6DA not found in lookup, ignoring...
[error] Function _sceIoGetPriority with NID 0x9E3F880D not found in lookup, ignoring...
[error] Function _sceIoGetProcessDefaultPriority with NID 0xB0486482 not found in lookup, ignoring...
[error] Function _sceIoSetPriority with NID 0xB14192F0 not found in lookup, ignoring...
[error] Function _sceIoReadAsync with NID 0xB2B891E6 not found in lookup, ignoring...
[error] Function _sceIoWriteAsync with NID 0xC92AF88F not found in lookup, ignoring...
[error] Function _sceIoSetProcessDefaultPriority with NID 0xD302DCB9 not found in lookup, ignoring...
[error] Function _sceIoSetPriorityForSystem with NID 0xE6C923B3 not found in lookup, ignoring...
[error] Function _sceIoRead with NID 0xF3C9E783 not found in lookup, ignoring...
[error] Function _sceIoSyncByFd with NID 0xF437545D not found in lookup, ignoring...
[error] Function _sceIoCloseAsync with NID 0xF4E13260 not found in lookup, ignoring...
[error] Function _sceIoDopenAsync with NID 0xF58286C3 not found in lookup, ignoring...
[error] Function _sceIoCancel with NID 0xF5DEEA19 not found in lookup, ignoring...
[error] Function _sceIoClose with NID 0xF69FB394 not found in lookup, ignoring...
[error] Function _sceIoDclose with NID 0xFAFF0002 not found in lookup, ignoring...
[Note] Ignoring function SceLcdForDriver_5127FB5E because it doesn't look legit
[Note] Ignoring function SceLcdForDriver_59CCDC97_dispatch_cmd_list because it doesn't look legit
[warning] Function sceLcdGetDDBForDriver found with different name in db: ksceLcdGetDDB , skipping...
[Note] Ignoring function ScePervasiveForDriver_18DD8043 because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_243D0E78 because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_25AE181E because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_2F195C97 because it doesn't look legit
[warning] Function scePervasiveRemovableMemoryGetCardInsertStateForDriver found with different name in db: kscePervasiveRemovableMemoryGetCardInsertState , skipping...
[Note] Ignoring function ScePervasiveForDriver_64ABE589 because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_731A097D because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_788B6C61 because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_78C34032 because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_7B16F900 because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_81A155F1 because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_8BAB45F8 because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_91C80C41 because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_8A85E36B because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_A7CE7DCC because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_A7E64C6F because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_A85BF98A because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_BC42C72F because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_DFD96BFC because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_E3FC1C8D because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_E4B145AE because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_EB176898 because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_EFD084D8 because it doesn't look legit
[Note] Ignoring function ScePervasiveForDriver_FFB43AC2 because it doesn't look legit
[warning] Function sceDsiStartMaster found with different name in db: ksceDsiEnableHead , skipping...
[Note] Ignoring function SceDsiForDriver_6F8029A1 because it doesn't look legit
[warning] Function sceDsiStopDisplay found with different name in db: ksceDsiSendBlankingPacket , skipping...
[warning] Function sceDsiSetDisplayMode found with different name in db: ksceDsiSetLanesAndPixelSize , skipping...
[Note] Ignoring function SceDsiForDriver_8610B795 because it doesn't look legit
[Note] Ignoring function SceDsiForDriver_F2921E29 because it doesn't look legit
[error] Function sceDsiQueryResolutionSize with NID 0xFA9E2DC5 not found in lookup, ignoring...
[Note] Ignoring function SceIftuForDriver_0FCBF457 because it doesn't look legit
[Note] Ignoring function SceIftuForDriver_357EAE24 because it doesn't look legit
[Note] Ignoring function SceIftuForDriver_67E37EFC because it doesn't look legit
[Note] Ignoring function SceIftuForDriver_D64F4C6B because it doesn't look legit
[warning] Function sceMsifReadSectorForDriver found with different name in db: ksceMsifReadSector , skipping...
[warning] Function sceMsifWriteSectorForDriver found with different name in db: ksceMsifWriteSector , skipping...
[warning] Function sceMsifEnableSlowCardModeForDriver found with different name in db: ksceMsifEnableSlowMode , skipping...
[warning] Function sceMsifDisableSlowCardModeForDriver found with different name in db: ksceMsifDisableSlowMode , skipping...
[warning] Function sceMsifGetSlowCardModeStateForDriver found with different name in db: ksceMsifGetSlowModeState , skipping...
[Note] Ignoring function ms_init because it doesn't look legit
[warning] Function sceMsifGetMsInfoForDriver found with different name in db: ksceMsifGetMsInfo , skipping...
[Note] Ignoring function init_mbr because it doesn't look legit
[Note] Ignoring function get_time_from_SceMsifSmshc because it doesn't look legit
[Note] Ignoring function ms_unk because it doesn't look legit
[Note] Ignoring function ms_format because it doesn't look legit
[Note] Ignoring function get_sha224_digest_source because it doesn't look legit
[warning] Function sceOledWaitReadyForDriver found with different name in db: ksceOledWaitReady , skipping...
[Note] Ignoring function SceOledForDriver_26F9EEA8 because it doesn't look legit
[Note] Ignoring function SceOledForDriver_2F0C4B67 because it doesn't look legit
[warning] Function sceOledGetBrightnessForDriver found with different name in db: ksceOledGetBrightness , skipping...
[warning] Function sceOledDisplayOnForDriver found with different name in db: ksceOledDisplayOn , skipping...
[warning] Function sceOledGetDisplayColorSpaceModeForDriver found with different name in db: ksceOledGetDisplayColorSpaceMode , skipping...
[Note] Ignoring function SceOledForDriver_6B1E0B52 because it doesn't look legit
[Note] Ignoring function SceOledForDriver_9F4ABDDC because it doesn't look legit
[warning] Function sceOledDisplayOffForDriver found with different name in db: ksceOledDisplayOff , skipping...
[warning] Function sceOledGetDDBForDriver found with different name in db: ksceOledGetDDB , skipping...
[warning] Function sceOledSetDisplayColorSpaceModeForDriver found with different name in db: ksceOledSetDisplayColorSpaceMode , skipping...
[Note] Ignoring function SceOledForDriver_E30604CC because it doesn't look legit
[warning] Function sceOledSetBrightnessForDriver found with different name in db: ksceOledSetBrightness , skipping...
[warning] Function sceKernelGetProcessInfoForDriver found with different name in db: ksceKernelGetProcessInfo , skipping...
[warning] Function sceKernelGetProcessStatusForDriver found with different name in db: ksceKernelGetProcessStatus , skipping...
[warning] Function sceKernelGetProcessTimeLowCoreForDriver found with different name in db: ksceKernelGetProcessTimeLowCore , skipping...
[warning] Function sceKernelGetProcessTimeWideCoreForDriver found with different name in db: ksceKernelGetProcessTimeWideCore , skipping...
[warning] Function sceKernelGetProcessTimeCoreForDriver found with different name in db: ksceKernelGetProcessTimeCore , skipping...
[warning] Function sceKernelCreateProcessLocalStorageForDriver found with different name in db: ksceKernelCreateProcessLocalStorage , skipping...
[warning] Function sceKernelGetProcessLocalStorageAddrForDriver found with different name in db: ksceKernelGetProcessLocalStorageAddr , skipping...
[warning] Function sceKernelGetPidProcessLocalStorageAddrForDriver found with different name in db: ksceKernelGetProcessLocalStorageAddrForPid , skipping...
[warning] Function sceKernelGetRemoteProcessTimeForDriver found with different name in db: ksceKernelGetRemoteProcessTime , skipping...
[warning] Function sceKernelIsCDialogAvailableForDriver found with different name in db: ksceKernelIsCDialogAvailable , skipping...
[warning] Function sceKernelIsGameBudgetForDriver found with different name in db: ksceKernelIsGameBudget , skipping...
[warning] Function sceKernelLaunchAppForKernel found with different name in db: ksceKernelLaunchApp , skipping...
[warning] Function sceKernelGetProcessKernelBufForKernel found with different name in db: ksceKernelGetProcessKernelBuf , skipping...
[warning] Function sceKernelGetProcessMainThreadForKernel found with different name in db: ksceKernelGetProcessMainThread , skipping...
[warning] Function sceKernelSuspendProcessForKernel found with different name in db: ksceKernelSuspendProcess , skipping...
[warning] Function sceKernelResumeProcessForKernel found with different name in db: ksceKernelResumeProcess , skipping...
[warning] Function sceKernelExitProcessForKernel found with different name in db: ksceKernelExitProcess , skipping...
[warning] Function sceKernelGetSelfAuthInfoForKernel found with different name in db: ksceKernelGetProcessAuthid , skipping...
[warning] Function sceRtcConvertLocalTimeToUtcForDriver found with different name in db: ksceRtcConvertLocalTimeToUtc , skipping...
[warning] Function sceRtcConvertUtcToLocalTime found with different name in db: ksceRtcConvertUtcToLocal , skipping...
[warning] Function sceRtcFormatRFC2822ForDriver found with different name in db: ksceRtcFormatRFC2822 , skipping...
[warning] Function sceRtcFormatRFC2822LocalTimeForDriver found with different name in db: ksceRtcFormatRFC2822LocalTime , skipping...
[warning] Function sceRtcFormatRFC3339ForDriver found with different name in db: ksceRtcFormatRFC3339 , skipping...
[warning] Function sceRtcFormatRFC3339LocalTimeForDriver found with different name in db: ksceRtcFormatRFC3339LocalTime , skipping...
[warning] Function sceRtcGetAccumulativeTimeForDriver found with different name in db: ksceRtcGetAccumulativeTime , skipping...
[warning] Function sceRtcGetCurrentAdNetworkTickForDriver found with different name in db: ksceRtcGetCurrentAdNetworkTick , skipping...
[warning] Function sceRtcGetCurrentClockForDriver found with different name in db: ksceRtcGetCurrentClock , skipping...
[warning] Function sceRtcGetCurrentClockLocalTimeForDriver found with different name in db: ksceRtcGetCurrentClockLocalTime , skipping...
[warning] Function sceRtcGetCurrentDebugNetworkTickForDriver found with different name in db: ksceRtcGetCurrentDebugNetworkTick , skipping...
[warning] Function sceRtcGetCurrentGpsTickForDriver found with different name in db: ksceRtcGetCurrentGpsTick , skipping...
[warning] Function sceRtcGetCurrentNetworkTickForDriver found with different name in db: ksceRtcGetCurrentNetworkTick , skipping...
[warning] Function sceRtcGetCurrentRetainedNetworkTickForDriver found with different name in db: ksceRtcGetCurrentRetainedNetworkTick , skipping...
[warning] Function sceRtcGetCurrentTickForDriver found with different name in db: ksceRtcGetCurrentTick , skipping...
[warning] Function sceRtcGetCurrentSecureTickForDriver found with different name in db: ksceRtcGetCurrentSecureTick , skipping...
[warning] Function sceRtcSetCurrentSecureTickForDriver found with different name in db: ksceRtcSetCurrentSecureTick , skipping...
[warning] Function sceRtcGetLastAdjustedTickForDriver found with different name in db: ksceRtcGetLastAdjustedTick , skipping...
[warning] Function sceRtcGetLastReincarnatedTickForDriver found with different name in db: ksceRtcGetLastReincarnatedTick , skipping...
[Note] Ignoring function init because it doesn't look legit
[Note] Ignoring function deinit because it doesn't look legit
[Note] Ignoring function return_error because it doesn't look legit
[Note] Ignoring function enable_slow_mode because it doesn't look legit
[Note] Ignoring function get_card_insert_state1 because it doesn't look legit
[Note] Ignoring function get_card_insert_state2 because it doesn't look legit
[Note] Ignoring function gc_cmd56_response because it doesn't look legit
[Note] Ignoring function gc_cmd56_request because it doesn't look legit
[Note] Ignoring function get_sd_context_global because it doesn't look legit
[Note] Ignoring function get_sd_context_part_validate_mmc because it doesn't look legit
[Note] Ignoring function get_sd_context_part_validate_sd because it doesn't look legit
[Note] Ignoring function get_sd_context_part_validate_sdio because it doesn't look legit
[Note] Ignoring function initialize_mmc_device because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_initialize_custom_context2 because it doesn't look legit
[Note] Ignoring function wlan_bt because it doesn't look legit
[Note] Ignoring function wlan_bt because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd7 because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt_initialize_custom_context1 because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd0 because it doesn't look legit
[Note] Ignoring function wlan_bt_cmd0_cmd52_sdio because it doesn't look legit
[Note] Ignoring function wlan_bt because it doesn't look legit
[Note] Ignoring function wlan_bt because it doesn't look legit
[Note] Ignoring function wlan_bt because it doesn't look legit
[Note] Ignoring function sdstor_read_sector_mmc because it doesn't look legit
[Note] Ignoring function sdstor_read_sector_sd because it doesn't look legit
[Note] Ignoring function sdstor_write_sector_mmc because it doesn't look legit
[Note] Ignoring function sdstor_write_sector_sd because it doesn't look legit
[Note] Ignoring function sdstor_get_cid because it doesn't look legit
[Note] Ignoring function sdstor_cmd0_cmd13 because it doesn't look legit
[Note] Ignoring function sdstor_cmd32_cmd33_cmd38_sdio because it doesn't look legit
[Note] Ignoring function initialize_sd_device because it doesn't look legit
[Note] Ignoring function sdstor_cmd6_cmd30 because it doesn't look legit
[Note] Ignoring function sdstor because it doesn't look legit
[Note] Ignoring function sdif_write because it doesn't look legit
[Note] Ignoring function sdif_write because it doesn't look legit
[Note] Ignoring function disable_slow_mode because it doesn't look legit
[Note] Ignoring function sdif_cmd0_cmd13 because it doesn't look legit
[Note] Ignoring function reset_to_low_speed_mode because it doesn't look legit
[Note] Ignoring function get_host_info because it doesn't look legit
[Note] Ignoring function get_device_info because it doesn't look legit
[Note] Ignoring function sdif_cmd_exec because it doesn't look legit
[Note] Ignoring function set_default_sector_size_mmc because it doesn't look legit
[Note] Ignoring function sdif_cmd0_cmd16 because it doesn't look legit
[Note] Ignoring function module_start because it doesn't look legit
[warning] Function sceSblSmSchedProxyWaitForKernel found with different name in db: ksceSblSmSchedProxyWait , skipping...
[warning] Function sceSblSmSchedProxyGetStatusForKernel found with different name in db: ksceSblSmSchedProxyGetStatus , skipping...
[warning] Function sceSblSmCommStopSmForKernel found with different name in db: ksceSblSmCommStopSm , skipping...
[warning] Function sceSblSmCommStartSmFromDataForKernel found with different name in db: ksceSblSmCommStartSmFromData , skipping...
[error] Function sceSblSmCommStartSmFromFileForKernel with NID 0x992BB9DB not found in lookup, ignoring...
[warning] Function sceSblSmCommStartSmFromFileForKernel found with different name in db: ksceSblSmCommStartSmFromFile , skipping...
[warning] Function sceSblSmCommCallFuncForKernel found with different name in db: ksceSblSmCommCallFunc , skipping...
[error] Function sceSblSmCommStartSm_ with NID 0x992BB9DB not found in lookup, ignoring...
[Note] Ignoring function return_ffffffff because it doesn't look legit
[error] Function sceSblQafManagerGetQafTokenForKernel with NID 0x281FD75A not found in lookup, ignoring...
[error] Function sceSblQafManagerSetQafTokenForKernel with NID 0x8E9447A1 not found in lookup, ignoring...
[error] Function sceSblQafManagerClearQafTokenForKernel with NID 0xD45155C6 not found in lookup, ignoring...
[warning] Function sceSblSsMgrGetRandomNumberForDriver found with different name in db: ksceKernelGetRandomNumber , skipping...
[warning] Function sceSblSsEncryptWithPortabilityForDriver found with different name in db: ksceSblSsEncryptWithPortability , skipping...
[warning] Function sceSblSsDecryptWithPortabilityForDriver found with different name in db: ksceSblSsDecryptWithPortability , skipping...
[warning] Function sceSblSsGetNvsDataForDriver found with different name in db: ksceSblSsGetNvsData , skipping...
[warning] Function sceSblSsSetNvsDataForDriver found with different name in db: ksceSblSsSetNvsData , skipping...
[warning] Function sceSblAimgrGetVisibleIdForDriver found with different name in db: ksceSblAimgrGetVisibleId , skipping...
[warning] Function sceSblAimgrGetConsoleIdForDriver found with different name in db: ksceSblAimgrGetConsoleId , skipping...
[warning] Function sceSblAimgrGetPscodeForDriver found with different name in db: ksceSblAimgrGetPscode , skipping...
[warning] Function sceSblAimgrGetPscode2ForDriver found with different name in db: ksceSblAimgrGetPscode2 , skipping...
[warning] Function sceSblSsCreatePassPhraseForDriver found with different name in db: ksceSblSsCreatePassPhrase , skipping...
[Note] Ignoring function unk_e0b13ba7 because it doesn't look legit
[Note] Ignoring function unk_c38d0cea because it doesn't look legit
[error] Function sceSblRtcMgrSetCpRtcForDriver with NID 0xD8F6F110 not found in lookup, ignoring...
[error] Function sceSblRtcMgrGetCpRtcPhysicalForDriver with NID 0xC96622EC not found in lookup, ignoring...
[error] Function sceSblRtcMgrGetCpRtcLogicalForDriver with NID 0xAF56206D not found in lookup, ignoring...
[error] Function sceSblLicGetActivationKeyForDriver with NID 0xED4878A4 not found in lookup, ignoring...
[error] Function sceSblLicMgrGetExpireDateForDriver with NID 0xE840CD4E not found in lookup, ignoring...
[error] Function sceSblPmMgrGetProductModeFromNVSForDriver with NID 0x196C7FB2 not found in lookup, ignoring...
[error] Function sceSblPmMgrSetProductModeForDriver with NID 0x33B706E1 not found in lookup, ignoring...
[error] Function sceSblPmMgrAuthEtoIForDriver with NID 0xB241EA2B not found in lookup, ignoring...
[error] Function sceSblSsInfraAllocatePARangeVector with NID 0x8C2822A9 not found in lookup, ignoring...
[Note] Ignoring function SceSblSsMgr_FAD42134 because it doesn't look legit
[warning] Function sceSblQafManagerGetQafName2ForUser found with different name in db: sceSblQafMgrGetQafName , skipping...
[error] Function sceSblSsMgrGetRandomData with NID 0xD1189305 not found in lookup, ignoring...
[warning] Function sceSysconBatteryExecBLCommandForDriver found with different name in db: ksceSysconBatteryExecBLCommand , skipping...
[warning] Function sceSysconBatteryReadBLCommandForDriver found with different name in db: ksceSysconBatteryReadBLCommand , skipping...
[warning] Function sceSysconBatterySetBLCommandForDriver found with different name in db: ksceSysconBatterySetBLCommand , skipping...
[warning] Function sceSysconBatteryStartBLModeForDriver found with different name in db: ksceSysconBatteryStartBLMode , skipping...
[warning] Function sceSysconBatteryStopBLModeForDriver found with different name in db: ksceSysconBatteryStopBLMode , skipping...
[warning] Function sceSysconBatterySWResetForDriver found with different name in db: ksceSysconBatterySWReset , skipping...
[warning] Function sceSysconGetManualChargeModeForDriver found with different name in db: ksceSysconGetManualChargeMode , skipping...
[warning] Function sceSysconGetLogInfoForDriver found with different name in db: ksceSysconGetLogInfo , skipping...
[warning] Function sceSysconLogStartForDriver found with different name in db: ksceSysconLogStart , skipping...
[warning] Function sceSysconLogStartWaitingForDriver found with different name in db: ksceSysconLogStartWaiting , skipping...
[warning] Function sceSysconLogReadDataForDriver found with different name in db: ksceSysconLogReadData , skipping...
[warning] Function sceSysconGetTemperatureLogForDriver found with different name in db: ksceSysconGetTemperatureLog , skipping...
[warning] Function sceSysconClearTemperatureLogForDriver found with different name in db: ksceSysconClearTemperatureLog , skipping...
[warning] Function sceSysconGetUsbDetStatusForDriver found with different name in db: ksceSysconGetUsbDetStatus , skipping...
[warning] Function sceSysconCmdReadForDriver found with different name in db: ksceSysconReadCommand , skipping...
[warning] Function sceSysconGetBaryonTimestampForDriver found with different name in db: ksceSysconGetBaryonTimestamp , skipping...
[warning] Function sceSysconWaitInitializedForDriver found with different name in db: ksceSysconWaitInitialized , skipping...
[warning] Function sceSysconCtrlHdmiCecPowerForDriver found with different name in db: ksceSysconCtrlHdmiCecPower , skipping...
[warning] Function sceSysconCmdSyncForDriver found with different name in db: ksceSysconCmdSync , skipping...
[warning] Function sceSysconCtrlRMRPowerForDriver found with different name in db: ksceSysconCtrlRMRPower , skipping...
[warning] Function sceSysconSetPowerModeForDriver found with different name in db: ksceSysconSetPowerMode , skipping...
[warning] Function sceSysconEnableHibernateIOForDriver found with different name in db: ksceSysconEnableHibernateIO , skipping...
[warning] Function sceSysconCmdExecForDriver found with different name in db: ksceSysconCmdExec , skipping...
[warning] Function sceSysconCtrlSdPowerForDriver found with different name in db: ksceSysconCtrlSdPower , skipping...
[error] Function sceSysconCtrlWirelessPowerForDriver with NID 0x4FBDA504 not found in lookup, ignoring...
[error] Function sceSysconCtrlWirelessPowerDownForDriver with NID 0xDF8C6D2D not found in lookup, ignoring...
[warning] Function sceSysconCmdExecAsyncForDriver found with different name in db: ksceSysconCmdExecAsync , skipping...
[warning] Function sceSysconCmdSendForDriver found with different name in db: ksceSysconSendCommand , skipping...
[warning] Function sceSysconVerifyConfigstorageScriptForDriver found with different name in db: ksceSysconVerifyConfigstorageScript , skipping...
[warning] Function sceSysconLoadConfigstorageScriptForDriver found with different name in db: ksceSysconLoadConfigstorageScript , skipping...
[warning] Function sceSysconBeginConfigstorageTransactionForDriver found with different name in db: ksceSysconBeginConfigstorageTransaction , skipping...
[warning] Function sceSysconCommitConfigstorageTransactionForDriver found with different name in db: ksceSysconCommitConfigstorageTransaction , skipping...
[warning] Function sceSysconEndConfigstorageTransactionForDriver found with different name in db: ksceSysconEndConfigstorageTransaction , skipping...
[warning] Function sceSysconSetDebugHandlersForDriver found with different name in db: ksceSysconSetDebugHandlers , skipping...
[warning] Function sceSysconGetBatteryCalibDataForDriver found with different name in db: ksceSysconGetBatteryCalibData , skipping...
[warning] Function sceSysconGetTouchpanelDeviceInfoForDriver found with different name in db: ksceSysconGetTouchpanelDeviceInfo , skipping...
[warning] Function sceSysconGetHardwareInfoForDriver found with different name in db: ksceSysconGetHardwareInfo , skipping...
[warning] Function sceSysconGetHardwareInfo2ForDriver found with different name in db: ksceSysconGetHardwareInfo2 , skipping...
[warning] Function sceSysconGetBaryonVersionForDriver found with different name in db: ksceSysconGetBaryonVersion , skipping...
[warning] Function sceSysconGetBatteryVersionForDriver found with different name in db: ksceSysconGetBatteryVersion , skipping...
[warning] Function sceSysconGetManufacturesStatusForDriver found with different name in db: ksceSysconGetManufacturesStatus , skipping...
[Note] Ignoring function unk_9DA2A5AB because it doesn't look legit
[warning] Function sceSysconNvsSetRunModeForDriver found with different name in db: ksceSysconNvsSetRunMode , skipping...
[warning] Function sceSysconNvsReadDataForDriver found with different name in db: ksceSysconNvsReadData , skipping...
[warning] Function sceSysconNvsWriteDataForDriver found with different name in db: ksceSysconNvsWriteData , skipping...
[warning] Function sceSysconSetMultiCnPortForDriver found with different name in db: ksceSysconSetMultiCnPort , skipping...
[warning] Function sceSysconCtrlLEDForDriver found with different name in db: ksceSysconCtrlLED , skipping...
[warning] Function sceSysconCtrlAccPowerForDriver found with different name in db: ksceSysconCtrlAccPower , skipping...
[warning] Function sceSysconCtrlDeviceResetForDriver found with different name in db: ksceSysconCtrlDeviceReset , skipping...
[warning] Function sceSysconJigOpenPortForDriver found with different name in db: ksceSysconJigOpenPort , skipping...
[warning] Function sceSysconJigClosePortForDriver found with different name in db: ksceSysconJigClosePort , skipping...
[warning] Function sceSysconJigSetConfigForDriver found with different name in db: ksceSysconJigSetConfig , skipping...
[warning] Function sceSysconCtrlHostOutputViaDongleForDriver found with different name in db: ksceSysconCtrlHostOutputViaDongle , skipping...
[Note] Ignoring function receive_pm_sm_jig_msg_from_syscon because it doesn't look legit
[Note] Ignoring function send_pm_sm_jig_msg_to_syscon because it doesn't look legit
[warning] Function sceSysconIduModeSetForDriver found with different name in db: ksceSysconIduModeSet , skipping...
[warning] Function sceSysconIduModeClearForDriver found with different name in db: ksceSysconIduModeClear , skipping...
[warning] Function sceSysconShowModeSetForDriver found with different name in db: ksceSysconShowModeSet , skipping...
[warning] Function sceSysconShowModeClearForDriver found with different name in db: ksceSysconShowModeClear , skipping...
[warning] Function sceSysconIsDownLoaderModeForDriver found with different name in db: ksceSysconIsDownLoaderMode , skipping...
[warning] Function sceSysconSetAlarmCallbackForDriver found with different name in db: ksceSysconSetAlarmCallback , skipping...
[warning] Function sceSysconSetLowBatteryCallbackForDriver found with different name in db: ksceSysconSetLowBatteryCallback , skipping...
[warning] Function sceSysconSetThermalAlertCallbackForDriver found with different name in db: ksceSysconSetThermalAlertCallback , skipping...
[warning] Function sceSysconUpdaterCalcChecksumForDriver found with different name in db: ksceSysconUpdaterCalcChecksum , skipping...
[warning] Function sceSysconUpdaterExecFinalizeForDriver found with different name in db: ksceSysconUpdaterExecFinalize , skipping...
[warning] Function sceSysconUpdaterExecProgrammingForDriver found with different name in db: ksceSysconUpdaterExecProgramming , skipping...
[warning] Function sceSysconUpdaterSetRunModeForDriver found with different name in db: ksceSysconUpdaterSetRunMode , skipping...
[warning] Function sceSysconUpdaterSetSegmentForDriver found with different name in db: ksceSysconUpdaterSetSegment , skipping...
[Note] Ignoring function memcpy_from_paddr because it doesn't look legit
[warning] Function sceKernelUIDEntryHeapGetInfoForKernel found with different name in db: ksceKernelUIDEntryHeapGetInfo , skipping...
[warning] Function sceKernelNameHeapGetInfoForKernel found with different name in db: ksceKernelNameHeapGetInfo , skipping...
[warning] Function sceKernelGetFixedHeapInfoByPointerForKernel found with different name in db: ksceKernelGetFixedHeapInfoByPointer , skipping...
[warning] Function sceKernelGetHeapInfoByPtrForKernel found with different name in db: ksceKernelGetHeapInfoByPtr , skipping...
[Note] Ignoring function SceSysmemForKernel_C38D61FC because it doesn't look legit
[error] Function sceUIDGetObjectForKernel with NID 0xC4893914 not found in lookup, ignoring...
[Note] Ignoring function SceSysmemForKernel_620E00E7 because it doesn't look legit
[Note] Ignoring function SceSysmemForKernel_7C797940 because it doesn't look legit
[Note] Ignoring function free because it doesn't look legit
[Note] Ignoring function SceSysmemForKernel_ED221825 because it doesn't look legit
[warning] Function sceGUIDGetUIDVectorByClassForKernel found with different name in db: ksceGUIDGetUIDVectorByClass , skipping...
[error] Function sceGUIDGetUIDVectorByClass2ForKernel with NID 0xA2F03233 not found in lookup, ignoring...
[warning] Function sceKernelRxMemcpyKernelToUserForPidForKernel found with different name in db: ksceKernelRxMemcpyKernelToUserForPid , skipping...
[warning] Function sceKernelFindClassByNameForKernel found with different name in db: ksceKernelFindClassByName , skipping...
[warning] Function sceKernelGetMemBlockTypeForKernel found with different name in db: ksceKernelGetMemBlockType , skipping...
[warning] Function sceKernelCreateUidObjForKernel found with different name in db: ksceKernelCreateUidObj , skipping...
[warning] Function sceKernelGetUidHeapClassForKernel found with different name in db: ksceKernelGetUidHeapClass , skipping...
[warning] Function sceKernelGetUidMemBlockClassForKernel found with different name in db: ksceKernelGetUidMemBlockClass , skipping...
[warning] Function sceKernelGetUidDLinkClassForKernel found with different name in db: ksceKernelGetUidDLinkClass , skipping...
[error] Function sceKernelRoMemcpyKernelToUserForPidForDriver with NID 0x571D2739 not found in lookup, ignoring...
[warning] Function sceKernelAllocHeapMemoryForDriver found with different name in db: ksceKernelAllocHeapMemory , skipping...
[warning] Function sceKernelAllocHeapMemoryWithOptionForDriver found with different name in db: ksceKernelAllocHeapMemoryWithOption , skipping...
[error] Function sceKernelAllocMemBlockForDriver with NID 0x402EB970 not found in lookup, ignoring...
[warning] Function sceKernelAllocMemBlockForDriver found with different name in db: ksceKernelAllocMemBlock , skipping...
[warning] Function sceKernelCreateClassForDriver found with different name in db: ksceKernelCreateClass , skipping...
[warning] Function sceKernelCreateHeapForDriver found with different name in db: ksceKernelCreateHeap , skipping...
[warning] Function sceKernelCreateUserUidForDriver found with different name in db: ksceKernelCreateUserUid , skipping...
[warning] Function sceKernelDeleteHeapForDriver found with different name in db: ksceKernelDeleteHeap , skipping...
[warning] Function sceKernelDeleteUidForDriver found with different name in db: ksceKernelDeleteUid , skipping...
[warning] Function sceKernelDeleteUserUidForDriver found with different name in db: ksceKernelDeleteUserUid , skipping...
[warning] Function sceKernelFindMemBlockByAddrForDriver found with different name in db: ksceKernelFindMemBlockByAddr , skipping...
[warning] Function sceKernelFindProcMemBlockByAddrForDriver found with different name in db: ksceKernelFindMemBlockByAddrForPid , skipping...
[warning] Function sceKernelFirstDifferentBlock32UserForPidForDriver found with different name in db: ksceKernelFirstDifferentIntUserForPid , skipping...
[warning] Function sceKernelFreeHeapMemoryForDriver found with different name in db: ksceKernelFreeHeapMemory , skipping...
[warning] Function sceKernelFreeMemBlockForDriver found with different name in db: ksceKernelFreeMemBlock , skipping...
[warning] Function sceKernelGetMemBlockBaseForDriver found with different name in db: ksceKernelGetMemBlockBase , skipping...
[error] Function sceUIDtoObjectForDriver with NID 0xAB7AC3D1 not found in lookup, ignoring...
[warning] Function sceKernelGetObjectForUidForClassForDriver found with different name in db: ksceKernelGetObjForUid , skipping...
[warning] Function sceKernelGetObjectForUidForDriver found with different name in db: ksceKernelUidRetain , skipping...
[error] Function sceKernelVAtoPAForDriver with NID 0x1DEADF6C not found in lookup, ignoring...
[warning] Function sceKernelVAtoPAForDriver found with different name in db: ksceKernelGetPaddr , skipping...
[warning] Function sceKernelVARangeToPAVectorForDriver found with different name in db: ksceKernelGetPaddrList , skipping...
[warning] Function sceKernelGetPidContextForDriver found with different name in db: ksceKernelGetPidContext , skipping...
[warning] Function sceKernelGetUidClassForDriver found with different name in db: ksceKernelGetUidClass , skipping...
[warning] Function scePUIDtoGUIDForDriver found with different name in db: ksceKernelKernelUidForUserUid , skipping...
[warning] Function sceKernelMapBlockUserVisibleForDriver found with different name in db: ksceKernelMapBlockUserVisible , skipping...
[warning] Function sceKernelUserMapForDriver found with different name in db: ksceKernelMapUserBlockDefaultType , skipping...
[warning] Function sceKernelMapUserBlockForDefaultTypeForPidForDriver found with different name in db: ksceKernelMapUserBlockDefaultTypeForPid , skipping...
[warning] Function sceKernelMapUserBlockForDriver found with different name in db: ksceKernelMapUserBlock , skipping...
[warning] Function sceKernelMemBlockReleaseForDriver found with different name in db: ksceKernelMemBlockRelease , skipping...
[warning] Function sceKernelMemRangeReleaseForDriver found with different name in db: ksceKernelMemRangeRelease , skipping...
[warning] Function sceKernelMemRangeReleaseForPidForDriver found with different name in db: ksceKernelMemRangeReleaseForPid , skipping...
[warning] Function sceKernelMemRangeReleaseWithPermForDriver found with different name in db: ksceKernelMemRangeReleaseWithPerm , skipping...
[warning] Function sceKernelMemRangeRetainForDriver found with different name in db: ksceKernelMemRangeRetain , skipping...
[warning] Function sceKernelMemRangeRetainForPidForDriver found with different name in db: ksceKernelMemRangeRetainForPid , skipping...
[warning] Function sceKernelMemRangeRetainWithPermForDriver found with different name in db: ksceKernelMemRangeRetainWithPerm , skipping...
[warning] Function sceKernelMemcpyKernelToUserForDriver found with different name in db: ksceKernelMemcpyKernelToUser , skipping...
[warning] Function sceKernelCopyoutProcForDriver found with different name in db: ksceKernelMemcpyKernelToUserForPid , skipping...
[warning] Function sceKernelMemcpyKernelToUserForPidUncheckedForDriver found with different name in db: ksceKernelMemcpyKernelToUserForPidUnchecked , skipping...
[warning] Function sceKernelMemcpyUserToKernelForDriver found with different name in db: ksceKernelMemcpyUserToKernel , skipping...
[warning] Function sceKernelMemcpyUserToKernelForPidForDriver found with different name in db: ksceKernelMemcpyUserToKernelForPid , skipping...
[warning] Function sceKernelMemcpyUserToUserForPidForDriver found with different name in db: ksceKernelMemcpyUserToUserForPid , skipping...
[error] Function sceKernelRemapBlockForDriver with NID 0x8D332AE1 not found in lookup, ignoring...
[warning] Function sceKernelRemapBlockForDriver found with different name in db: ksceKernelRemapBlock , skipping...
[warning] Function sceKernelStrnlenUserForDriver found with different name in db: ksceKernelStrnlenUser , skipping...
[warning] Function sceKernelStrnlenUserForPidForDriver found with different name in db: ksceKernelStrnlenUserForPid , skipping...
[warning] Function sceKernelStrncpyKernelToUserForDriver found with different name in db: ksceKernelStrncpyKernelToUser , skipping...
[warning] Function sceKernelStrncpyKernelToUserForPidForDriver found with different name in db: ksceKernelStrncpyUserForPid , skipping...
[warning] Function sceKernelStrncpyUserToKernelForDriver found with different name in db: ksceKernelStrncpyUserToKernel , skipping...
[warning] Function sceKernelUidReleaseForDriver found with different name in db: ksceKernelUidRelease , skipping...
[warning] Function sceKernelUnmapMemBlockForDriver found with different name in db: ksceKernelUnmapMemBlock , skipping...
[Note] Ignoring function some_memblock_operation because it doesn't look legit
[Note] Ignoring function some_memblock_operation because it doesn't look legit
[Note] Ignoring function some_memblock_operation because it doesn't look legit
[Note] Ignoring function some_memblock_operation because it doesn't look legit
[Note] Ignoring function some_memblock_operation because it doesn't look legit
[Note] Ignoring function memblock_related_operation because it doesn't look legit
[Note] Ignoring function memblock_related_operation because it doesn't look legit
[Note] Ignoring function memblock_related_operation because it doesn't look legit
[Note] Ignoring function SceSysmemForDriver_856fa2e3 because it doesn't look legit
[Note] Ignoring function SceSysmemForDriver_89475192 because it doesn't look legit
[Note] Ignoring function SceSysmemForDriver_c50a9c0d because it doesn't look legit
[error] Function sceKernelIsAccessibleRangeProcForDebugger with NID 0x01DFC193 not found in lookup, ignoring...
[error] Function sceKernelIsAccessibleRangeForDebugger with NID 0xD027761F not found in lookup, ignoring...
[error] Function sceKernelMapMemBlock with NID 0x7B763A21 not found in lookup, ignoring...
[error] Function sceKernelRemapMemBlock with NID 0x3B29E0F5 not found in lookup, ignoring...
[error] Function sceKernelPartialMapMemBlock with NID 0xC0A59868 not found in lookup, ignoring...
[error] Function sceKernelUnmapMemBlock with NID 0xEE30D976 not found in lookup, ignoring...
[error] Function sceKernelPartialUnmapMemBlock with NID 0xCA99929B not found in lookup, ignoring...
[warning] Function sceKernelCheckDipswForDriver found with different name in db: ksceKernelCheckDipsw , skipping...
[warning] Function sceKernelClearDipswForDriver found with different name in db: ksceKernelClearDipsw , skipping...
[warning] Function sceKernelSetDipswForDriver found with different name in db: ksceKernelSetDipsw , skipping...
[warning] Function sceUartWriteForKernel found with different name in db: ksceUartWrite , skipping...
[warning] Function sceUartReadAvailableForKernel found with different name in db: ksceUartReadAvailable , skipping...
[warning] Function sceUartReadForKernel found with different name in db: ksceUartRead , skipping...
[warning] Function sceUartInitForKernel found with different name in db: ksceUartInit , skipping...
[error] Function sceKernelCpuSaveContextForKernel with NID 0x211B89DA not found in lookup, ignoring...
[error] Function sceKernelCpuRestoreContextForKernel with NID 0x0A4F0FB9 not found in lookup, ignoring...
[warning] Function sceKernelCpuDcacheCleanInvalidateMVACRangeForKernel found with different name in db: ksceKernelCpuDcacheWritebackInvalidateRange , skipping...
[warning] Function sceKernelCpuDcacheInvalidateSWForKernel found with different name in db: ksceKernelCpuDcacheInvalidateAll , skipping...
[warning] Function sceKernelCpuDcacheCleanSWForKernel found with different name in db: ksceKernelCpuDcacheWritebackAll , skipping...
[warning] Function sceKernelCpuDcacheCleanInvalidateSWForKernel found with different name in db: ksceKernelCpuDcacheWritebackInvalidateAll , skipping...
[warning] Function sceKernelCpuIcacheInvalidateAllUISForKernel found with different name in db: ksceKernelCpuIcacheInvalidateAll , skipping...
[warning] Function sceKernelCpuIcacheInvalidateMVAURangeForKernel found with different name in db: ksceKernelCpuIcacheInvalidateRange , skipping...
[warning] Function sceKernelCpuIcacheAndL2InvalidateMVAURangeForKernel found with different name in db: ksceKernelCpuIcacheAndL2WritebackInvalidateRange , skipping...
[error] Function sceKernelCpuIcacheAndL2InvalidateMVAURangeForKernel with NID 0x73E895EA not found in lookup, ignoring...
[warning] Function sceKernelCpuUnrestrictedMemcpyForKernel found with different name in db: ksceKernelCpuUnrestrictedMemcpy , skipping...
[Note] Ignoring function SceCpuForKernel_A5C9DBBA because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_9D72DD1B because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_4CD4D921 because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_43CC6E20 because it doesn't look legit
[Note] Ignoring function SceCpuUnrestrictedBzeroIntForKernel because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_337473B5 because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_37FBFD12 because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_D37AABE5 because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_4553FBDE because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_6190A018 because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_D8A7216C because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_7FB4E7AC because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_8510FA52 because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_5F64E5ED because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_98E91C1C because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_6C7E7B57 because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_9A3281C0 because it doesn't look legit
[Note] Ignoring function SceCpuForKernel_9CB82EB0 because it doesn't look legit
[warning] Function sceKernelCpuGetCpuIdForDriver found with different name in db: ksceKernelCpuGetCpuId , skipping...
[warning] Function sceKernelCpuDcacheAndL2InvalidateMVACRange_1ForDriver found with different name in db: ksceKernelCpuDcacheAndL2InvalidateRange , skipping...
[warning] Function sceKernelCpuDcacheAndL2InvalidateMVACRange_20ForDriver found with different name in db: ksceKernelCpuDcacheInvalidateRange , skipping...
[warning] Function sceKernelCpuDcacheAndL2CleanInvalidateMVACRange_1ForDriver found with different name in db: ksceKernelCpuDcacheAndL2WritebackInvalidateRange , skipping...
[warning] Function sceKernelDcacheCleanRangeCoreForDriver found with different name in db: ksceKernelCpuDcacheAndL2WritebackRange , skipping...
[warning] Function sceKernelCpuDcacheAndL2CleanMVACRange_20ForDriver found with different name in db: ksceKernelCpuDcacheWritebackRange , skipping...
[Note] Ignoring function SceCpuForDriver_E813EBB2 because it doesn't look legit
[warning] Function sceKernelCpuLockSuspendIntrStoreLRForDriver found with different name in db: ksceKernelCpuSuspendIntr , skipping...
[warning] Function sceKernelCpuUnlockResumeIntrStoreLRForDriver found with different name in db: ksceKernelCpuResumeIntr , skipping...
[warning] Function sceKernelCpuSpinLockSuspendIntrStoreLRForDriver found with different name in db: ksceKernelCpuSpinLockIrqSave , skipping...
[warning] Function sceKernelCpuSpinUnlockResumeIntrStoreLRForDriver found with different name in db: ksceKernelCpuSpinLockIrqRestore , skipping...
[warning] Function sceKernelCpuDisableInterruptsForDriver found with different name in db: ksceKernelCpuDisableInterrupts , skipping...
[warning] Function sceKernelCpuEnableInterruptsForDriver found with different name in db: ksceKernelCpuEnableInterrupts , skipping...
[Note] Ignoring function SceSysclibForKernel_E38E7605 because it doesn't look legit
[Note] Ignoring function SceSysclibForKernel_F7E34376 because it doesn't look legit
[Note] Ignoring function SceSysclibForKernel_FA746181 because it doesn't look legit
[Note] Ignoring function __aeabi_idiv because it doesn't look legit
[Note] Ignoring function __aeabi_uidiv because it doesn't look legit
[Note] Ignoring function __aeabi_uidivmod because it doesn't look legit
[Note] Ignoring function __aeabi_ldivmod because it doesn't look legit
[Note] Ignoring function __memcpy_chk because it doesn't look legit
[Note] Ignoring function __memmove_chk because it doesn't look legit
[Note] Ignoring function __memset_chk because it doesn't look legit
[Note] Ignoring function __stack_chk_fail because it doesn't look legit
[Note] Ignoring function __strncat_chk because it doesn't look legit
[Note] Ignoring function __strncpy_chk because it doesn't look legit
[Note] Ignoring function look_ctype_table because it doesn't look legit
[Note] Ignoring function memchr because it doesn't look legit
[Note] Ignoring function memcmp because it doesn't look legit
[Note] Ignoring function memcmp2 because it doesn't look legit
[Note] Ignoring function memcpy because it doesn't look legit
[Note] Ignoring function memmove because it doesn't look legit
[Note] Ignoring function memset because it doesn't look legit
[Note] Ignoring function memset2 because it doesn't look legit
[Note] Ignoring function rshift because it doesn't look legit
[Note] Ignoring function snprintf because it doesn't look legit
[Note] Ignoring function strchr because it doesn't look legit
[Note] Ignoring function strcmp because it doesn't look legit
[Note] Ignoring function strlcat because it doesn't look legit
[Note] Ignoring function strlcpy because it doesn't look legit
[Note] Ignoring function strlen because it doesn't look legit
[Note] Ignoring function strncat because it doesn't look legit
[Note] Ignoring function strncmp because it doesn't look legit
[Note] Ignoring function strncpy because it doesn't look legit
[Note] Ignoring function strnlen because it doesn't look legit
[Note] Ignoring function strrchr because it doesn't look legit
[Note] Ignoring function strstr because it doesn't look legit
[Note] Ignoring function strtol because it doesn't look legit
[Note] Ignoring function strtoll because it doesn't look legit
[Note] Ignoring function strtoul because it doesn't look legit
[Note] Ignoring function tolower because it doesn't look legit
[Note] Ignoring function toupper because it doesn't look legit
[Note] Ignoring function vsnprintf because it doesn't look legit
[warning] Function sceSysrootGetSmSelfInfoForKernel found with different name in db: ksceSysrootGetSelfInfo , skipping...
[warning] Function sceSysrootGetSelfAuthInfoForKernel found with different name in db: ksceSysrootGetSelfAuthInfo , skipping...
[warning] Function sceSysrootGetProcessTitleIdForPidForKernel found with different name in db: ksceKernelGetProcessTitleId , skipping...
[Note] Ignoring function SceSysrootForKernel_377895EB because it doesn't look legit
[warning] Function sceSysrootGetSysbaseForKernel found with different name in db: ksceKernelGetSysbase , skipping...
[warning] Function sceKernelSysrootGetKblParamForKernel found with different name in db: ksceKernelGetSysrootBuffer , skipping...
[warning] Function sceSysrootGetHardwareFlagsForKernel found with different name in db: ksceSysrootIsAuCodecIcConexant , skipping...
[warning] Function sceSysrootIsExternalBootModeForKernel found with different name in db: ksceSysrootIsExternalBootMode , skipping...
[warning] Function sceKernelSysrootIsSafeModeForKernel found with different name in db: ksceSysrootIsSafeMode , skipping...
[warning] Function sceSysrootIsUpdateModeForKernel found with different name in db: ksceSysrootIsUpdateMode , skipping...
[warning] Function sceSysrootIsBsodRebootForKernel found with different name in db: ksceSysrootIsBsodReboot , skipping...
[warning] Function sceSysrootIsUsbEnumWakeupForKernel found with different name in db: ksceSysrootIsUsbEnumWakeup , skipping...
[warning] Function sceSysrootUseExternalStorageForKernel found with different name in db: ksceSysrootUseExternalStorage , skipping...
[warning] Function sceSysrootUseInternalStorageForKernel found with different name in db: ksceSysrootUseInternalStorage , skipping...
[warning] Function sceKernelSysrootDbgpSuspendProcessAndWaitResumeForDriver found with different name in db: ksceKernelSysrootDbgpSuspendProcessAndWaitResume , skipping...
[warning] Function sceKernelSysrootAppMgrSpawnProcessForDriver found with different name in db: ksceKernelSysrootAppMgrSpawnProcess , skipping...
[Note] Ignoring function SceSysrootForDriver_421EFC96 because it doesn't look legit
[warning] Function sceKernelSysrootGetSystemSwVersionForDriver found with different name in db: ksceKernelSysrootGetSystemSwVersion , skipping...
[warning] Function sceKernelSysrootIsSafeModeForDriver found with different name in db: ksceSysrootIsSafeMode , skipping...
[warning] Function sceAesDecrypt2ForDriver found with different name in db: ksceAesDecrypt2 , skipping...
[warning] Function sceAesInit2ForDriver found with different name in db: ksceAesInit2 , skipping...
[warning] Function sceAesInit3ForDriver found with different name in db: ksceAesInit3 , skipping...
[warning] Function sceDeflateDecompressForDriver found with different name in db: ksceDeflateDecompress , skipping...
[warning] Function sceDeflateDecompressPartialForDriver found with different name in db: ksceDeflateDecompressPartial , skipping...
[warning] Function sceGzipDecompressForDriver found with different name in db: ksceGzipDecompress , skipping...
[warning] Function sceGzipGetCommentForDriver found with different name in db: ksceGzipGetComment , skipping...
[warning] Function sceGzipGetCompressedDataForDriver found with different name in db: ksceGzipGetCompressedData , skipping...
[warning] Function sceGzipGetInfoForDriver found with different name in db: ksceGzipGetInfo , skipping...
[warning] Function sceGzipGetNameForDriver found with different name in db: ksceGzipGetName , skipping...
[warning] Function sceGzipIsValidForDriver found with different name in db: ksceGzipIsValid , skipping...
[warning] Function sceHmacSha1DigestForDriver found with different name in db: ksceHmacSha1Digest , skipping...
[warning] Function sceHmacSha224DigestForDriver found with different name in db: ksceHmacSha224Digest , skipping...
[warning] Function sceHmacSha256DigestForDriver found with different name in db: ksceHmacSha256Digest , skipping...
[warning] Function sceMt19937InitForDriver found with different name in db: ksceMt19937Init , skipping...
[warning] Function sceMt19937UIntForDriver found with different name in db: ksceMt19937UInt , skipping...
[warning] Function sceSfmt19937FillArray32ForDriver found with different name in db: ksceSfmt19937FillArray32 , skipping...
[warning] Function sceSfmt19937FillArray64ForDriver found with different name in db: ksceSfmt19937FillArray64 , skipping...
[warning] Function sceSfmt19937GenRand32ForDriver found with different name in db: ksceSfmt19937GenRand32 , skipping...
[warning] Function sceSfmt19937GenRand64ForDriver found with different name in db: ksceSfmt19937GenRand64 , skipping...
[warning] Function sceSfmt19937InitByArrayForDriver found with different name in db: ksceSfmt19937InitByArray , skipping...
[warning] Function sceSfmt19937InitGenRandForDriver found with different name in db: ksceSfmt19937InitGenRand , skipping...
[warning] Function sceSha1BlockInitForDriver found with different name in db: ksceSha1BlockInit , skipping...
[warning] Function sceSha1BlockResultForDriver found with different name in db: ksceSha1BlockResult , skipping...
[warning] Function sceSha1BlockUpdateForDriver found with different name in db: ksceSha1BlockUpdate , skipping...
[warning] Function sceSha1DigestForDriver found with different name in db: ksceSha1Digest , skipping...
[warning] Function sceSha224BlockInitForDriver found with different name in db: ksceSha224BlockInit , skipping...
[warning] Function sceSha224BlockResultForDriver found with different name in db: ksceSha224BlockResult , skipping...
[warning] Function sceSha224BlockUpdateForDriver found with different name in db: ksceSha224BlockUpdate , skipping...
[warning] Function sceSha224DigestForDriver found with different name in db: ksceSha224Digest , skipping...
[warning] Function sceSha256BlockInitForDriver found with different name in db: ksceSha256BlockInit , skipping...
[warning] Function sceSha256BlockResultForDriver found with different name in db: ksceSha256BlockResult , skipping...
[warning] Function sceSha256BlockUpdateForDriver found with different name in db: ksceSha256BlockUpdate , skipping...
[warning] Function sceSha256DigestForDriver found with different name in db: ksceSha256Digest , skipping...
[warning] Function sceZlibDecompressForDriver found with different name in db: ksceZlibDecompress , skipping...
[warning] Function sceZlibGetCompressedDataForDriver found with different name in db: ksceZlibGetCompressedData , skipping...
[warning] Function sceZlibGetInfoForDriver found with different name in db: ksceZlibGetInfo , skipping...
[Note] Ignoring function inflate because it doesn't look legit
[Note] Ignoring function deflate because it doesn't look legit
[Note] Ignoring function deflateReset because it doesn't look legit
[Note] Ignoring function crc32 because it doesn't look legit
[Note] Ignoring function adler32 because it doesn't look legit
[Note] Ignoring function inflateSetDictionary because it doesn't look legit
[warning] Function sceKernelRegisterSysEventHandlerForDriver found with different name in db: ksceKernelRegisterSysEventHandler , skipping...
[warning] Function sceKernelUnregisterSysEventHandlerForDriver found with different name in db: ksceKernelUnregisterSysEventHandler , skipping...
[warning] Function sceKernelSysEventDispatchForDriver found with different name in db: ksceKernelSysEventDispatch , skipping...
[warning] Function sceKernelPowerTickForDriver found with different name in db: ksceKernelPowerTick , skipping...
[Note] Ignoring function SceQafMgrForDriver_7B14DC45 because it doesn't look legit
[Note] Ignoring function SceQafMgrForDriver_082A4FC2 because it doesn't look legit
[warning] Function sceSblAIMgrGetSMIForDriver found with different name in db: ksceSblAimgrGetSMI , skipping...
[warning] Function sceSblAIMgrGetProductCodeForDriver found with different name in db: ksceSblAimgrGetTargetId , skipping...
[warning] Function sceSblAIMgrIsTestForDriver found with different name in db: ksceSblAimgrIsTest , skipping...
[warning] Function sceSblAIMgrIsToolOrTestForDriver found with different name in db: ksceSblAimgrIsTool , skipping...
[warning] Function sceSblAIMgrIsNonCEXForDriver found with different name in db: ksceSblAimgrIsDEX , skipping...
[warning] Function sceSblAIMgrIsCEXForDriver found with different name in db: ksceSblAimgrIsCEX , skipping...
[warning] Function sceSblAIMgrIsVITAForDriver found with different name in db: ksceSblAimgrIsVITA , skipping...
[warning] Function sceSblAIMgrIsDolceForDriver found with different name in db: ksceSblAimgrIsDolce , skipping...
[warning] Function sceSblAIMgrIsGenuineVITAForDriver found with different name in db: ksceSblAimgrIsGenuineVITA , skipping...
[warning] Function sceSblAIMgrIsGenuineDolceForDriver found with different name in db: ksceSblAimgrIsGenuineDolce , skipping...
[Note] Ignoring function get_74 because it doesn't look legit
[Note] Ignoring function get_78 because it doesn't look legit
[warning] Function sceKernelGetGPIForDriver found with different name in db: sceKernelGetGPI , skipping...
[warning] Function sceKernelSetGPOForDriver found with different name in db: sceKernelSetGPO , skipping...
[Note] Ignoring function set_74 because it doesn't look legit
[Note] Ignoring function set_78 because it doesn't look legit
[warning] Function sceDebugSetHandlersForKernel found with different name in db: ksceDebugSetHandlers , skipping...
[warning] Function sceDebugPutcharForKernel found with different name in db: ksceDebugPutchar , skipping...
[warning] Function sceDebugGetPutcharHandlerForKernel found with different name in db: ksceDebugGetPutcharHandler , skipping...
[warning] Function sceDebugRegisterPutcharHandlerForKernel found with different name in db: ksceDebugRegisterPutcharHandler , skipping...
[Note] Ignoring function SceDebugForKernel_082B8D6A because it doesn't look legit
[warning] Function sceDebugDisableInfoDumpForKernel found with different name in db: ksceDebugDisableInfoDump , skipping...
[warning] Function sceDebugPrintfForDriver found with different name in db: ksceDebugPrintf , skipping...
[warning] Function sceDebugPrintf2ForDriver found with different name in db: ksceDebugPrintf2 , skipping...
[Note] Ignoring function print_kernel_panic because it doesn't look legit
[Note] Ignoring function printf_kernel_panic because it doesn't look legit
[Note] Ignoring function print_kernel_assertion because it doesn't look legit
[Note] Ignoring function printf_kernel_assertion because it doesn't look legit
[Note] Ignoring function invoke_some_callback because it doesn't look legit
[error] Function sceKernelAllocMemBlockForPidForTZS with NID 0x0028E26C not found in lookup, ignoring...
[error] Function sceSysrootGetSysrootBufferForTZS with NID 0x29C1049E not found in lookup, ignoring...
[warning] Function sceKernelGetThreadIdListForDriver found with different name in db: ksceKernelGetThreadIdList , skipping...
[warning] Function sceKernelGetThreadCpuRegistersForDriver found with different name in db: ksceKernelGetThreadCpuRegisters , skipping...
[warning] Function sceKernelChangeThreadSuspendStatusForDriver found with different name in db: ksceKernelChangeThreadSuspendStatus , skipping...
[warning] Function sceKernelChangeActiveCpuMaskForDriver found with different name in db: sceKernelChangeActiveCpuMask , skipping...
[warning] Function sceKernelGetThreadCurrentPriorityForDriver found with different name in db: ksceKernelGetThreadCurrentPriority , skipping...
[warning] Function sceKernelCreateCallbackForDriver found with different name in db: ksceKernelCreateCallback , skipping...
[warning] Function sceKernelWaitThreadEndCB_089ForDriver found with different name in db: sceKernelWaitThreadEndCB_089 , skipping...
[warning] Function sceKernelDeleteCallbackForDriver found with different name in db: ksceKernelDeleteCallback , skipping...
[warning] Function sceKernelExitThreadForDriver found with different name in db: ksceKernelExitThread , skipping...
[warning] Function sceKernelLockMutex_089ForDriver found with different name in db: ksceKernelLockMutex , skipping...
[warning] Function sceKernelExitDeleteThreadForDriver found with different name in db: ksceKernelExitDeleteThread , skipping...
[warning] Function sceKernelUnlockMutex_089ForDriver found with different name in db: ksceKernelUnlockMutex , skipping...
[warning] Function sceKernelStartThread_089ForDriver found with different name in db: ksceKernelStartThread , skipping...
[warning] Function sceKernelTryLockMutex_089ForDriver found with different name in db: ksceKernelTryLockMutex , skipping...
[warning] Function sceKernelGetSystemTimeLowForDriver found with different name in db: ksceKernelGetSystemTimeLow , skipping...
[warning] Function sceKernelDelayThreadForDriver found with different name in db: ksceKernelDelayThread , skipping...
[warning] Function sceKernelGetMutexInfo_089ForDriver found with different name in db: ksceKernelGetMutexInfo , skipping...
[warning] Function sceKernelCancelMutex_089ForDriver found with different name in db: ksceKernelCancelMutex , skipping...
[warning] Function sceKernelDelayThreadCBForDriver found with different name in db: ksceKernelDelayThreadCB , skipping...
[warning] Function sceKernelLockMutexCB_089ForDriver found with different name in db: ksceKernelLockMutexCB_089 , skipping...
[warning] Function sceKernelCheckWaitableStatusForDriver found with different name in db: ksceKernelCheckWaitableStatus , skipping...
[warning] Function sceKernelCheckCallbackForDriver found with different name in db: ksceKernelCheckCallback , skipping...
[warning] Function sceKernelWaitThreadEnd_089ForDriver found with different name in db: sceKernelWaitThreadEnd_089 , skipping...
[warning] Function sceKernelGetSystemTimeWideForDriver found with different name in db: ksceKernelGetSystemTimeWide , skipping...
[warning] Function sceKernelInitializeFastMutexForDriver found with different name in db: ksceKernelInitializeFastMutex , skipping...
[warning] Function sceKernelLockFastMutexForDriver found with different name in db: ksceKernelLockFastMutex , skipping...
[warning] Function sceKernelUnlockFastMutexForDriver found with different name in db: ksceKernelUnlockFastMutex , skipping...
[warning] Function sceKernelDeleteFastMutexForDriver found with different name in db: ksceKernelDeleteFastMutex , skipping...
[warning] Function sceKernelSignalCondToForDriver found with different name in db: ksceKernelSignalCondTo , skipping...
[warning] Function sceKernelCreateCondForDriver found with different name in db: ksceKernelCreateCond , skipping...
[warning] Function sceKernelWaitCondForDriver found with different name in db: ksceKernelWaitCond , skipping...
[warning] Function sceKernelGetThreadIdForDriver found with different name in db: ksceKernelGetThreadId , skipping...
[warning] Function sceKernelDeleteCondForDriver found with different name in db: ksceKernelDeleteCond , skipping...
[warning] Function sceKernelCreateSemaForDriver found with different name in db: ksceKernelCreateSema , skipping...
[warning] Function sceKernelWaitSemaCBForDriver found with different name in db: ksceKernelWaitSema , skipping...
[warning] Function sceKernelSignalCondForDriver found with different name in db: ksceKernelSignalCond , skipping...
[warning] Function sceKernelSetPermissionForDriver found with different name in db: ksceKernelSetPermission , skipping...
[warning] Function sceKernelGetProcessIdForDriver found with different name in db: ksceKernelGetProcessId , skipping...
[warning] Function sceKernelSetProcessIdToTLSForDriver found with different name in db: ksceKernelSetProcessId , skipping...
[warning] Function sceKernelGetProcessIdForKernel found with different name in db: ksceKernelGetProcessId , skipping...
[warning] Function sceKernelChangeActiveCpuMaskForKernel found with different name in db: sceKernelChangeActiveCpuMask , skipping...
[warning] Function sceKernelGetThreadCurrentPriorityForKernel found with different name in db: ksceKernelGetThreadCurrentPriority , skipping...
[warning] Function sceKernelWaitThreadEndCB_089ForKernel found with different name in db: sceKernelWaitThreadEndCB_089 , skipping...
[warning] Function sceKernelExitThreadForKernel found with different name in db: ksceKernelExitThread , skipping...
[warning] Function sceKernelLockMutex_089ForKernel found with different name in db: ksceKernelLockMutex , skipping...
[warning] Function sceKernelExitDeleteThreadForKernel found with different name in db: ksceKernelExitDeleteThread , skipping...
[warning] Function sceKernelUnlockMutex_089ForKernel found with different name in db: ksceKernelUnlockMutex , skipping...
[warning] Function sceKernelStartThread_089ForKernel found with different name in db: ksceKernelStartThread , skipping...
[warning] Function sceKernelTryLockMutex_089ForKernel found with different name in db: ksceKernelTryLockMutex , skipping...
[warning] Function sceKernelDelayThreadForKernel found with different name in db: ksceKernelDelayThread , skipping...
[warning] Function sceKernelGetMutexInfo_089ForKernel found with different name in db: ksceKernelGetMutexInfo , skipping...
[warning] Function sceKernelCancelMutex_089ForKernel found with different name in db: ksceKernelCancelMutex , skipping...
[warning] Function sceKernelChangeCurrentThreadAttrForKernel found with different name in db: ksceKernelChangeCurrentThreadAttr , skipping...
[warning] Function sceKernelDelayThreadCBForKernel found with different name in db: ksceKernelDelayThreadCB , skipping...
[warning] Function sceKernelLockMutexCB_089ForKernel found with different name in db: ksceKernelLockMutexCB_089 , skipping...
[warning] Function sceKernelCheckWaitableStatusForKernel found with different name in db: ksceKernelCheckWaitableStatus , skipping...
[warning] Function sceKernelCheckCallbackForKernel found with different name in db: ksceKernelCheckCallback , skipping...
[warning] Function sceKernelWaitThreadEnd_089ForKernel found with different name in db: sceKernelWaitThreadEnd_089 , skipping...
[warning] Function sceKernelCreateMutexForKernelForKernel found with different name in db: ksceKernelCreateMutex , skipping...
[warning] Function sceKernelDeleteMutexForKernel found with different name in db: ksceKernelDeleteMutex , skipping...
[warning] Function sceKernelWaitSemaCBForKernel found with different name in db: ksceKernelWaitSema , skipping...
[warning] Function sceKernelGetFaultingProcessForKernel found with different name in db: ksceKernelGetFaultingProcess , skipping...
[error] Function sceKernelGetFaultingProcessForKernel with NID 0x6C1F092F not found in lookup, ignoring...
[Note] Ignoring function SceThreadmgrForKernel_E0833C77 because it doesn't look legit
[error] Function sceKernelGetActiveCpuMask with NID 0x0C3CBB8B not found in lookup, ignoring...
[error] Function _sceKernelSignalCondAll with NID 0x0F11545D not found in lookup, ignoring...
[error] Function _sceKernelUnlockMutex with NID 0x12948A63 not found in lookup, ignoring...
[error] Function _sceKernelDeleteThread with NID 0x151E0020 not found in lookup, ignoring...
[warning] Function sceKernelLockMutex_089 found with different name in db: ksceKernelLockMutex , skipping...
[error] Function _sceKernelDeleteEventFlag with NID 0x16C93704 not found in lookup, ignoring...
[error] Function _sceKernelOpenMsgPipe with NID 0x16EC5B7C not found in lookup, ignoring...
[error] Function _sceKernelCancelCallback with NID 0x19A0C1B6 not found in lookup, ignoring...
[warning] Function sceKernelUnlockMutex_089 found with different name in db: ksceKernelUnlockMutex , skipping...
[error] Function _sceKernelPollSema with NID 0x20AF286A not found in lookup, ignoring...
[error] Function _sceKernelCloseMutex with NID 0x21716C81 not found in lookup, ignoring...
[warning] Function sceKernelStartThread_089 found with different name in db: ksceKernelStartThread , skipping...
[error] Function _sceKernelCloseTimer with NID 0x22605E63 not found in lookup, ignoring...
[warning] Function sceKernelTryLockMutex_089 found with different name in db: ksceKernelTryLockMutex , skipping...
[error] Function _sceKernelOpenCond with NID 0x27DD11EA not found in lookup, ignoring...
[error] Function _sceKernelGetThreadmgrUIDClass with NID 0x27EE191B not found in lookup, ignoring...
[error] Function _sceKernelGetMsgPipeCreatorId with NID 0x2B751F95 not found in lookup, ignoring...
[error] Function _sceKernelGetTimerBaseWide with NID 0x370E147B not found in lookup, ignoring...
[error] Function _sceKernelSetTimerTimeWide with NID 0x39364623 not found in lookup, ignoring...
[error] Function _sceKernelWaitThreadEndCB_0910 with NID 0x394BCCF2 not found in lookup, ignoring...
[error] Function _sceKernelSignalCondTo with NID 0x3C00071F not found in lookup, ignoring...
[error] Function _sceKernelCreateCallback with NID 0x3F42E175 not found in lookup, ignoring...
[error] Function _sceKernelSetEventFlag with NID 0x438917E4 not found in lookup, ignoring...
[error] Function _sceKernelClearEvent with NID 0x4B7F47DC not found in lookup, ignoring...
[error] Function _sceKernelNotifyCallback with NID 0x4DF8B624 not found in lookup, ignoring...
[error] Function _sceKernelTryLockWriteRWLock with NID 0x52DD3322 not found in lookup, ignoring...
[error] Function _sceKernelUnregisterCallbackFromEventAll with NID 0x5B5650C7 not found in lookup, ignoring...
[error] Function _sceKernelUnlockWriteRWLock with NID 0x5B746A69 not found in lookup, ignoring...
[error] Function _sceKernelGetCallbackCount with NID 0x5D06FF09 not found in lookup, ignoring...
[error] Function sceKernelResumeThreadForVM with NID 0x5E93840E not found in lookup, ignoring...
[error] Function _sceKernelCloseCond with NID 0x650CE348 not found in lookup, ignoring...
[error] Function _sceKernelPMonCpuGetCounter with NID 0x667A4649 not found in lookup, ignoring...
[error] Function _sceKernelGetActiveCpuMask with NID 0x67FDA21B not found in lookup, ignoring...
[error] Function _sceKernelDeleteCallback with NID 0x68D0FA79 not found in lookup, ignoring...
[warning] Function sceKernelGetMutexInfo_089 found with different name in db: ksceKernelGetMutexInfo , skipping...
[error] Function _sceKernelSuspendThreadForVM with NID 0x7192B01C not found in lookup, ignoring...
[warning] Function sceKernelCancelMutex_089 found with different name in db: ksceKernelCancelMutex , skipping...
[error] Function _sceKernelSignalCond with NID 0x79889DAC not found in lookup, ignoring...
[error] Function _sceKernelUnlockReadRWLock with NID 0x7D16FB3B not found in lookup, ignoring...
[error] Function _sceKernelGetThreadExitStatus_0940 with NID 0x800BB137 not found in lookup, ignoring...
[error] Function _sceKernelDeleteSema with NID 0x855F49D5 not found in lookup, ignoring...
[error] Function _sceKernelOpenTimer with NID 0x8564E008 not found in lookup, ignoring...
[error] Function _sceKernelSignalSema with NID 0x8E9A0400 not found in lookup, ignoring...
[error] Function _sceKernelDeleteTimer with NID 0x921A043D not found in lookup, ignoring...
[error] Function _sceKernelSetEvent with NID 0x9A92C33F not found in lookup, ignoring...
[error] Function _sceKernelDeleteRWLock with NID 0x9AA387DF not found in lookup, ignoring...
[error] Function _sceKernelGetTimerTimeWide with NID 0x9AC39954 not found in lookup, ignoring...
[error] Function _sceKernelRegisterCallbackToEvent with NID 0x9B1922F2 not found in lookup, ignoring...
[error] Function _sceKernelChangeThreadCpuAffinityMask with NID 0x9C921F8D not found in lookup, ignoring...
[error] Function _sceKernelOpenMutex with NID 0x9D291788 not found in lookup, ignoring...
[error] Function _sceKernelCloseMsgPipe with NID 0xAA888831 not found in lookup, ignoring...
[error] Function _sceKernelGetThreadStackFreeSize with NID 0xB5EC061A not found in lookup, ignoring...
[error] Function _sceKernelDeleteMsgPipe with NID 0xB6D50FCC not found in lookup, ignoring...
[error] Function _sceKernelChangeThreadVfpException with NID 0xB8F165B4 not found in lookup, ignoring...
[error] Function _sceKernelOpenSema with NID 0xB96FED7D not found in lookup, ignoring...
[warning] Function _sceKernelGetThreadTLSAddr found with different name in db: sceKernelGetThreadTLSAddr , skipping...
[error] Function _sceKernelTryLockMutex with NID 0xBCFB867F not found in lookup, ignoring...
[error] Function _sceKernelSendSignal with NID 0xC21FC992 not found in lookup, ignoring...
[error] Function _sceKernelCloseRWLock with NID 0xC239DBCC not found in lookup, ignoring...
[error] Function _sceKernelStartTimer with NID 0xC3ED6E4A not found in lookup, ignoring...
[error] Function _sceKernelCloseSimpleEvent with NID 0xC6FFE335 not found in lookup, ignoring...
[error] Function _sceKernelStopTimer with NID 0xC96F4269 not found in lookup, ignoring...
[error] Function _sceKernelWaitThreadEnd_0910 with NID 0xD38231C9 not found in lookup, ignoring...
[error] Function _sceKernelDeleteCond with NID 0xD99F51D3 not found in lookup, ignoring...
[error] Function _sceKernelOpenRWLock with NID 0xDFCEE5AB not found in lookup, ignoring...
[error] Function _sceKernelDeleteMutex with NID 0xE0A6D759 not found in lookup, ignoring...
[error] Function _sceKernelOpenSimpleEvent with NID 0xE326EA7A not found in lookup, ignoring...
[error] Function _sceKernelChangeThreadPriority with NID 0xE61C2B06 not found in lookup, ignoring...
[error] Function _sceKernelCloseSema with NID 0xE8C03447 not found in lookup, ignoring...
[error] Function _sceKernelTryLockReadRWLock with NID 0xEB9054B2 not found in lookup, ignoring...
[error] Function _sceKernelClearEventFlag with NID 0xF0526CE2 not found in lookup, ignoring...
[error] Function _sceKernelPulseEvent with NID 0xF6A0FE84 not found in lookup, ignoring...
[error] Function _sceKernelCloseEventFlag with NID 0xF6CFB4F1 not found in lookup, ignoring...
[error] Function _sceKernelDeleteSimpleEvent with NID 0xF7413EC7 not found in lookup, ignoring...
[error] Function _sceKernelOpenEventFlag with NID 0xFA64FB37 not found in lookup, ignoring...
[error] Function _sceKernelUnregisterCallbackFromEvent with NID 0xFB66565E not found in lookup, ignoring...
[Note] Ignoring function SceMotion_unk_09338B80 because it doesn't look legit
[Note] Ignoring function SceMotion_unk_3C970E36 because it doesn't look legit
[Note] Ignoring function SceMotion_unk_452F92F7 because it doesn't look legit
[Note] Ignoring function SceMotion_unk_58C0187B because it doesn't look legit
[Note] Ignoring function SceMotion_unk_833FD8DC because it doesn't look legit
[Note] Ignoring function SceMotion_unk_B7F7535F because it doesn't look legit
[Note] Ignoring function SceMotion_unk_D87E2B64 because it doesn't look legit
[Note] Ignoring function SceMotion_unk_EB345158 because it doesn't look legit
[Note] Ignoring function SceMotion_unk_0D9FA7EA because it doesn't look legit
[Note] Ignoring function SceMotion_unk_A408BC69 because it doesn't look legit
[Note] Ignoring function SceMotion_unk_D23686B0 because it doesn't look legit
[Note] Ignoring function SceMotion_unk_D88B731D because it doesn't look legit
[Note] Ignoring function SceMotion_unk_ACEFA121 because it doesn't look legit
[Note] Ignoring function SceMotion_unk_AD0B62B7 because it doesn't look legit
[Note] Ignoring function SceMotion_unk_BC5C86C5 because it doesn't look legit
[Note] Ignoring function sceDrmBridgeIsAllow_unk because it doesn't look legit
[Note] Ignoring function SceAppUtil_unk_e8cadca9 because it doesn't look legit
[Note] Ignoring function SceAppUtil_unk_1cffe892 because it doesn't look legit
[Note] Ignoring function SceAppUtil_unk_a3e0694f because it doesn't look legit
[Note] Ignoring function SceAppUtil_unk_7da34311 because it doesn't look legit
[Note] Ignoring function SceAppUtil_unk_cd0e5c59 because it doesn't look legit
[Note] Ignoring function SceAppUtil_unk_f93c691c because it doesn't look legit
[Note] Ignoring function SceAppUtil_unk_c3cb128b because it doesn't look legit
[Note] Ignoring function SceAppUtil_unk_c0418b1c because it doesn't look legit
[Note] Ignoring function SceAppUtil_unk_b2fe3bb1 because it doesn't look legit
[Note] Ignoring function SceAppUtil_unk_1e2a6158 because it doesn't look legit
[Note] Ignoring function SceAppUtilDevice_unk_0aa41ead because it doesn't look legit
[Note] Ignoring function SceAppUtilUmass_unk_cc85f96f because it doesn't look legit
[Note] Ignoring function SceAppUtilUmass_unk_96c76886 because it doesn't look legit
[Note] Ignoring function SceAppUtilUmass_unk_6d8cf67e because it doesn't look legit
[Note] Ignoring function SceAppUtilUmass_unk_ae1230d3 because it doesn't look legit
[Note] Ignoring function SceAppUtilUmass_unk_0bc38a89 because it doesn't look legit
[Note] Ignoring function SceAppUtilWebBrowserCBLimited_unk_3ed8f841 because it doesn't look legit
[Note] Ignoring function SceAppUtilNpSignin_unk_56c91a8e because it doesn't look legit
[Note] Ignoring function SceAppUtilLaunchApp_unk_e70c7435 because it doesn't look legit
[Note] Ignoring function SceAppUtilLaunchApp_unk_d2338d13 because it doesn't look legit
[Note] Ignoring function SceAppUtilPsm_unk_deb51a38 because it doesn't look legit
[Note] Ignoring function SceAppUtilAppEventUserDefined_unk_54580104 because it doesn't look legit
[Note] Ignoring function SceAppUtilExtPlayReady_unk_a9c2098c because it doesn't look legit
[Note] Ignoring function SceAppUtilExtPlayReady_unk_e915a695 because it doesn't look legit
[Note] Ignoring function SceAppUtilExtPlayReady_unk_4c91cdb1 because it doesn't look legit
[Note] Ignoring function SceAppUtilExtPlayReady_unk_9b52c63d because it doesn't look legit
[Note] Ignoring function SceAppUtilExtMarlinIptv_unk_dfff8d1f because it doesn't look legit
[Note] Ignoring function SceAppUtilExtMarlinIptv_unk_b86104db because it doesn't look legit
[Note] Ignoring function SceAppUtilExtPsNow_unk_2cf451be because it doesn't look legit
[Note] Ignoring function SceAppUtilExtPsNow_unk_2bf9a33d because it doesn't look legit
[warning] Function sceCtrlRegisterVirtualControllerDriverForDriver found with different name in db: ksceCtrlRegisterVirtualControllerDriver , skipping...
[warning] Function sceTouchSetTouchEmulationDataForDriver found with different name in db: ksceTouchSetTouchEmulationData , skipping...
[warning] Function sceMotionDevGetDeviceInfoForDriver found with different name in db: ksceMotionDevGetDeviceInfo , skipping...
[warning] Function sceMotionDevIsReadyForDriver found with different name in db: ksceMotionDevIsReady , skipping...
[warning] Function sceMotionDevNoiseFilterIsAvailableForDriver found with different name in db: ksceMotionDevNoiseFilterIsAvailable , skipping...
[warning] Function sceMotionDevReadForDriver found with different name in db: ksceMotionDevRead , skipping...
[warning] Function sceMotionDevRegisterVirtualMotionDriverForDriver found with different name in db: ksceMotionDevRegisterVirtualMotionDriver , skipping...
[warning] Function sceMotionDevSamplingStartForDriver found with different name in db: ksceMotionDevSamplingStart , skipping...
[warning] Function sceMotionDevSamplingStopForDriver found with different name in db: ksceMotionDevSamplingStop , skipping...
[warning] Function sceMotionDevSetSamplingModeForDriver found with different name in db: ksceMotionDevSetSamplingMode , skipping...
[Note] Ignoring function SceMotionDevForDriver_unk_031AF7A1 because it doesn't look legit
[Note] Ignoring function SceMotionDevForDriver_unk_0808D77D because it doesn't look legit
[Note] Ignoring function SceMotionDevForDriver_unk_09918DAE because it doesn't look legit
[Note] Ignoring function SceMotionDevForDriver_unk_22CD6DCA because it doesn't look legit
[Note] Ignoring function SceMotionDevForDriver_unk_3CD0CE14 because it doesn't look legit
[Note] Ignoring function SceMotionDevForDriver_unk_77BA3A04 because it doesn't look legit
[Note] Ignoring function SceMotionDevForDriver_unk_85E3C678 because it doesn't look legit
[Note] Ignoring function SceMotionDevForDriver_unk_A75976EE because it doesn't look legit
[Note] Ignoring function SceMotionDevForDriver_unk_D7DA3DA7 because it doesn't look legit
[Note] Ignoring function SceMotionDevForDriver_unk_DB89D1BF because it doesn't look legit
[Note] Ignoring function SceMotionDevForDriver_unk_FD1C528D because it doesn't look legit
[Note] Ignoring function SceMotionDevForDriver_unk_FE6ECA41 because it doesn't look legit
[warning] Function scePowerSetDisplayBrightnessForDriver found with different name in db: kscePowerSetDisplayBrightness , skipping...
[warning] Function scePowerGetDisplayMaxBrightnessForDriver found with different name in db: kscePowerGetDisplayMaxBrightness , skipping...
[warning] Function scePowerSetDisplayMaxBrightnessForDriver found with different name in db: kscePowerSetDisplayMaxBrightness , skipping...
[warning] Function scePowerTickForDriver found with different name in db: kscePowerTick , skipping...
[warning] Function scePowerSetStandbyButtonPushTimeForDriver found with different name in db: kscePowerSetStandbyButtonPushTime , skipping...
[warning] Function scePowerSetPsButtonPushTimeForDriver found with different name in db: kscePowerSetPsButtonPushTime , skipping...
[warning] Function scePowerGetWakeupFactorForDriver found with different name in db: kscePowerGetWakeupFactor , skipping...
[warning] Function scePowerGetPowerSwModeForDriver found with different name in db: kscePowerGetPowerSwMode , skipping...
[warning] Function scePowerSetPowerSwModeForDriver found with different name in db: kscePowerSetPowerSwMode , skipping...
[warning] Function scePowerGetBatteryCycleCountForDriver found with different name in db: scePowerGetBatteryCycleCount , skipping...
[warning] Function scePowerGetGpuEs4ClockFrequencyForDriver found with different name in db: kscePowerGetDeviceCount , skipping...
[warning] Function scePowerGetResumeCountForDriver found with different name in db: kscePowerGetResumeCount , skipping...
[warning] Function scePowerIsRequestForDriver found with different name in db: scePowerIsRequest , skipping...
[warning] Function scePowerCancelRequestForDriver found with different name in db: scePowerCancelRequest , skipping...
[warning] Function scePowerRequestSoftResetForDriver found with different name in db: kscePowerRequestSoftReset , skipping...
[warning] Function scePowerRequestColdResetForDriver found with different name in db: scePowerRequestColdReset , skipping...
[warning] Function scePowerRequestHibernateForDriver found with different name in db: kscePowerRequestHibernate , skipping...
[warning] Function scePowerRequestSuspendForDriver found with different name in db: scePowerRequestSuspend , skipping...
[warning] Function scePowerRequestStandbyForDriver found with different name in db: scePowerRequestStandby , skipping...
[warning] Function scePowerRequestResumeForDriver found with different name in db: kscePowerRequestResume , skipping...
[warning] Function scePowerRequestDisplayOffForDriver found with different name in db: scePowerRequestDisplayOff , skipping...
[warning] Function scePowerRequestDisplayOnForDriver found with different name in db: scePowerRequestDisplayOn , skipping...
[warning] Function scePowerIsSuspendRequiredForDriver found with different name in db: scePowerIsSuspendRequired , skipping...
[warning] Function scePowerRegisterCallbackForDriver found with different name in db: scePowerRegisterCallback , skipping...
[warning] Function scePowerUnregisterCallbackForDriver found with different name in db: scePowerUnregisterCallback , skipping...
[warning] Function scePowerGetIdleTimerForDriver found with different name in db: kscePowerGetIdleTimer , skipping...
[warning] Function scePowerSetIdleTimerForDriver found with different name in db: kscePowerSetIdleTimer , skipping...
[warning] Function scePowerSetIdleCallbackForDriver found with different name in db: kscePowerSetIdleCallback , skipping...
[warning] Function scePowerSetProcessIdleCallbackForDriver found with different name in db: kscePowerSetProcessIdleCallback , skipping...
[warning] Function scePowerGetGpuClockFrequencyForDriver found with different name in db: scePowerGetGpuClockFrequency , skipping...
[warning] Function scePowerGetGpuXbarClockFrequencyForDriver found with different name in db: scePowerGetGpuXbarClockFrequency , skipping...
[warning] Function scePowerGetBusClockFrequencyForDriver found with different name in db: scePowerGetBusClockFrequency , skipping...
[warning] Function scePowerGetArmClockFrequencyForDriver found with different name in db: scePowerGetArmClockFrequency , skipping...
[warning] Function scePowerGetCompatClockFrequencyForDriver found with different name in db: kscePowerGetCompatClockFrequency , skipping...
[warning] Function scePowerSetBusClockFrequencyForDriver found with different name in db: scePowerSetBusClockFrequency , skipping...
[warning] Function scePowerSetGpuEs4ClockFrequencyForDriver found with different name in db: kscePowerSetGpuClockFrequency , skipping...
[warning] Function scePowerSetGpuClockFrequencyForDriver found with different name in db: scePowerSetGpuClockFrequency , skipping...
[warning] Function scePowerSetGpuXbarClockFrequencyForDriver found with different name in db: scePowerSetGpuXbarClockFrequency , skipping...
[warning] Function scePowerSetArmClockFrequencyForDriver found with different name in db: scePowerSetArmClockFrequency , skipping...
[warning] Function scePowerSetCompatClockFrequencyForDriver found with different name in db: kscePowerSetCompatClockFrequency , skipping...
[warning] Function scePowerGetCaseTempForDriver found with different name in db: scePowerGetCaseTemp , skipping...
[warning] Function scePowerIsBatteryExistForDriver found with different name in db: scePowerIsBatteryExist , skipping...
[warning] Function scePowerEncodeUBatteryForDriver found with different name in db: kscePowerEncodeUBattery , skipping...
[warning] Function scePowerSetBatteryFakeStatusForDriver found with different name in db: kscePowerSetBatteryFakeStatus , skipping...
[warning] Function scePowerIsPowerOnlineForDriver found with different name in db: scePowerIsPowerOnline , skipping...
[warning] Function scePowerIsBatteryChargingForDriver found with different name in db: scePowerIsBatteryCharging , skipping...
[warning] Function scePowerGetBatteryLifePercentForDriver found with different name in db: scePowerGetBatteryLifePercent , skipping...
[warning] Function scePowerBatteryUpdateInfoForDriver found with different name in db: scePowerBatteryUpdateInfo , skipping...
[warning] Function scePowerGetBatteryTempForDriver found with different name in db: scePowerGetBatteryTemp , skipping...
[warning] Function scePowerGetBatteryVoltForDriver found with different name in db: scePowerGetBatteryVolt , skipping...
[warning] Function scePowerGetBatteryElecForDriver found with different name in db: scePowerGetBatteryElec , skipping...
[warning] Function scePowerGetBatteryLifeTimeForDriver found with different name in db: scePowerGetBatteryLifeTime , skipping...
[warning] Function scePowerGetBatteryRemainCapacityForDriver found with different name in db: scePowerGetBatteryRemainCapacity , skipping...
[warning] Function scePowerGetBatteryRemainLevelForDriver found with different name in db: scePowerGetBatteryRemainLevel , skipping...
[warning] Function scePowerGetBatteryRemainMaxLevelForDriver found with different name in db: scePowerGetBatteryRemainMaxLevel , skipping...
[warning] Function scePowerGetBatterySOHForDriver found with different name in db: scePowerGetBatterySOH , skipping...
[warning] Function scePowerGetBatteryChargingStatusForDriver found with different name in db: scePowerGetBatteryChargingStatus , skipping...
[warning] Function scePowerIsLowBatteryForDriver found with different name in db: scePowerIsLowBattery , skipping...
[warning] Function scePowerGetBatteryFullCapacityForDriver found with different name in db: scePowerGetBatteryFullCapacity , skipping...
[warning] Function scePowerBatteryDisableUsbChargingForDriver found with different name in db: kscePowerBatteryDisableUsbCharging , skipping...
[warning] Function scePowerBatteryEnableUsbChargingForDriver found with different name in db: kscePowerBatteryEnableUsbCharging , skipping...
[warning] Function scePowerBatteryForbidChargingForDriver found with different name in db: kscePowerBatteryForbidCharging , skipping...
[warning] Function scePowerBatteryPermitChargingForDriver found with different name in db: kscePowerBatteryPermitCharging , skipping...
[warning] Function scePowerBatteryStopUsbChargingForDriver found with different name in db: kscePowerBatteryStopUsbCharging , skipping...
[warning] Function scePowerBatterySetUsbStatusForDriver found with different name in db: kscePowerBatterySetUsbStatus , skipping...
[warning] Function scePowerWlanActivateForDriver found with different name in db: kscePowerWlanActivate , skipping...
[warning] Function scePowerWlanDeactivateForDriver found with different name in db: kscePowerWlanDeactivate , skipping...
[Note] Ignoring function set_some_battery_info because it doesn't look legit
[Note] Ignoring function set_udcd_state because it doesn't look legit
[warning] Function sceLedSetModeForDriver found with different name in db: ksceLedSetMode , skipping...
[warning] Function sceUsbdGetDeviceLocationForUser found with different name in db: sceUsbdGetDeviceAddress , skipping...
[warning] Function sceUsbdGetDescriptorForDriver found with different name in db: ksceUsbdGetDescriptor , skipping...
[warning] Function sceUsbdRegisterCompositeLddForDriver found with different name in db: ksceUsbdRegisterCompositeLdd , skipping...
[warning] Function sceUsbdRegisterDriverForDriver found with different name in db: ksceUsbdRegisterDriver , skipping...
[warning] Function sceUsbdUnregisterDriverForDriver found with different name in db: ksceUsbdUnregisterDriver , skipping...
[warning] Function sceUsbdSuspendPhase2ForDriver found with different name in db: ksceUsbdSuspendPhase2 , skipping...
[warning] Function sceUsbdOpenEndpointForDriver found with different name in db: ksceUsbdOpenEndpoint , skipping...
[warning] Function sceUsbdCloseEndpointForDriver found with different name in db: ksceUsbdCloseEndpoint , skipping...
[warning] Function sceUsbdControlTransferForDriver found with different name in db: ksceUsbdControlTransfer , skipping...
[warning] Function sceUsbdInterruptTransferForDriver found with different name in db: ksceUsbdInterruptTransfer , skipping...
[Note] Ignoring function SceUdcd_F1A3690B because it doesn't look legit
[Note] Ignoring function enable_usb_charging because it doesn't look legit
[warning] Function sceUdcdStartForDriver found with different name in db: ksceUdcdStart , skipping...
[warning] Function sceUdcdStartInternalForDriver found with different name in db: ksceUdcdStartInternal , skipping...
[warning] Function sceUdcdStartCurrentInternalForDriver found with different name in db: ksceUdcdStartCurrentInternal , skipping...
[warning] Function sceUdcdStopForDriver found with different name in db: ksceUdcdStop , skipping...
[warning] Function sceUdcdStopInternalForDriver found with different name in db: ksceUdcdStopInternal , skipping...
[warning] Function sceUdcdStopCurrentInternalForDriver found with different name in db: ksceUdcdStopCurrentInternal , skipping...
[warning] Function sceUdcdReqSendForDriver found with different name in db: ksceUdcdReqSend , skipping...
[warning] Function sceUdcdReqSendInternalForDriver found with different name in db: ksceUdcdReqSendInternal , skipping...
[warning] Function sceUdcdStallForDriver found with different name in db: ksceUdcdStall , skipping...
[warning] Function sceUdcdStallInternalForDriver found with different name in db: ksceUdcdStall , skipping...
[warning] Function sceUdcdReqCancelAllForDriver found with different name in db: ksceUdcdReqCancelAll , skipping...
[warning] Function sceUdcdRegisterForDriver found with different name in db: ksceUdcdRegister , skipping...
[warning] Function sceUdcdRegisterInternalForDriver found with different name in db: ksceUdcdRegisterInternal , skipping...
[warning] Function sceUdcdUnregisterForDriver found with different name in db: ksceUdcdUnregister , skipping...
[warning] Function sceUdcdUnregisterInternalForDriver found with different name in db: ksceUdcdUnregisterInternal , skipping...
[warning] Function sceUdcdActivateForDriver found with different name in db: ksceUdcdActivate , skipping...
[warning] Function sceUdcdActivateInternalForDriver found with different name in db: ksceUdcdActivateInternal , skipping...
[warning] Function sceUdcdDeactivateForDriver found with different name in db: ksceUdcdDeactivate , skipping...
[warning] Function sceUdcdDeactivateInternalForDriver found with different name in db: ksceUdcdDeactivateInternal , skipping...
[warning] Function sceUdcdClearFIFOForDriver found with different name in db: ksceUdcdClearFIFO , skipping...
[warning] Function sceUdcdClearFIFOInternalForDriver found with different name in db: ksceUdcdClearFIFOInternal , skipping...
[warning] Function sceUdcdGetDrvStateForDriver found with different name in db: ksceUdcdGetDrvState , skipping...
[warning] Function sceUdcdGetDrvStateInternalForDriver found with different name in db: ksceUdcdGetDrvStateInternal , skipping...
[warning] Function sceUdcdReqRecvForDriver found with different name in db: ksceUdcdReqRecv , skipping...
[warning] Function sceUdcdReqRecvInternalForDriver found with different name in db: ksceUdcdReqRecvInternal , skipping...
[warning] Function sceUdcdWaitBusInitializedForDriver found with different name in db: ksceUdcdWaitBusInitialized , skipping...
[warning] Function sceUdcdWaitStateForDriver found with different name in db: ksceUdcdWaitState , skipping...
[warning] Function sceUdcdWaitStateInternalForDriver found with different name in db: ksceUdcdWaitStateInternal , skipping...
[warning] Function sceUdcdGetDeviceStateForDriver found with different name in db: ksceUdcdGetDeviceState , skipping...
[warning] Function sceUdcdGetDeviceStateInternalForDriver found with different name in db: ksceUdcdGetDeviceStateInternal , skipping...
[warning] Function sceUdcdGetDeviceInfoForDriver found with different name in db: ksceUdcdGetDeviceInfo , skipping...
[warning] Function sceUdcdGetDeviceInfoInternalForDriver found with different name in db: ksceUdcdGetDeviceInfoInternal , skipping...
[Note] Ignoring function SceUdcdForDriver_EBB1E86B because it doesn't look legit
[Note] Ignoring function SceUdcdForDriver_DB7EF7AB because it doesn't look legit
[Note] Ignoring function SceUdcdForDriver_360E95B9 because it doesn't look legit
[Note] Ignoring function SceUdcdForDriver_0F3595AE because it doesn't look legit
[error] Function sceUsbSerialStartForDriver with NID 0xFEE7F4BA not found in lookup, ignoring...
[error] Function sceUsbSerialSetupForDriver with NID 0x590B8F97 not found in lookup, ignoring...
[error] Function sceUsbSerialStatusForDriver with NID 0x8C426906 not found in lookup, ignoring...
[error] Function sceUsbSerialCloseForDriver with NID 0xE6B1E64F not found in lookup, ignoring...
[error] Function sceUsbSerialGetRecvBufferSizeForDriver with NID 0xF531B5AE not found in lookup, ignoring...
[error] Function sceUsbSerialSendForDriver with NID 0x0C2E73C0 not found in lookup, ignoring...
[error] Function sceUsbSerialRecvForDriver with NID 0x6B5E296F not found in lookup, ignoring...
[warning] Function sceSblLicMgrActivateDevkitForDriver found with different name in db: ksceSblPostSsMgrActivateForDriver , skipping...
[warning] Function sceSblLicMgrGetExpireDateForDriver found with different name in db: ksceSblPostSsMgrGetExpireDateForDriver , skipping...
[warning] Function sceSblPmMgrSetProductModeForDriver found with different name in db: ksceSblPostSsMgrExecutePmSmF00dCommandForDriver , skipping...
[warning] Function sceSblPmMgrGetProductModeFromNVSForDriver found with different name in db: ksceSblPostSsMgrExecutePmSmF00dCommand8ForDriver , skipping...
[warning] Function sceSblPmMgrAuthEtoIForDriver found with different name in db: ksceSblPostSsMgrExecutePmSmSdF00dCommandForDriver , skipping...
[warning] Function sceSblUtMgrUpdateUtokenForDriver found with different name in db: ksceSblUtMgrExecuteUtokenSmCommand1ForDriver , skipping...
[warning] Function sceSblRtcMgrSetCpRtcForDriver found with different name in db: ksceSblPostSsMgrSetCpRtcForDriver , skipping...
[Note] Ignoring function init because it doesn't look legit
[warning] Function sceRegMgrGetRegVersionForDriver found with different name in db: sceRegMgrGetRegVersion , skipping...
[warning] Function sceRegMgrIsBlueScreenForDriver found with different name in db: sceRegMgrIsBlueScreen , skipping...
[warning] Function sceRegMgrResetRegistryLvForDriver found with different name in db: sceRegMgrResetRegistryLv , skipping...
[warning] Function sceRegMgrGetKeyBinForDriver found with different name in db: sceRegMgrGetKeyBin , skipping...
[warning] Function sceRegMgrGetKeyIntForDriver found with different name in db: sceRegMgrGetKeyInt , skipping...
[warning] Function sceRegMgrGetKeyStrForDriver found with different name in db: sceRegMgrGetKeyStr , skipping...
[warning] Function sceRegMgrGetKeysForDriver found with different name in db: sceRegMgrGetKeys , skipping...
[warning] Function sceRegMgrGetInitValsForDriver found with different name in db: sceRegMgrGetInitVals , skipping...
[warning] Function sceRegMgrGetKeysInfoForDriver found with different name in db: sceRegMgrGetKeysInfo , skipping...
[warning] Function sceRegMgrSetKeyBinForDriver found with different name in db: sceRegMgrSetKeyBin , skipping...
[warning] Function sceRegMgrSetKeyIntForDriver found with different name in db: sceRegMgrSetKeyInt , skipping...
[warning] Function sceRegMgrSetKeyStrForDriver found with different name in db: sceRegMgrSetKeyStr , skipping...
[warning] Function sceRegMgrSetKeysForDriver found with different name in db: sceRegMgrSetKeys , skipping...
[warning] Function sceRegMgrSystemParamGetBinForDriver found with different name in db: ksceRegMgrSystemParamGetBin , skipping...
[warning] Function sceRegMgrSystemParamGetIntForDriver found with different name in db: ksceRegMgrSystemParamGetInt , skipping...
[warning] Function sceRegMgrSystemParamGetStrForDriver found with different name in db: ksceRegMgrSystemParamGetStr , skipping...
[warning] Function sceRegMgrDbBackupForDriver found with different name in db: sceRegMgrDbBackup , skipping...
[warning] Function sceRegMgrDbRestoreForDriver found with different name in db: sceRegMgrDbRestore , skipping...
[warning] Function sceRegMgrRegisterCallbackForDriver found with different name in db: sceRegMgrRegisterCallback , skipping...
[warning] Function sceRegMgrRegisterDrvErrCallbackForDriver found with different name in db: sceRegMgrRegisterDrvErrCallback , skipping...
[warning] Function sceRegMgrAddRegistryCallbackForDriver found with different name in db: sceRegMgrAddRegistryCallback , skipping...
[warning] Function sceRegMgrStartCallbackForDriver found with different name in db: sceRegMgrStartCallback , skipping...
[warning] Function sceRegMgrStopCallbackForDriver found with different name in db: sceRegMgrStopCallback , skipping...
[warning] Function sceRegMgrUnregisterCallbackForDriver found with different name in db: sceRegMgrUnregisterCallback , skipping...
[warning] Function sceRegMgrUnregisterDrvErrCallbackForDriver found with different name in db: sceRegMgrUnregisterDrvErrCallback , skipping...
[warning] Function sceRegMgrSrvCnvRegionStrForDriver found with different name in db: sceRegMgrSrvCnvRegionStr , skipping...
[warning] Function sceRegMgrSrvCnvRegionIntForDriver found with different name in db: sceRegMgrSrvCnvRegionInt , skipping...
[warning] Function sceRegMgrSrvCnvRegionPsCodeForDriver found with different name in db: sceRegMgrSrvCnvRegionPsCode , skipping...
[warning] Function sceRegMgrSrvGetRegionStrForDriver found with different name in db: sceRegMgrSrvGetRegionStr , skipping...
[warning] Function sceRegMgrSrvGetRegionForDriver found with different name in db: sceRegMgrSrvGetRegion , skipping...
[warning] Function sceNpDrmGetRifInfoForDriver found with different name in db: ksceNpDrmGetRifInfo , skipping...
[warning] Function sceNpDrmGetFixedRifNameForDriver found with different name in db: ksceNpDrmGetFixedRifName , skipping...
[warning] Function sceNpDrmGetRifNameForDriver found with different name in db: ksceNpDrmGetRifName , skipping...
[warning] Function sceNpDrmGetRifNameForInstallForDriver found with different name in db: ksceNpDrmGetRifNameForInstall , skipping...
[warning] Function sceNpDrmPresetRifProvisionalFlagForDriver found with different name in db: ksceNpDrmPresetRifProvisionalFlag , skipping...
[warning] Function sceNpDrmCheckActDataForDriver found with different name in db: ksceNpDrmCheckActData , skipping...
[warning] Function sceNpDrmRemoveActDataForDriver found with different name in db: ksceNpDrmRemoveActData , skipping...
[warning] Function sceNpDrmUpdateAccountIdForDriver found with different name in db: ksceNpDrmUpdateAccountId , skipping...
[warning] Function sceNpDrmEbootSigGenMultiDiscForDriver found with different name in db: ksceNpDrmEbootSigGenMultiDisc , skipping...
[warning] Function sceNpDrmEbootSigGenPs1ForDriver found with different name in db: ksceNpDrmEbootSigGenPs1 , skipping...
[warning] Function sceNpDrmGetLegacyDocKeyForDriver found with different name in db: ksceNpDrmGetLegacyDocKey , skipping...
[warning] Function sceNpDrmEbootSigVerifyForDriver found with different name in db: ksceNpDrmEbootSigVerify , skipping...
[warning] Function sceNpDrmEbootSigGenPspForDriver found with different name in db: ksceNpDrmEbootSigGenPsp , skipping...
[warning] Function sceNpDrmEbootSigConvertForDriver found with different name in db: ksceNpDrmEbootSigConvert , skipping...
[warning] Function sceNpDrmPspEbootVerifyForDriver found with different name in db: ksceNpDrmPspEbootVerify , skipping...
[warning] Function sceNpDrmPspEbootSigGenForDriver found with different name in db: ksceNpDrmPspEbootSigGen , skipping...
[warning] Function sceNpDrmIsLooseAccountBindForDriver found with different name in db: ksceNpDrmIsLooseAccountBind , skipping...
[warning] Function sceNpDrmUpdateDebugSettingsForDriver found with different name in db: ksceNpDrmUpdateDebugSettings , skipping...
[warning] Function sceNpDrmGetRifPspKeyForDriver found with different name in db: ksceNpDrmGetRifPspKey , skipping...
[warning] Function sceNpDrmGetRifVitaKeyForDriver found with different name in db: ksceNpDrmGetRifVitaKey , skipping...
[Note] Ignoring function set_act_data because it doesn't look legit
[Note] Ignoring function get_act_data because it doesn't look legit
[Note] Ignoring function verify_rif because it doesn't look legit
[Note] Ignoring function verify_rif_full because it doesn't look legit
[Note] Ignoring function reset_act_dat because it doesn't look legit
[Note] Ignoring function unk_200D2DE4 because it doesn't look legit
[Note] Ignoring function unk_4665E75A because it doesn't look legit
[Note] Ignoring function unk_640C1724 because it doesn't look legit
[Note] Ignoring function unk_97BB85BD because it doesn't look legit
[Note] Ignoring function unk_A5E0F38C because it doesn't look legit
[Note] Ignoring function unk_C75A775B because it doesn't look legit
[Note] Ignoring function get_rif_name because it doesn't look legit
[Note] Ignoring function _get_info because it doesn't look legit
[Note] Ignoring function unk_E193CBB because it doesn't look legit
[Note] Ignoring function unk_3E881391 because it doesn't look legit
[Note] Ignoring function unk_A89653B3 because it doesn't look legit
[Note] Ignoring function get_info_2_for_driver because it doesn't look legit
[Note] Ignoring function set_psm_act_data because it doesn't look legit
[Note] Ignoring function unk_4CD5375C because it doesn't look legit
[Note] Ignoring function unk_791198CE because it doesn't look legit
[Note] Ignoring function unk_B09003A7 because it doesn't look legit
[warning] Function sceNetListenForDriver found with different name in db: ksceNetListen , skipping...
[warning] Function sceNetConnectForDriver found with different name in db: ksceNetConnect , skipping...
[warning] Function sceNetCloseForDriver found with different name in db: ksceNetClose , skipping...
[warning] Function sceNetRecvfromForDriver found with different name in db: ksceNetRecvfrom , skipping...
[warning] Function sceNetSetsockoptForDriver found with different name in db: ksceNetSetsockopt , skipping...
[warning] Function sceNetBindForDriver found with different name in db: ksceNetBind , skipping...
[warning] Function sceNetAcceptForDriver found with different name in db: ksceNetAccept , skipping...
[warning] Function sceNetGetsocknameForDriver found with different name in db: ksceNetGetsockname , skipping...
[warning] Function sceNetGetsockoptForDriver found with different name in db: ksceNetGetsockopt , skipping...
[warning] Function sceNetSendtoForDriver found with different name in db: ksceNetSendto , skipping...
[warning] Function sceNetGetpeernameForDriver found with different name in db: ksceNetGetpeername , skipping...
[warning] Function sceNetSocketForDriver found with different name in db: ksceNetSocket , skipping...
[warning] Function sceNetShutdownForDriver found with different name in db: ksceNetShutdown , skipping...
[warning] Function sceBtGetVidPid found with different name in db: sceBtGetDeviceId , skipping...
[error] Function sceNgsPatchGetInfoInternal with NID 0x04F7AB7C not found in lookup, ignoring...
[error] Function sceNgsVoiceSetParamsBlockInternal with NID 0x1326390F not found in lookup, ignoring...
[error] Function sceNgsVoiceLockParamsInternal with NID 0x1417788C not found in lookup, ignoring...
[error] Function sceNgsVoicePatchSetVolumesMatrixInternal with NID 0x2C040685 not found in lookup, ignoring...
[warning] Function sceNgsRackGetVoiceHandleInternal found with different name in db: sceNgsRackGetVoiceHandleInternal6 , skipping...
[error] Function sceNgsVoiceGetStateDataInternal with NID 0x96B4F8D7 not found in lookup, ignoring...
[error] Function sceNgsVoiceGetModuleTypeInternal with NID 0x9B2C8ED1 not found in lookup, ignoring...
[error] Function sceNgsVoicePatchSetVolumesInternal with NID 0xC303DB7A not found in lookup, ignoring...
[error] Function sceNgsVoiceGetInfoInternal with NID 0xC80BD00F not found in lookup, ignoring...
[error] Function sceNgsVoiceUnlockParamsInternal with NID 0xD9FC0ADF not found in lookup, ignoring...
[error] Function sceNgsVoicePatchSetVolumeInternal with NID 0xE0014910 not found in lookup, ignoring...
[error] Function sceNgsVoiceGetParamsOutOfRangeInternal with NID 0xE4E40955 not found in lookup, ignoring...
[Note] Ignoring function PVRSRVOpen because it doesn't look legit
[Note] Ignoring function PVRSRVRelease because it doesn't look legit
[Note] Ignoring function PVRSRV_BridgeDispatchKM because it doesn't look legit
[Note] Ignoring function SceCompatForDriver_6EBD9E01 because it doesn't look legit
[Note] Ignoring function SceCompatForVsh_4915DEE7 because it doesn't look legit
[Note] Ignoring function SceCompatForVsh_70997F92 because it doesn't look legit
[Note] Ignoring function SceCompatForVsh_9C107CC9 because it doesn't look legit
[error] Function sceCompatSetSettings with NID 0x312782DC not found in lookup, ignoring...
[error] Function sceCompatRegRead with NID 0x4521505D not found in lookup, ignoring...
[error] Function sceCompatAllocCdram with NID 0x6E8E3BA8 not found in lookup, ignoring...
[error] Function sceCompatGetSettings with NID 0x782C980E not found in lookup, ignoring...
[error] Function sceCompatRegWrite with NID 0x912B1C28 not found in lookup, ignoring...
[error] Function sceCompatGetRequest with NID 0xCB9F607B not found in lookup, ignoring...
[Note] Ignoring function SceCoredumpForDriver_unk_097AA37D because it doesn't look legit
[Note] Ignoring function SceCoredumpForDriver_unk_A7D214A7 because it doesn't look legit
[Note] Ignoring function SceCoredumpForDriver_unk_340856F7 because it doesn't look legit
[Note] Ignoring function SceCoredumpForDriver_unk_10863B61 because it doesn't look legit
[Note] Ignoring function SceCoredumpForDriver_unk_12392973 because it doesn't look legit
[Note] Ignoring function SceCoredumpForDriver_unk_D064F6DC because it doesn't look legit
[Note] Ignoring function SceCoredumpForDriver_unk_EF20949F because it doesn't look legit
[Note] Ignoring function SceCoredumpForDriver_unk_13EF8516 because it doesn't look legit
[error] Function sceAVConfigOledOn with NID 0xA1DE61B0 not found in lookup, ignoring...
[Note] Ignoring function SceFios2KernelForDriver_unk_2649408B because it doesn't look legit
[Note] Ignoring function SceFios2KernelForDriver_unk_28E28A58 because it doesn't look legit
[Note] Ignoring function SceFios2KernelForDriver_unk_35E7E75C because it doesn't look legit
[Note] Ignoring function SceFios2KernelForDriver_unk_3B329E86 because it doesn't look legit
[Note] Ignoring function SceFios2KernelForDriver_unk_990F46A5 because it doesn't look legit
[Note] Ignoring function SceFios2KernelForDriver_unk_DD7627EC because it doesn't look legit
[Note] Ignoring function savedata_ioctl_0x4410 because it doesn't look legit
[Note] Ignoring function t_scePfsFacadeReadForDriver because it doesn't look legit
[Note] Ignoring function t_scePfsFacadeWriteForDriver because it doesn't look legit
[Note] Ignoring function t_scePfsFacadePreadForDriver because it doesn't look legit
[Note] Ignoring function t_scePfsFacadePwriteForDriver because it doesn't look legit
[warning] Function sceAppMgrAcInstGetAcdirParamForDriver found with different name in db: ksceAppMgrAcInstGetAcdirParam , skipping...
[warning] Function sceAppMgrBgdlSetQueueStatusForDriver found with different name in db: ksceAppMgrBgdlSetQueueStatus , skipping...
[warning] Function sceAppMgrCheckContentInstallPeriodForDriver found with different name in db: ksceAppMgrCheckContentInstallPeriod , skipping...
[warning] Function sceAppMgrCheckPfsMountedForDriver found with different name in db: ksceAppMgrCheckPfsMounted , skipping...
[warning] Function sceAppMgrCloudDataClearMcIdForDriver found with different name in db: ksceAppMgrCloudDataClearMcId , skipping...
[warning] Function sceAppMgrCloudDataCreateHeaderForDriver found with different name in db: ksceAppMgrCloudDataCreateHeader , skipping...
[warning] Function sceAppMgrCloudDataDstCreateMountForDriver found with different name in db: ksceAppMgrCloudDataDstCreateMount , skipping...
[warning] Function sceAppMgrCloudDataGetMcIdForDriver found with different name in db: ksceAppMgrCloudDataGetMcId , skipping...
[warning] Function sceAppMgrCloudDataSetMcIdForDriver found with different name in db: ksceAppMgrCloudDataSetMcId , skipping...
[warning] Function sceAppMgrCloudDataSetupKeyForDriver found with different name in db: ksceAppMgrCloudDataSetupKey , skipping...
[warning] Function sceAppMgrCloudDataSrcMountForDriver found with different name in db: ksceAppMgrCloudDataSrcMount , skipping...
[warning] Function sceAppMgrCloudDataVerifyHeaderForDriver found with different name in db: ksceAppMgrCloudDataVerifyHeader , skipping...
[warning] Function sceAppMgrDebugSettingNotifyUpdateForDriver found with different name in db: ksceAppMgrDebugSettingNotifyUpdate , skipping...
[warning] Function sceAppMgrFakeSaveDataCreateMountForDriver found with different name in db: ksceAppMgrFakeSaveDataCreateMount , skipping...
[warning] Function sceAppMgrGameDataMountForDriver found with different name in db: ksceAppMgrGameDataMount , skipping...
[warning] Function sceAppMgrGetPfsProcessStatusForDriver found with different name in db: ksceAppMgrGetPfsProcessStatus , skipping...
[warning] Function sceAppMgrGetSystemDataFileForDriver found with different name in db: ksceAppMgrGetSystemDataFile , skipping...
[warning] Function sceAppMgrIsExclusiveProcessRunningForDriver found with different name in db: ksceAppMgrIsExclusiveProcessRunning , skipping...
[warning] Function sceAppMgrLaunchAppByPathForDriver found with different name in db: ksceAppMgrLaunchAppByPath , skipping...
[warning] Function sceAppMgrLoadSafeMemoryForDriver found with different name in db: ksceAppMgrLoadSafeMemory , skipping...
[warning] Function sceAppMgrLocalBackupGetOfflineIdForDriver found with different name in db: ksceAppMgrLocalBackupGetOfflineId , skipping...
[warning] Function sceAppMgrLocalBackupVerifyOfflineHeaderForDriver found with different name in db: ksceAppMgrLocalBackupVerifyOfflineHeader , skipping...
[warning] Function sceAppMgrRegisterPathForDriver found with different name in db: ksceAppMgrRegisterPath , skipping...
[warning] Function sceAppMgrSaveDataLocalBackupTargetGetListForDriver found with different name in db: ksceAppMgrSaveDataLocalBackupTargetGetList , skipping...
[warning] Function sceAppMgrSaveDataLocalBackupTargetRemoveItemForDriver found with different name in db: ksceAppMgrSaveDataLocalBackupTargetRemoveItem , skipping...
[warning] Function sceAppMgrSaveDataNotifyBackupFinishedForDriver found with different name in db: ksceAppMgrSaveDataNotifyBackupFinished , skipping...
[warning] Function sceAppMgrSaveSafeMemoryForDriver found with different name in db: ksceAppMgrSaveSafeMemory , skipping...
[warning] Function sceAppMgrSystemParamDateTimeSetConfForDriver found with different name in db: ksceAppMgrSystemParamDateTimeSetConf , skipping...
[warning] Function sceAppMgrUmountForDriver found with different name in db: ksceAppMgrUmount , skipping...
[warning] Function sceAppMgrUpdateRifInfoForDriver found with different name in db: ksceAppMgrUpdateRifInfo , skipping...
[Note] Ignoring function SceAppMgrForDriver_unk_0813AFCA because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_2FEACA9F because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_324DD34E because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_0C5D65F1 because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_1574E1A4 because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_1B6C2FED because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_21BE167A because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_29421DCD because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_30947DF4 because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_3B4F305B because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_4FA62A46 because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_504023C8 because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_99AA37C1 because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_C4924946 because it doesn't look legit
[warning] Function sceAppMgrKillProcessForDriver found with different name in db: ksceAppMgrKillProcess , skipping...
[Note] Ignoring function SceAppMgrForDriver_unk_DC13160A because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_DD5BEEE3 because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_E8DB7942 because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_EBFE1BE2 because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_EE6047CA because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_F3B1D42E because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_F9A61E94 because it doesn't look legit
[Note] Ignoring function SceAppMgrForDriver_unk_FC89D33D because it doesn't look legit
[error] Function _sceAppMgrCaptureFrameBuf with NID 0xFA21A020 not found in lookup, ignoring...
[error] Function _sceAppMgrCaptureFrameBufByAppId with NID 0xD3787750 not found in lookup, ignoring...
[error] Function _sceAppMgrCaptureFrameBufDMAC with NID 0x34170882 not found in lookup, ignoring...
[error] Function _sceAppMgrCaptureFrameBufIFTU with NID 0x4799F0F7 not found in lookup, ignoring...
[error] Function _sceAppMgrCheckSaveDataMounted with NID 0x947A95CA not found in lookup, ignoring...
[error] Function _sceAppMgrGameDataMountWithPatch with NID 0x7A239EDC not found in lookup, ignoring...
[error] Function _sceAppMgrGetParam with NID 0x5FF430E8 not found in lookup, ignoring...
[error] Function _sceAppMgrSendEvent with NID 0x5432E51D not found in lookup, ignoring...
[error] Function _sceAppMgrReleaseSoundOutExclusive3 with NID 0x82C924AD not found in lookup, ignoring...
[error] Function sceAppMgrDestroyApp with NID 0xD18F8DDD not found in lookup, ignoring...
[error] Function sceAppMgrGetActivateApp with NID 0x4C1183C2 not found in lookup, ignoring...
[error] Function sceAppMgrGrowMemory2 with NID 0xE4CE2CB5 not found in lookup, ignoring...
[error] Function sceAppMgrInfoBarClose with NID 0x9A60BED4 not found in lookup, ignoring...
[error] Function sceAppMgrInfoBarOpen with NID 0x97B80C01 not found in lookup, ignoring...
[error] Function sceAppMgrSetEnablePrioritizeSystemChat with NID 0xD4078CC0 not found in lookup, ignoring...
[error] Function sceAppMgrSetInfobarStateForShellByPid with NID 0xA3314B2B not found in lookup, ignoring...
[error] Function sceSharedFbSetShellRenderPort with NID 0x0B81B10F not found in lookup, ignoring...
[error] Function sceSharedFbSetRenderingOrderForTest with NID 0x0D2B21AE not found in lookup, ignoring...
[warning] Function _sceSysmoduleUnloadModuleInternalWithArg found with different name in db: sceSysmoduleUnloadModuleInternalWithArg , skipping...
[warning] Function _sceSysmoduleLoadModuleInternalWithArg found with different name in db: sceSysmoduleLoadModuleInternalWithArg , skipping...
[error] Function _vshIoRmdev with NID 0xABA3EB4C not found in lookup, ignoring...
[error] Function _vshSblAimgrGetOpenPsId with NID 0x9FA17A89 not found in lookup, ignoring...
[error] Function _vshSblGcAuthMgrAdhocBB224Auth1 with NID 0x77BFA6A2 not found in lookup, ignoring...
[error] Function _vshSblGcAuthMgrAdhocBB224Auth2 with NID 0x6C757B8B not found in lookup, ignoring...
[error] Function _vshSblGcAuthMgrAdhocBB224Auth3 with NID 0x69C73C7A not found in lookup, ignoring...
[error] Function _vshSblGcAuthMgrAdhocBB224Auth4 with NID 0xEDF7285F not found in lookup, ignoring...
[error] Function _vshSblGcAuthMgrAdhocBB224Auth5 with NID 0x484CECAF not found in lookup, ignoring...
[error] Function _vshSblGcAuthMgrAdhocBB224GetKeys with NID 0x415D0502 not found in lookup, ignoring...
[error] Function sceSblAimgrIsCEX with NID 0xA64F334B not found in lookup, ignoring...
[error] Function vshDisplaySetColorSpaceMode with NID 0x12E3C5FF not found in lookup, ignoring...
[error] Function vshSblGcAuthMgrAdhocBB224Init with NID 0xD6EA8623 not found in lookup, ignoring...
[error] Function vshSblGcAuthMgrAdhocBB224Shutdown with NID 0x9CEE676C not found in lookup, ignoring...
[error] Function sceDrmBridgeGetCurrentSecureTickForDriver has a kernel prefix but is not in a library marked kernel
[error] Function sceDrmBridgeIsAllowRemotePlayDebugForDriver has a kernel prefix but is not in a library marked kernel
[Note] Ignoring function sceDrmBridgeIsAllow_unk_ForDriver because it doesn't look legit
[error] Function sceDrmBridgeMlnpsnlAuth1ForDriver has a kernel prefix but is not in a library marked kernel
[error] Function sceDrmBridgeMlnpsnlAuth2ForDriver has a kernel prefix but is not in a library marked kernel
[error] Function sceKernelStderr with NID 0x35EE7CF5 not found in lookup, ignoring...
[error] Function sceKernelStdin with NID 0x54237407 not found in lookup, ignoring...
[error] Function sceKernelStdout with NID 0x9033E9BD not found in lookup, ignoring...
[Note] Ignoring function printf because it doesn't look legit
```