### PR TITLE
correct ksceKernelSysrootSetProcessHandler library

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -2346,6 +2346,7 @@ modules:
           ksceKernelSysrootCoredumpTrigger: 0xCD8CD242
           ksceKernelSysrootGetShellPid: 0x05093E7B
           ksceKernelSysrootGetSystemSwVersion: 0x67AAB627
+          ksceKernelSysrootSetProcessHandler: 0x0F07C3FC
           ksceKernelSysrootSetSystemSwVersion: 0x3276086B
           ksceSysrootGetHardwareInfo: 0x930B1342
           ksceSysrootUtMgrHasNpTestFlag: 0xA43599E9
@@ -2373,7 +2374,6 @@ modules:
           ksceKernelSysrootIofilemgrStart: 0xF6A6D205
           ksceKernelSysrootIsUserModeThread: 0x7FC7A163
           ksceKernelSysrootProcessmgrStart2: 0x62E8F511
-          ksceKernelSysrootSetProcessHandler: 0x0F07C3FC
           ksceKernelSysrootSetSysroot: 0x36916C30
           ksceSysrootGetFactorySystemSwVersion: 0xD3872270
           ksceSysrootGetModuleInfoForPid: 0xFF9F80FF


### PR DESCRIPTION
should be part of SceSysrootForDriver instead.