### PR TITLE
Fix arguments for scePromoterUtilityPromoteImport

### DIFF
--- a/include/psp2/promoterutil.h
+++ b/include/psp2/promoterutil.h
@@ -70,7 +70,7 @@ int scePromoterUtilityUpdateLiveArea(ScePromoterUtilityLAUpdate *args);
 /**
  * Install Content Manager import contents and create bubbles without checking license files.
  *
- * @param[in] *params - see ScePromoterUtilImportParams
+ * @param[in] *params - see ::ScePromoterUtilImportParams
  *
  * @return 0 on success.
  */

--- a/include/psp2/promoterutil.h
+++ b/include/psp2/promoterutil.h
@@ -62,7 +62,7 @@ int scePromoterUtilityDeletePkg(const char *titleid);
 int scePromoterUtilityUpdateLiveArea(ScePromoterUtilityLAUpdate *args);
 
 /**
- * Install Content Mannager import content. and create bubbles without checking license files.
+ * Install Content Manager import content. and create bubbles without checking license files.
  *
  * @param[in] *params - see ScePromoterUtilImportParams
  *

--- a/include/psp2/promoterutil.h
+++ b/include/psp2/promoterutil.h
@@ -13,20 +13,26 @@
 extern "C" {
 #endif
 
+/** Avalible types for ::ScePromoterUtilityImportParams **/
+typedef enum ScePromoterUtilityPackageType{
+	SCE_PKG_TYPE_VITA               = 0x0001,          //!< PSVita Apps
+	SCE_PKG_TYPE_PSM                = 0x0003,          //!< PlayStation Mobile
+}ScePromoterUtilityPackageType;
+	
 /** Parameters for scePromoterUtilityUpdateLiveArea() */
 typedef struct ScePromoterUtilityLAUpdate {
 	char titleid[12];  //!< Target app.
 	char path[128];    //!< Directory of extracted LA update data.
 } ScePromoterUtilityLAUpdate;
-
+	
 /** Parameters for scePromoterUtilityPromoteImport() */
-typedef struct ScePromoterUtilImportParams{
+typedef struct ScePromoterUtilityImportParams{
 	char path[0x80]; //!< Install path usually (ux0:/temp/game) 
 	char titleid[0xC]; //!< Game titleid
-	uint32_t type; //!< Package Type (0x3 on PSM, 0x1 on VITA)
-	uint32_t attribute; //!< Appears to be 0x1 on PSM content but 0x00 on Vita.
+	ScePromoterUtilityPackageType type; //!< Package type
+	uint32_t attribute; //!< Additional Attributes
 	char reserved[0x1C];
-} ScePromoterUtilImportParams;
+} ScePromoterUtilityImportParams;
 	
 /**
  * Init the promoter utility.
@@ -68,7 +74,7 @@ int scePromoterUtilityUpdateLiveArea(ScePromoterUtilityLAUpdate *args);
  *
  * @return 0 on success.
  */
-int scePromoterUtilityPromoteImport(ScePromoterUtilImportParams *params);
+int scePromoterUtilityPromoteImport(ScePromoterUtilityImportParams *params);
 
 /**
  * Install a package from a directory, and add an icon on the LiveArea.

--- a/include/psp2/promoterutil.h
+++ b/include/psp2/promoterutil.h
@@ -24,7 +24,7 @@ typedef struct ScePromoterUtilImportParams{
 	char path[0x80]; //!< Install path usually (ux0:/temp/game) 
 	char titleid[0xC]; //!< Game titleid
 	uint32_t type; //!< Package Type (0x3 on PSM, 0x1 on VITA)
-	uint32_t unk0; //!< Unknown value (seems to be 0x1 on PSM content but 0x00 on Vita contents?)
+	uint32_t attribute; //!< Appears to be 0x1 on PSM content but 0x00 on Vita.
 	char reserved[0x1C];
 } ScePromoterUtilImportParams;
 	
@@ -62,9 +62,9 @@ int scePromoterUtilityDeletePkg(const char *titleid);
 int scePromoterUtilityUpdateLiveArea(ScePromoterUtilityLAUpdate *args);
 
 /**
- * Install a import from a directory, and add an icon on the LiveArea.
+ * Install Content Mannager import content. and create bubbles without checking license files.
  *
- * @param[in] *path - the path of the directory where the extracted content of the import is
+ * @param[in] *params - see ScePromoterUtilImportParams
  *
  * @return 0 on success.
  */

--- a/include/psp2/promoterutil.h
+++ b/include/psp2/promoterutil.h
@@ -14,10 +14,10 @@ extern "C" {
 #endif
 
 /** Avalible types for ::ScePromoterUtilityImportParams **/
-typedef enum ScePromoterUtilityPackageType{
+typedef enum ScePromoterUtilityPackageType {
 	SCE_PKG_TYPE_VITA               = 0x0001,          //!< PSVita Apps
 	SCE_PKG_TYPE_PSM                = 0x0003,          //!< PlayStation Mobile
-}ScePromoterUtilityPackageType;
+} ScePromoterUtilityPackageType;
 	
 /** Parameters for scePromoterUtilityUpdateLiveArea() */
 typedef struct ScePromoterUtilityLAUpdate {
@@ -26,11 +26,11 @@ typedef struct ScePromoterUtilityLAUpdate {
 } ScePromoterUtilityLAUpdate;
 	
 /** Parameters for scePromoterUtilityPromoteImport() */
-typedef struct ScePromoterUtilityImportParams{
+typedef struct ScePromoterUtilityImportParams {
 	char path[0x80]; //!< Install path usually (ux0:/temp/game) 
 	char titleid[0xC]; //!< Game titleid
 	ScePromoterUtilityPackageType type; //!< Package type
-	uint32_t attribute; //!< Additional Attributes
+	uint32_t attribute; //!< Additional Attributes (Appears to be 0x1 on PSM content but 0x00 on Vita contents)
 	char reserved[0x1C];
 } ScePromoterUtilityImportParams;
 	

--- a/include/psp2/promoterutil.h
+++ b/include/psp2/promoterutil.h
@@ -62,7 +62,7 @@ int scePromoterUtilityDeletePkg(const char *titleid);
 int scePromoterUtilityUpdateLiveArea(ScePromoterUtilityLAUpdate *args);
 
 /**
- * Install Content Manager import content. and create bubbles without checking license files.
+ * Install Content Manager import contents and create bubbles without checking license files.
  *
  * @param[in] *params - see ScePromoterUtilImportParams
  *

--- a/include/psp2/promoterutil.h
+++ b/include/psp2/promoterutil.h
@@ -19,6 +19,15 @@ typedef struct ScePromoterUtilityLAUpdate {
 	char path[128];    //!< Directory of extracted LA update data.
 } ScePromoterUtilityLAUpdate;
 
+/** Parameters for scePromoterUtilityPromoteImport() */
+typedef struct ScePromoterUtilImportParams{
+	char path[0x80]; //!< Install path usually (ux0:/temp/game) 
+	char titleid[0xC]; //!< Game titleid
+	uint32_t type; //!< Package Type (0x3 on PSM, 0x1 on VITA)
+	uint32_t unk0; //!< Unknown value (seems to be 0x1 on PSM content but 0x00 on Vita contents?)
+	char reserved[0x1C];
+} ScePromoterUtilImportParams;
+	
 /**
  * Init the promoter utility.
  * \note Needs to be called before using the other functions.
@@ -59,7 +68,7 @@ int scePromoterUtilityUpdateLiveArea(ScePromoterUtilityLAUpdate *args);
  *
  * @return 0 on success.
  */
-int scePromoterUtilityPromoteImport(const char *path);
+int scePromoterUtilityPromoteImport(ScePromoterUtilImportParams *params);
 
 /**
  * Install a package from a directory, and add an icon on the LiveArea.


### PR DESCRIPTION
scePromoterUtilityPromoteImport is the function Content Mannager uses to install games.
it can be used to install games WITHOUT a valid license file- (they dont run w/o it though obviously.) 
as well as w savedata addcont etc preinstalled and such.
also works on PlayStation Mobile content. . neat stuffs ^-^