### PR TITLE
Fix value for SCE_EVENT_WAITMULTIPLE, add other missing event flags

### DIFF
--- a/include/psp2/kernel/threadmgr.h
+++ b/include/psp2/kernel/threadmgr.h
@@ -594,7 +594,7 @@ typedef enum SceEventFlagAttributes {
 	/* Waiting threads queued on a FIFO basis */
 	SCE_EVENT_THREAD_FIFO = 0,
 	/* Waiting threads queued on priority basis */
-        SCE_EVENT_THREAD_PRIO = 0x00002000,
+	SCE_EVENT_THREAD_PRIO = 0x00002000,
 	/* Event flag can only be waited upon by one thread */
 	SCE_EVENT_WAITSINGLE = 0,
 	/* Event flag can be waited upon by multiple threads */

--- a/include/psp2/kernel/threadmgr.h
+++ b/include/psp2/kernel/threadmgr.h
@@ -591,8 +591,16 @@ typedef struct SceKernelEventFlagOptParam SceKernelEventFlagOptParam;
 
 /** Event flag creation attributes */
 typedef enum SceEventFlagAttributes {
-	/** Allow the event flag to be waited upon by multiple threads */
-	SCE_EVENT_WAITMULTIPLE = 0x200
+	/* Waiting threads queued on a FIFO basis */
+	SCE_EVENT_THREAD_FIFO = 0,
+	/* Waiting threads queued on priority basis */
+        SCE_EVENT_THREAD_PRIO = 0x00002000,
+	/* Event flag can only be waited upon by one thread */
+	SCE_EVENT_WAITSINGLE = 0,
+	/* Event flag can be waited upon by multiple threads */
+	SCE_EVENT_WAITMULTIPLE = 0x00001000,
+	/* Event flag can be accessed by sceKernelOpenEventFlag / sceKernelCloseEventFlag */
+	SCE_EVENT_OPENABLE = 0x00000080
 } SceEventFlagAttributes;
 
 /** Event flag wait types */


### PR DESCRIPTION
The current definition for SCE_EVENT_WAITMULTIPLE is incorrect, and results in SCE_KERNEL_ERROR_ILLEGAL_ATTR if used.

This fixes the value, and adds definitions for priority or fifo-based thread waiting (fifo is the default), a placeholder for single thread waiting, and the flag allowing the event flag to be accessed via sceKernelOpenEventFlag and sceKernelCloseEventFlag (api not currently exposed).