### PR TITLE
Removed wrong data types and fixed SceMotionState struct.

### DIFF
--- a/include/psp2/motion.h
+++ b/include/psp2/motion.h
@@ -22,8 +22,8 @@ typedef struct SceMotionState {
 	SceFVector3 angularVelocity;
 	uint8_t reserved1[12];
 	SceFQuaternion deviceQuat;
-	SceUMatrix4 rotationMatrix;
-	SceUMatrix4 nedMatrix;
+	SceFMatrix4 rotationMatrix;
+	SceFMatrix4 nedMatrix;
 	uint32_t reserved2;
 	SceFVector3 basicOrientation;
 	SceULong64 hostTimestamp;

--- a/include/psp2/types.h
+++ b/include/psp2/types.h
@@ -96,13 +96,6 @@ typedef struct SceIVector4 {
     SceInt w;
 } SceIVector4;
 
-typedef struct SceUVector4 {
-    SceUInt x;
-    SceUInt y;
-    SceUInt z;
-    SceUInt w;
-} SceUVector4;
-
 typedef struct SceFVector4 {
     SceFloat x;
     SceFloat y;
@@ -139,13 +132,6 @@ typedef struct SceIMatrix4 {
     SceIVector4 w;
 } SceIMatrix4;
 
-typedef struct SceUMatrix4 {
-    SceUVector4 x;
-    SceUVector4 y;
-    SceUVector4 z;
-    SceUVector4 w;
-} SceUMatrix4;
-
 typedef struct SceFMatrix4 {
     SceFVector4 x;
     SceFVector4 y;
@@ -173,48 +159,6 @@ typedef struct SceFPlane {
     SceFloat c;
     SceFloat d;
 } SceFPlane;
-
-typedef union SceUnion32 {
-    unsigned int ui;
-    int i;
-    unsigned short us[2];
-    short s[2];
-    unsigned char uc[4];
-    char c[4];
-    float f;
-    void *p;
-} SceUnion32;
-
-typedef union SceUnion64 {
-    SceULong64 ull;
-    SceLong64 ll;
-    unsigned int ui[2];
-    int i[2];
-    unsigned short us[4];
-    short s[4];
-    unsigned char uc[8];
-    char c[8];
-    float f[2];
-    SceFVector2 fv;
-    SceIVector2 iv;
-} SceUnion64;
-
-typedef union SceUnion128 {
-    SceULong64 ull[2];
-    SceLong64 ll[2];
-    unsigned int ui[4];
-    int i[4];
-    unsigned short us[8];
-    short s[8];
-    unsigned char uc[16];
-    char c[16];
-    float f[4];
-    SceFVector4 fv;
-    SceFQuaternion fq;
-    SceFPlane fp;
-    SceFColor fc;
-    SceIVector4 iv;
-} SceUnion128;
 
 typedef struct SceDateTime {
     unsigned short year;


### PR DESCRIPTION
The SceUnion32/64/128 data types were never used and are pretty abnormal and useless data types regardless.
As for SceUMatrix4/SceUVector4, those are supposed to mean SceUnion and not SceUnsigned like we thought and were remainings of SceUnion data types. After doing some tests, sceMotionGetState properly returns a float matrix as rotationMatrix so i just removed SceUMatrix4/SceUVector4 and replaced the occurrence in the SceMotionState struct with a SceFMatrix4.