### PR TITLE
Final Additions and Changes for the Json Library

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -3187,7 +3187,7 @@ modules:
           _ZN3sce4Json5Value12referBooleanEv: 0xF7F9550C
           _ZN3sce4Json5Value12referIntegerEv: 0x9F0BD96B
           _ZN3sce4Json5Value13referUIntegerEv: 0xD1C592D6
-          _ZN3sce4Json5Value21setNullAccessCallBackEPFRKS1_NS0_9ValueTypeEPS2_PvES6_: 0x349F2D89
+          _ZN3sce4Json5Value21setNullAccessCallbackEPFRKS1_NS0_9ValueTypeEPS2_PvES6_: 0x349F2D89
           _ZN3sce4Json5Value3setENS0_9ValueTypeE: 0x925E89F8
           _ZN3sce4Json5Value3setERKNS0_5ArrayE: 0x49389A02
           _ZN3sce4Json5Value3setERKNS0_6ObjectE: 0x8725FD85


### PR DESCRIPTION
Switched ValueType to an enum class. Changed values to be more C++ like, rather than C like.

Added public type specifier to the InitParameter class.

Removed Initializer::setAllocatorInfoCallBack and AllocatorInfoCallback typedef.

Added some missing documentation, and some other minor changes.