### PR TITLE
Revert "Added sceGxmTextureInitSwizzledArbitrary function prototype"

### DIFF
--- a/include/psp2/gxm.h
+++ b/include/psp2/gxm.h
@@ -1496,7 +1496,6 @@ unsigned int sceGxmShaderPatcherGetVertexUsseMemAllocated(const SceGxmShaderPatc
 unsigned int sceGxmShaderPatcherGetFragmentUsseMemAllocated(const SceGxmShaderPatcher *shaderPatcher);
 
 int sceGxmTextureInitSwizzled(SceGxmTexture *texture, const void *data, SceGxmTextureFormat texFormat, unsigned int width, unsigned int height, unsigned int mipCount);
-int sceGxmTextureInitSwizzledArbitrary(SceGxmTexture *texture, const void *data, SceGxmTextureFormat texFormat, unsigned int width, unsigned int height, unsigned int mipCount);
 int sceGxmTextureInitLinear(SceGxmTexture *texture, const void *data, SceGxmTextureFormat texFormat, unsigned int width, unsigned int height, unsigned int mipCount);
 int sceGxmTextureInitLinearStrided(SceGxmTexture *texture, const void *data, SceGxmTextureFormat texFormat, unsigned int width, unsigned int height, unsigned int byteStride);
 int sceGxmTextureInitTiled(SceGxmTexture *texture, const void *data, SceGxmTextureFormat texFormat, unsigned int width, unsigned int height, unsigned int mipCount);


### PR DESCRIPTION
Reverts vitasdk/vita-headers#469

I couldn't find any license permit from vita3k yet.