### PR TITLE
Define remaining unknown fields in Json Library classes.

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -454,7 +454,7 @@ EXTRACT_ALL            = YES
 # be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PRIVATE        = NO
+EXTRACT_PRIVATE        = YES
 
 # If the EXTRACT_PACKAGE tag is set to YES, all members with package or internal
 # scope will be included in the documentation.


### PR DESCRIPTION
Defined unk_0x8, unk_0x10 and unk_0x4 in the InitParameter, Value and Pair classes.

Small adjustments to account for the above change.

Move the SceJsonError enum and it's values outside of the sce::Json namespace.

Set Doxygen to generate documentation for private class members as well.

Numerous other minor changes.