### PR TITLE
Fix incorrect NIDs for SceJpegEncArm functions

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -2727,14 +2727,14 @@ modules:
         kernel: false
         nid: 0xCF9C23A2
         functions:
-          sceJpegArmEncoderEncode: 0xC60DE94C
-          sceJpegArmEncoderEnd: 0xC87AA849
-          sceJpegArmEncoderGetContextSize: 0x2B55844D
-          sceJpegArmEncoderInit: 0x88DA92B4
-          sceJpegArmEncoderSetCompressionRatio: 0xB2B828EC
-          sceJpegArmEncoderSetHeaderMode: 0x2F58B12C
-          sceJpegArmEncoderSetOutputAddr: 0x25D52D97
-          sceJpegArmEncoderSetValidRegion: 0x9511F3BC
+          sceJpegArmEncoderEncode: 0x648FFAA3
+          sceJpegArmEncoderEnd: 0x8A42D6EC
+          sceJpegArmEncoderGetContextSize: 0x8D15B36D
+          sceJpegArmEncoderInit: 0x8C23875A
+          sceJpegArmEncoderSetCompressionRatio: 0x32B8E159
+          sceJpegArmEncoderSetHeaderMode: 0x6D24A669
+          sceJpegArmEncoderSetOutputAddr: 0xDA0D0868
+          sceJpegArmEncoderSetValidRegion: 0xD561E2E5
   SceKernelDmacMgr:
     nid: 0xF926C804
     libraries:


### PR DESCRIPTION
Was mistakenly using same NIDs as SceJpegEnc before.