### PR TITLE
Update SceKernelFaultingProcessInfo

### DIFF
--- a/include/psp2kern/kernel/threadmgr.h
+++ b/include/psp2kern/kernel/threadmgr.h
@@ -110,7 +110,7 @@ typedef enum SceThreadStatus {
 
 typedef struct SceKernelFaultingProcessInfo {
     SceUID pid;
-    uint32_t unk;
+    SceUID faultingThreadId; //Kernel UID of the faulting thread
 } SceKernelFaultingProcessInfo;
 
 /**

--- a/include/psp2kern/kernel/threadmgr.h
+++ b/include/psp2kern/kernel/threadmgr.h
@@ -110,7 +110,7 @@ typedef enum SceThreadStatus {
 
 typedef struct SceKernelFaultingProcessInfo {
     SceUID pid;
-    SceUID faultingThreadId; //Kernel UID of the faulting thread
+    SceUID faultingThreadId; //!< Kernel UID of the faulting thread
 } SceKernelFaultingProcessInfo;
 
 /**
@@ -1084,4 +1084,3 @@ int ksceKernelCancelMsgPipe(SceUID uid, int *psend, int *precv);
 #endif
 
 #endif /* _PSP2_KERNEL_THREADMGR_H_ */
-


### PR DESCRIPTION
Document missing field of SceKernelFaultingProcessInfo.

Found by reversing a SceDeci4p module, as evidenced by the following code: 
```c
SceKernelFaultingProcessInfo fpi;
ksceKernelGetFaultingProcess(&fpi);
SceUID usrthid = sceKernelGetUserThreadId(fpi.unk);
```