### PR TITLE
Fix documentation for battery life time functions

### DIFF
--- a/include/psp2/power.h
+++ b/include/psp2/power.h
@@ -122,7 +122,7 @@ SceBool scePowerIsPowerOnline(void);
 /**
  * Returns battery life time
  *
- * @return Battery life time in seconds
+ * @return Battery life time in minutes
  */
 int scePowerGetBatteryLifeTime(void);
 

--- a/include/psp2kern/power.h
+++ b/include/psp2kern/power.h
@@ -89,7 +89,7 @@ SceBool kscePowerIsPowerOnline(void);
 /**
  * Returns battery life time
  *
- * @return Battery life time in seconds
+ * @return Battery life time in minutes
  */
 int kscePowerGetBatteryLifeTime(void);
 


### PR DESCRIPTION
Both `scePowerGetBatteryLifeTime` & `kscePowerGetBatteryLifeTime` return battery life time in minutes not seconds.