### PR TITLE
Fix invalid size of SceKernelLwCondWork

### DIFF
--- a/include/psp2/kernel/threadmgr.h
+++ b/include/psp2/kernel/threadmgr.h
@@ -1130,7 +1130,7 @@ int sceKernelTryLockLwMutex(SceKernelLwMutexWork *pWork, int lockCount);
 int sceKernelUnlockLwMutex(SceKernelLwMutexWork *pWork, int unlockCount);
 
 typedef struct	SceKernelLwCondWork {
-	SceInt64 data[4];
+	SceInt32 data[4];
 } SceKernelLwCondWork;
 
 typedef struct SceKernelLwCondOptParam {


### PR DESCRIPTION
Verified by reversing of Threadmgr
