### PR TITLE
Processmgr fix

### DIFF
--- a/include/psp2kern/kernel/processmgr.h
+++ b/include/psp2kern/kernel/processmgr.h
@@ -66,6 +66,13 @@ int ksceKernelSuspendProcess(SceUID pid, int status);
  */
 int ksceKernelGetProcessStatus(SceUID pid, int *status);
 
+/**
+ * @brief       Get the main thread for a given process.
+ * @param[in]   pid The process id to query for.
+ * @return      The thread UID on success, else < 0 on error.
+ */
+SceUID ksceKernelGetProcessMainThread(SceUID pid);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/psp2kern/kernel/threadmgr.h
+++ b/include/psp2kern/kernel/threadmgr.h
@@ -891,13 +891,6 @@ typedef int (* SceKernelWorkQueueWorkFunction)(void *args);
 int ksceKernelEnqueueWorkQueue(SceUID uid, const char *name, SceKernelWorkQueueWorkFunction work, void *args);
 
 /**
- * @brief       Get the main thread for a given process.
- * @param[in]   pid The process id to query for.
- * @return      The thread UID on success, else < 0 on error.
- */
-SceUID ksceKernelGetProcessMainThread(SceUID pid);
-
-/**
  * @brief       Retrieve a list of all threads belonging to a process.
  * @param[in]   pid         The process to query.
  * @param[out]  ids         The list of thread ids. Can be NULL if output is not required.


### PR DESCRIPTION
ksceKernelGetProcessMainThread is from processmgr, not exported from threadmgr