### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains all Vita headers needed for development.
 
 ## Structure :
-- `db.yml` contains all the unique identifiers (NID) of the available functions.
+- `db` contains all the unique identifiers (NID) of the available functions.
 - `include/` contains the header files themselves
   - `psp2` is for header files of user-exported libraries
   - `psp2kern` is for header files of kernel-exported libraries


### PR DESCRIPTION
`db.yml` no longer exists.