### PR TITLE
Revert "Add SceKernelSysClock typedef"

### DIFF
--- a/include/psp2kern/kernel/processmgr.h
+++ b/include/psp2kern/kernel/processmgr.h
@@ -13,8 +13,6 @@
 extern "C" {
 #endif
 
-typedef uint64_t SceKernelSysClock;
-
 typedef struct SceKernelProcessInfo {
 	SceSize size;           //!< size of this struct, make sure it's 0xE8
 	SceUID pid;             //!< our process ID


### PR DESCRIPTION
SceKernelSysClock already existed in threadmgr.h but I misunderstood that it belongs to processmgr and added it, So revert it