### PR TITLE
Fix ksceKernelSetProcessId

### DIFF
--- a/db/360/SceKernelThreadMgr.yml
+++ b/db/360/SceKernelThreadMgr.yml
@@ -267,7 +267,7 @@ modules:
           ksceKernelSetEvent: 0x9EA3A45C
           ksceKernelSetEventFlag: 0xD4780C3E
           ksceKernelSetPermission: 0x02EEDF17
-          ksceKernelSetProcessId: 0x0486F239
+          ksceKernelSetProcessIdToTLS: 0x0486F239
           ksceKernelSetTimerTimeWide: 0x85195A16
           ksceKernelSignalCond: 0xAC616150
           ksceKernelSignalCondAll: 0x6EC78CD0

--- a/include/psp2kern/kernel/threadmgr/misc.h
+++ b/include/psp2kern/kernel/threadmgr/misc.h
@@ -87,13 +87,20 @@ int ksceKernelSetPermission(int value);
 SceUID ksceKernelGetProcessId(void);
 
 /**
- * @brief Set Process id
+ * @brief Get Process id from Thread Local Storage
+ *
+ * @return current process id
+ */
+SceUID ksceKernelGetProcessIdFromTLS(void);
+
+/**
+ * @brief Set Process id to Thread Local Storage
  *
  * @param[in] value - The new process id
  *
  * @return previous process id
  */
-SceUID ksceKernelSetProcessId(SceUID pid);
+SceUID ksceKernelSetProcessIdToTLS(SceUID pid);
 
 /**
  * @brief      Runs a function with larger stack size


### PR DESCRIPTION
At least 3.60 does not exist sceKernelSetProcessId. Instead there is sceKernelSetProcessIdToTLS.