### PR TITLE
Update paf

### DIFF
--- a/.travis.d/definition_check.py
+++ b/.travis.d/definition_check.py
@@ -70,6 +70,8 @@ def read_nids():
             for line_no, line in enumerate(readlines(d)):
                 line = line.strip()
                 k, v = line.split(':')[:3]
+                if k[0] == "#": # It a comment
+                    continue
                 if not v.strip():
                     SECTION = k
                     continue

--- a/db/360/ScePaf.yml
+++ b/db/360/ScePaf.yml
@@ -8,7 +8,13 @@ modules:
         kernel: false
         nid: 0x3D643CE8
         functions:
+          scePafCreateHeap: 0xA2B0BF4D
+          scePafDeleteHeap: 0x25238A3A
+          scePafFreeWithContext: 0xCE97B579
           scePafGetCurrentClockLocalTime: 0x96345146
+          scePafMallocAlignWithContext: 0x04716F15
+          scePafMallocWithContext: 0x89A1CE78
+          scePafReallocWithContext: 0x74DB7F5D
           scePafSha1Init: 0xB38C53C0
           scePafSha1Result: 0xB3BF59FC
           scePafSha1Update: 0xE6BB459E
@@ -46,95 +52,93 @@ modules:
         kernel: false
         nid: 0xA7D28DAE
         functions:
+          # memcpy: 0x5883A6E3
+          # memset: 0x75ECC54E
+          sce_paf_abs: 0x0F297A5E
+          sce_paf_atof: 0x9C251354
+          sce_paf_atoi: 0x5930D99A
+          sce_paf_atol: 0x086AD1FA
+          sce_paf_atoll: 0x47B19A87
+          sce_paf_bcmp: 0x1076722F
+          sce_paf_bcopy: 0x44C0825D
+          sce_paf_bsearch: 0x78AE1C51
+          sce_paf_bzero: 0xD21442B4
+          sce_paf_fclose: 0xA005E879
+          sce_paf_fgetc: 0xDEB581B4
+          sce_paf_fopen: 0x1BCCD0B9
+          sce_paf_fputc: 0xAF1831DC
+          sce_paf_fread: 0x43A53623
+          sce_paf_free: 0x347AFDD9
+          sce_paf_fseek: 0xFC10F9E9
+          sce_paf_ftell: 0x77CB5E21
+          sce_paf_fwrite: 0x4D5BB0F8
+          sce_paf_longjmp: 0x001BFAC2
+          sce_paf_look_ctype_table: 0x247C19A8
+          sce_paf_malloc: 0x0886C1E3
           sce_paf_memalign: 0xAA9952E0
-          sce_paf_private_abs: 0x0F297A5E
+          sce_paf_memchr: 0x1D286681
+          sce_paf_memcmp: 0x79DFA2A2
+          sce_paf_memcpy: 0x2C5B6F9C
+          sce_paf_memmove: 0x01566828
+          sce_paf_memset: 0xE148AF94
           sce_paf_private_atexit: 0x9A1D1ED1
-          sce_paf_private_atof: 0x9C251354
-          sce_paf_private_atoi: 0x5930D99A
-          sce_paf_private_atol: 0x086AD1FA
-          sce_paf_private_atoll: 0x47B19A87
-          sce_paf_private_bcmp: 0x1076722F
-          sce_paf_private_bcopy: 0x44C0825D
-          sce_paf_private_bsearch: 0x78AE1C51
-          sce_paf_private_bzero: 0xD21442B4
           sce_paf_private_exit: 0x92BF63C9
-          sce_paf_private_fclose: 0xA005E879
           sce_paf_private_fflush: 0x26A0A5F6
-          sce_paf_private_fgetc: 0xDEB581B4
-          sce_paf_private_fopen: 0x1BCCD0B9
-          sce_paf_private_fputc: 0xAF1831DC
-          sce_paf_private_fread: 0x43A53623
-          sce_paf_private_free: 0x1B77082E
-          sce_paf_private_free2: 0x5C468294
-          sce_paf_private_fseek: 0xFC10F9E9
-          sce_paf_private_ftell: 0x77CB5E21
-          sce_paf_private_fwrite: 0x4D5BB0F8
-          sce_paf_private_longjmp: 0x001BFAC2
-          sce_paf_private_look_ctype_table: 0x247C19A8
-          sce_paf_private_malloc: 0xFC5CD359
-          sce_paf_private_malloc2: 0xD8CC1AFE
-          sce_paf_private_memchr: 0x1D286681
-          sce_paf_private_memcmp: 0x79DFA2A2
-          sce_paf_private_memcpy: 0x2C5B6F9C
-          sce_paf_private_memcpy2: 0x5883A6E3
-          sce_paf_private_memmove: 0x01566828
-          sce_paf_private_memset: 0xE148AF94
-          sce_paf_private_memset2: 0x75ECC54E
-          sce_paf_private_qsort: 0xF7A11753
-          sce_paf_private_rand: 0xC9DACD41
-          sce_paf_private_setjmp: 0x2105FFAD
-          sce_paf_private_snprintf: 0x4E0D907E
-          sce_paf_private_sprintf: 0x19182BDA
-          sce_paf_private_srand: 0x772DF5A0
-          sce_paf_private_strcasecmp: 0x70A459B2
-          sce_paf_private_strcat: 0x2344E6F2
-          sce_paf_private_strchr: 0x1A22784C
-          sce_paf_private_strcmp: 0x5CD08A47
-          sce_paf_private_strcpy: 0xA523672C
-          sce_paf_private_strcspn: 0xB429DD2A
-          sce_paf_private_strlcat: 0x52A68C8D
-          sce_paf_private_strlcpy: 0x3D1AAC3A
-          sce_paf_private_strlen: 0xF5A2AA0C
-          sce_paf_private_strncasecmp: 0xA6014289
-          sce_paf_private_strncat: 0xD259BEAF
-          sce_paf_private_strncmp: 0x1E1EA818
-          sce_paf_private_strncpy: 0xE29DA0BF
-          sce_paf_private_strpbrk: 0xA14AB14F
-          sce_paf_private_strrchr: 0xFA2C892F
-          sce_paf_private_strspn: 0xE3F8F3D6
           sce_paf_private_strtof: 0x945EA5EA
           sce_paf_private_strtok: 0x15C4B5A4
-          sce_paf_private_strtok_r: 0x0D305F0E
-          sce_paf_private_strtol: 0xDB814C12
-          sce_paf_private_strtoll: 0x2F6B94FF
-          sce_paf_private_strtoul: 0x04FDF238
-          sce_paf_private_strtoull: 0xC05A18CA
-          sce_paf_private_swprintf: 0xF67F76D0
-          sce_paf_private_tolower: 0xDAC2EE4D
-          sce_paf_private_toupper: 0x761184A5
           sce_paf_private_towlower: 0xC8C2CDAC
-          sce_paf_private_vsnprintf: 0x51C66C6E
-          sce_paf_private_vsprintf: 0x3079B56B
-          sce_paf_private_wcscasecmp: 0x92A125F6
-          sce_paf_private_wcscat: 0xDDDDD6E0
-          sce_paf_private_wcschr: 0x13833CAE
-          sce_paf_private_wcscmp: 0x822897E3
-          sce_paf_private_wcscpy: 0xE9B40477
-          sce_paf_private_wcscspn: 0xDE8B2091
-          sce_paf_private_wcslen: 0xBED4F3D0
-          sce_paf_private_wcsncasecmp: 0x8D65035E
-          sce_paf_private_wcsncat: 0x49023581
-          sce_paf_private_wcsncmp: 0xA41CD38D
-          sce_paf_private_wcsncpy: 0x21B784DD
-          sce_paf_private_wcsnlen: 0xDCE80ABB
-          sce_paf_private_wcspbrk: 0xD7A2DF29
-          sce_paf_private_wcsrchr: 0x439EB9D4
-          sce_paf_private_wcsspn: 0x85DB686E
-          sce_paf_private_wmemchr: 0x8236A020
-          sce_paf_private_wmemcmp: 0x381B6216
-          sce_paf_private_wmemcpy: 0x19B5B91D
-          sce_paf_private_wmemmove: 0x468A09B1
-          sce_paf_private_wmemset: 0x36890967
+          sce_paf_qsort: 0xF7A11753
+          sce_paf_rand: 0xC9DACD41
+          sce_paf_setjmp: 0x2105FFAD
+          sce_paf_snprintf: 0x4E0D907E
+          sce_paf_sprintf: 0x19182BDA
+          sce_paf_srand: 0x772DF5A0
+          sce_paf_strcasecmp: 0x70A459B2
+          sce_paf_strcat: 0x2344E6F2
+          sce_paf_strchr: 0x1A22784C
+          sce_paf_strcmp: 0x5CD08A47
+          sce_paf_strcpy: 0xA523672C
+          sce_paf_strcspn: 0xB429DD2A
+          sce_paf_strlcat: 0x52A68C8D
+          sce_paf_strlcpy: 0x3D1AAC3A
+          sce_paf_strlen: 0xF5A2AA0C
+          sce_paf_strncasecmp: 0xA6014289
+          sce_paf_strncat: 0xD259BEAF
+          sce_paf_strncmp: 0x1E1EA818
+          sce_paf_strncpy: 0xE29DA0BF
+          sce_paf_strpbrk: 0xA14AB14F
+          sce_paf_strrchr: 0xFA2C892F
+          sce_paf_strspn: 0xE3F8F3D6
+          sce_paf_strtok_r: 0x0D305F0E
+          sce_paf_strtol: 0xDB814C12
+          sce_paf_strtoll: 0x2F6B94FF
+          sce_paf_strtoul: 0x04FDF238
+          sce_paf_strtoull: 0xC05A18CA
+          sce_paf_swprintf: 0xF67F76D0
+          sce_paf_tolower: 0xDAC2EE4D
+          sce_paf_toupper: 0x761184A5
+          sce_paf_vsnprintf: 0x51C66C6E
+          sce_paf_vsprintf: 0x3079B56B
+          sce_paf_wcscasecmp: 0x92A125F6
+          sce_paf_wcscat: 0xDDDDD6E0
+          sce_paf_wcschr: 0x13833CAE
+          sce_paf_wcscmp: 0x822897E3
+          sce_paf_wcscpy: 0xE9B40477
+          sce_paf_wcscspn: 0xDE8B2091
+          sce_paf_wcslen: 0xBED4F3D0
+          sce_paf_wcsncasecmp: 0x8D65035E
+          sce_paf_wcsncat: 0x49023581
+          sce_paf_wcsncmp: 0xA41CD38D
+          sce_paf_wcsncpy: 0x21B784DD
+          sce_paf_wcsnlen: 0xDCE80ABB
+          sce_paf_wcspbrk: 0xD7A2DF29
+          sce_paf_wcsrchr: 0x439EB9D4
+          sce_paf_wcsspn: 0x85DB686E
+          sce_paf_wmemchr: 0x8236A020
+          sce_paf_wmemcmp: 0x381B6216
+          sce_paf_wmemcpy: 0x19B5B91D
+          sce_paf_wmemmove: 0x468A09B1
+          sce_paf_wmemset: 0x36890967
       ScePafWidget:
         kernel: false
         nid: 0x073F8C68

--- a/include/psp2/paf.h
+++ b/include/psp2/paf.h
@@ -7,69 +7,10 @@
 #ifndef _PSP2_PAF_H_
 #define _PSP2_PAF_H_
 
-#include <psp2/types.h>
-#include <stdarg.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-void sce_paf_private_free(void *ptr);
-void *sce_paf_private_malloc(SceSize size);
-
-/**
- * @brief Alloc memory with align
- *
- * @param[in] align  - The align size
- * @param[in] length - The alloc length
- *
- * @return memory pointer or NULL
+/*
+ * PAF many part is really written in C++, but header is in C language
  */
-void *sce_paf_memalign(SceSize align, SceSize length);
-
-void *sce_paf_private_bzero(void *ptr, SceSize num);
-void *sce_paf_private_memchr(const void *ptr, int value, SceSize num);
-int sce_paf_private_memcmp(const void *ptr1, const void *ptr2, SceSize num);
-int sce_paf_private_bcmp(const void *ptr1, const void *ptr2, SceSize num);
-void *sce_paf_private_memcpy(void *destination, const void *source, SceSize num);
-void *sce_paf_private_memcpy2(void *destination, const void *source, SceSize num);
-void *sce_paf_private_memmove(void *destination, const void *source, SceSize num);
-void *sce_paf_private_bcopy(void *destination, const void *source, SceSize num);
-void *sce_paf_private_memset(void *ptr, int value, SceSize num);
-int sce_paf_private_snprintf(char *s, SceSize n, const char *format, ...);
-
-int sce_paf_private_vsnprintf(char *dst, unsigned int max, const char *fmt, va_list arg);
-
-#define sce_paf_vsnprintf sce_paf_private_vsnprintf
-
-int sce_paf_private_strcasecmp(const char *str1, const char *str2);
-char *sce_paf_private_strchr(const char *str, int character);
-int sce_paf_private_strcmp(const char *str1, const char *str2);
-size_t sce_paf_private_strlen(const char *str);
-int sce_paf_private_strncasecmp(const char *str1, const char *str2, SceSize num);
-int sce_paf_private_strncmp(const char *str1, const char *str2, SceSize num);
-char *sce_paf_private_strncpy(char *destination, const char *source, SceSize num);
-char *sce_paf_private_strrchr(const char *str, int character);
-
-typedef struct ScePafDateTime {
-  SceDateTime data;
-  int data_0x10;
-  int data_0x14;
-} ScePafDateTime;
-
-int scePafGetCurrentClockLocalTime(ScePafDateTime *data);
-
-typedef struct ScePafSha1Context { // size is 0x68
-	uint32_t h[5];
-	char unk[0x54];
-} ScePafSha1Context;
-
-int scePafSha1Init(ScePafSha1Context *context);
-int scePafSha1Update(ScePafSha1Context *context, const void *data, SceSize length);
-int scePafSha1Result(ScePafSha1Context *context, void *dst);
-
-#ifdef __cplusplus
-}
-#endif
+#include <psp2/paf/stdc.h>
+#include <psp2/paf/misc.h>
 
 #endif /* _PSP2_PAF_H_ */

--- a/include/psp2/paf/misc.h
+++ b/include/psp2/paf/misc.h
@@ -1,0 +1,77 @@
+/**
+ * \usergroup{ScePaf}
+ * \usage{psp2/paf/misc.h,ScePaf_stub}
+ */
+
+
+#ifndef _PSP2_PAF_MISC_H_
+#define _PSP2_PAF_MISC_H_
+
+#include <psp2/types.h>
+#include <psp2/kernel/threadmgr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ScePafDateTime {
+  SceDateTime data;
+  int data_0x10;
+  int data_0x14;
+} ScePafDateTime;
+
+int scePafGetCurrentClockLocalTime(ScePafDateTime *data);
+
+typedef struct ScePafSha1Context { // size is 0x68
+	uint32_t h[5];
+	char unk[0x54];
+} ScePafSha1Context;
+
+int scePafSha1Init(ScePafSha1Context *context);
+int scePafSha1Update(ScePafSha1Context *context, const void *data, SceSize length);
+int scePafSha1Result(ScePafSha1Context *context, void *dst);
+
+typedef struct ScePafHeapContext { // size is 0x60-bytes
+	void *vtable;
+	void *heap;
+	void *membase;
+	SceSize size;
+	char name[0x20];
+	SceChar8 is_import_membase;
+	SceChar8 is_skip_debug_msg;
+	char data_0x32;
+	char data_0x33; // maybe unused. just for align.
+	int data_0x34;  // maybe unused. just for align.
+	SceKernelLwMutexWork lw_mtx;
+	SceUID memblk_id;
+
+	/*
+	 * !1 : Game
+	 *  1 : CDialog
+	 */
+	SceInt32 mode;
+} ScePafHeapContext;
+
+typedef struct ScePafHeapOpt { // size is 0x14-bytes
+	int a1;
+	int a2;
+	SceChar8 is_skip_debug_msg;
+	char a3[3];
+	SceInt32 mode;
+	int a5;
+} ScePafHeapOpt;
+
+void scePafCreateHeap(ScePafHeapContext *context, void *membase, SceSize size, const char *name, ScePafHeapOpt *opt);
+void scePafDeleteHeap(ScePafHeapContext *context);
+
+void *scePafMallocWithContext(ScePafHeapContext *context, SceSize len);
+void scePafFreeWithContext(ScePafHeapContext *context, void *ptr);
+
+void *scePafMallocAlignWithContext(ScePafHeapContext *context, SceUInt32 align, SceSize len);
+void *scePafReallocWithContext(ScePafHeapContext *context, void *ptr, SceSize len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PSP2_PAF_MISC_H_ */

--- a/include/psp2/paf/stdc.h
+++ b/include/psp2/paf/stdc.h
@@ -1,0 +1,78 @@
+/**
+ * \usergroup{ScePaf}
+ * \usage{psp2/paf/stdc.h,ScePaf_stub}
+ */
+
+
+#ifndef _PSP2_PAF_STDC_H_
+#define _PSP2_PAF_STDC_H_
+
+#include <psp2/types.h>
+#include <stdint.h>
+#include <stdarg.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void *sce_paf_malloc(SceSize size);
+void sce_paf_free(void *ptr);
+
+/**
+ * @brief Alloc memory with align
+ *
+ * @param[in] align  The align size
+ * @param[in] length The alloc length
+ *
+ * @return memory pointer or NULL
+ */
+void *sce_paf_memalign(SceSize align, SceSize length);
+
+void *sce_paf_memchr(const void *src, int ch, SceSize length);
+int sce_paf_memcmp(const void *s1, const void *s2, SceSize n);
+
+void *sce_paf_memcpy(void *dst, const void *src, SceSize len);
+void *sce_paf_memset(void *dst, int ch, SceSize len);
+void *sce_paf_memmove(void *dst, const void *src, SceSize len);
+
+int sce_paf_snprintf(char *dst, unsigned int max, const char *fmt, ...);
+int sce_paf_vsnprintf(char *dst, unsigned int max, const char *fmt, va_list arg);
+
+int sce_paf_bcmp(const void *ptr1, const void *ptr2, SceSize num);
+void *sce_paf_bcopy(void *dst, const void *src, SceSize n);
+void *sce_paf_bzero(void *dst, SceSize n);
+
+char *sce_paf_strchr(const char *s, int ch);
+int sce_paf_strcmp(const char *s1, const char *s2);
+size_t sce_paf_strlen(const char *s);
+int sce_paf_strcasecmp(const char *s1, const char *s2);
+int sce_paf_strncasecmp(const char *s1, const char *s2, SceSize len);
+int sce_paf_strncmp(const char *s1, const char *s2, SceSize len);
+char *sce_paf_strncpy(char *dst, const char *src, SceSize len);
+char *sce_paf_strrchr(const char *s, int ch);
+
+#define sce_paf_private_bcmp(__ptr1__, __ptr2__, __num__)             sce_paf_bcmp((__ptr1__), (__ptr2__), (__num__))
+#define sce_paf_private_bcopy(__dst__, __src__, __n__)                sce_paf_bcopy((__dst__), (__src__), (__n__))
+#define sce_paf_private_bzero(__dst__, __n__)                         sce_paf_bzero((__dst__), (__n__))
+#define sce_paf_private_memchr(__src__, __ch__, __length__)           sce_paf_memchr((__src__), (__ch__), (__length__))
+#define sce_paf_private_memcmp(__s1__, __s2__, __n__)                 sce_paf_memcmp((__s1__), (__s2__), (__n__))
+#define sce_paf_private_memcpy(__dst__, __src__, __len__)             sce_paf_memcpy((__dst__), (__src__), (__len__))
+#define sce_paf_private_memmove(__dst__, __src__, __len__)            sce_paf_memmove((__dst__), (__src__), (__len__))
+#define sce_paf_private_memset(__dst__, __ch__, __len__)              sce_paf_memset((__dst__), (__ch__), (__len__))
+#define sce_paf_private_snprintf                                      sce_paf_snprintf
+#define sce_paf_private_vsnprintf(__dst__, __max__, __fmt__, __arg__) sce_paf_vsnprintf((__dst__), (__max__), (__fmt__), (__arg__))
+#define sce_paf_private_strchr(__s__, __ch__)                         sce_paf_strchr((__s__), (__ch__))
+#define sce_paf_private_strcmp(__s1__, __s2__)                        sce_paf_strcmp((__s1__), (__s2__))
+#define sce_paf_private_strlen(__s__)                                 sce_paf_strlen((__s__))
+#define sce_paf_private_strcasecmp(__s1__, __s2__)                    sce_paf_strcasecmp((__s1__), (__s2__))
+#define sce_paf_private_strncasecmp(__s1__, __s2__, __len__)          sce_paf_strncasecmp((__s1__), (__s2__), (__len__))
+#define sce_paf_private_strncmp(__s1__, __s2__, __len__)              sce_paf_strncmp((__s1__), (__s2__), (__len__))
+#define sce_paf_private_strncpy(__dst__, __src__, __len__)            sce_paf_strncpy((__dst__), (__src__), (__len__))
+#define sce_paf_private_strrchr(__s__, __ch__)                        sce_paf_strrchr((__s__), (__ch__))
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PSP2_PAF_STDC_H_ */


### PR DESCRIPTION
Add some memory stuff and rename the stdc function to the name given by the bruteforce attack.
But now Removed unnecessary sce_paf_private_malloc2 and sce_paf_private_free2.

sha1("memcpyPAF") = `e3a68358 50eec820606f2aad1c617c18fa21598f`.

The remaining `sce_paf_private_*` functions are those not found in the bruteforce attack.
