### PR TITLE
Add SCE_KERNEL_THREAD_ID_SELF

### DIFF
--- a/include/psp2/kernel/threadmgr.h
+++ b/include/psp2/kernel/threadmgr.h
@@ -278,8 +278,7 @@ int sceKernelCheckThreadStack(void);
 /**
  * Get the free stack size for a thread.
  *
- * @param thid - The thread ID. Seem to take current thread
- * if set to 0.
+ * @param thid - The thread ID
  *
  * @return The free size.
  */

--- a/include/psp2common/types.h
+++ b/include/psp2common/types.h
@@ -81,8 +81,8 @@ typedef char* SceName;       //!< Names are used to describe object names
 /** 64-bit system clock type. */
 typedef SceUInt64 SceKernelSysClock;
 
-
-#define SCE_KERNEL_PROCESS_ID_SELF 0  //!< Current running process ID is always 0
+#define SCE_KERNEL_THREAD_ID_SELF  0  //!< Current thread's UID - pass to APIs expecting a thread ID to operate on calling thread
+#define SCE_KERNEL_PROCESS_ID_SELF 0  //!< Current process's UID - pass to APIs expecting a process ID to operate on calling process
 #define SCE_UID_NAMELEN            31 //!< Maximum length for kernel object names
 
 

--- a/include/psp2kern/kernel/threadmgr/thread.h
+++ b/include/psp2kern/kernel/threadmgr/thread.h
@@ -237,8 +237,7 @@ int ksceKernelGetThreadCurrentPriority(void);
 /**
  * Get the free stack size for a thread.
  *
- * @param thid - The thread ID. Seem to take current thread
- * if set to 0.
+ * @param thid - The thread ID
  *
  * @return The free size.
  */


### PR DESCRIPTION
(Reopen of #680)
Also removed comments of confusion related to missing define.
May have missed some.