### PR TITLE
Add missing SceShaccCg functions

### DIFF
--- a/db/360/SceShaccCg.yml
+++ b/db/360/SceShaccCg.yml
@@ -34,8 +34,10 @@ modules:
           sceShaccCgGetSamplerQueryFormatPrecision: 0xA067C481
           sceShaccCgGetSamplerQueryFormatPrecisionCount: 0x268FAEE9
           sceShaccCgGetSamplerQueryFormatWidth: 0xA56B1A5B
+          sceShaccCgGetVersionString: 0x7F430CCD
           sceShaccCgInitializeCallbackList: 0xA8C2C1C8
           sceShaccCgInitializeCompileOptions: 0x3B58AFA0
           sceShaccCgIsParameterReferenced: 0x0E1285A6
           sceShaccCgIsParameterRegFormat: 0xA13A8A1E
+          sceShaccCgReleaseCompiler: 0x95F57A23
           sceShaccCgSetDefaultAllocator: 0x6F01D573

--- a/include/psp2/shacccg.h
+++ b/include/psp2/shacccg.h
@@ -153,6 +153,10 @@ void sceShaccCgInitializeCallbackList(
 void sceShaccCgDestroyCompileOutput(
 	SceShaccCgCompileOutput const *output);
 
+void sceShaccCgReleaseCompiler(void);
+
+const char *sceShaccCgGetVersionString(void);
+
 #ifdef	__cplusplus
 }
 #endif	/* __cplusplus */


### PR DESCRIPTION
Neither of these function names are the official ones.

sceShaccCgReleaseCompiler releases all resources allocated by the compiler. Should be called before unloading the libshacccg module