### PR TITLE
Switch CI builder to latest ubuntu

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,14 +11,11 @@ on:
 jobs:
   check-headers:
     runs-on: ubuntu-latest
-    container: ubuntu:14.04
+    container: ubuntu:20.04
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y software-properties-common
-        sudo add-apt-repository ppa:george-edison55/cmake-3.x
         sudo apt-get update
         sudo apt-get install -y cmake cmake-data git doxygen python curl rsync 
     - name: Check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   check-headers:
     runs-on: ubuntu-latest
-    container: ubuntu:20.04
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies


### PR DESCRIPTION
14.04 is way old. And sdl2 requires cmake 3.11 minimum. 20.04 provides cmake 3.16