### PR TITLE
Add SceKernelMemBlockType typedef

### DIFF
--- a/include/psp2/kernel/sysmem.h
+++ b/include/psp2/kernel/sysmem.h
@@ -46,7 +46,7 @@ typedef struct SceKernelMemBlockInfo {
 	SceSize mappedSize;
 	int memoryType;
 	SceUInt32 access;
-	SceUInt32 type;
+	SceKernelMemBlockType type;
 } SceKernelMemBlockInfo;
 
 typedef enum SceKernelMemoryAccessType {
@@ -70,7 +70,7 @@ typedef enum SceKernelMemoryType {
  *
  * @return SceUID of the memory block on success, < 0 on error.
 */
-SceUID sceKernelAllocMemBlock(const char *name, SceUInt32 type, SceSize size, SceKernelAllocMemBlockOpt *opt);
+SceUID sceKernelAllocMemBlock(const char *name, SceKernelMemBlockType type, SceSize size, SceKernelAllocMemBlockOpt *opt);
 
 /**
  * Frees new memory block

--- a/include/psp2common/kernel/sysmem.h
+++ b/include/psp2common/kernel/sysmem.h
@@ -12,6 +12,7 @@
 extern "C" {
 #endif
 
+typedef SceUInt32 SceKernelMemBlockType;
 
 /*
  * User/Kernel shared memtypes

--- a/include/psp2kern/kernel/sysmem.h
+++ b/include/psp2kern/kernel/sysmem.h
@@ -82,7 +82,7 @@ typedef enum SceKernelModel {
  *
  * @return SceUID of the memory block on success, < 0 on error.
 */
-SceUID ksceKernelAllocMemBlock(const char *name, SceUInt32 type, SceSize size, SceKernelAllocMemBlockKernelOpt *opt);
+SceUID ksceKernelAllocMemBlock(const char *name, SceKernelMemBlockType type, SceSize size, SceKernelAllocMemBlockKernelOpt *opt);
 
 /**
  * Frees new memory block
@@ -142,7 +142,7 @@ SceUID ksceKernelFindMemBlockByAddrForPid(SceUID pid, const void *addr, SceSize 
  *
  * @return 0 on success, < 0 on error.
  */
-int ksceKernelRemapBlock(SceUID uid, SceUInt32 type);
+int ksceKernelRemapBlock(SceUID uid, SceKernelMemBlockType type);
 
 int ksceKernelMapBlockUserVisible(SceUID uid);
 


### PR DESCRIPTION
That last commits removed this typedef entirely breaking many packages. Redefined it by setting it to `typedef SceUInt32 SceKernelMemBlockType;`