### PR TITLE
Consistent header guards

### DIFF
--- a/include/psp2/apputil.h
+++ b/include/psp2/apputil.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_APPUTL_H_
-#define _PSP2_APPUTL_H_
+#ifndef _PSP2_APPUTIL_H_
+#define _PSP2_APPUTIL_H_
 
 #include <psp2/types.h>
 #include <stdint.h>
@@ -243,5 +243,5 @@ int sceAppUtilLaunchWebBrowser(SceAppUtilWebBrowserParam *param);
 }
 #endif
 
-#endif /* _PSP2_APPUTL_H_ */
+#endif /* _PSP2_APPUTIL_H_ */
 

--- a/include/psp2/atrac.h
+++ b/include/psp2/atrac.h
@@ -177,5 +177,5 @@ int sceAtracGetInternalError(int atracHandle, int *pInternalError);
 }
 #endif
 
-#endif
+#endif /* _PSP2_ATRAC_H_ */
 

--- a/include/psp2/audiodec.h
+++ b/include/psp2/audiodec.h
@@ -202,4 +202,4 @@ extern SceInt32 sceAudiodecDeleteDecoderExternal(SceAudiodecCtrl *pCtrl, SceUInt
 }
 #endif
 
-#endif
+#endif /* _PSP2_AUDIODEC_H_ */

--- a/include/psp2/avconfig.h
+++ b/include/psp2/avconfig.h
@@ -87,5 +87,5 @@ int sceAVConfigSetDisplayColorSpaceMode(int csm);
 }
 #endif
 
-#endif
+#endif /* _PSP2_AVCONFIG_H_ */
 

--- a/include/psp2/avplayer.h
+++ b/include/psp2/avplayer.h
@@ -228,4 +228,4 @@ int sceAvPlayerSetTrickSpeed(SceAvPlayerHandle handle, int speed);
 }
 #endif
 
-#endif
+#endif /* _PSP2_AVPLAYER_H_ */

--- a/include/psp2/common_dialog.h
+++ b/include/psp2/common_dialog.h
@@ -128,5 +128,5 @@ int sceCommonDialogUpdate(const SceCommonDialogUpdateParam *updateParam);
 }
 #endif
 
-#endif
+#endif /* _PSP2_COMMON_API_H_ */
 

--- a/include/psp2/common_dialog.h
+++ b/include/psp2/common_dialog.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_COMMON_API_H_
-#define _PSP2_COMMON_API_H_
+#ifndef _PSP2_COMMON_DIALOG_H_
+#define _PSP2_COMMON_DIALOG_H_
 
 #include <string.h>
 #include <psp2/system_param.h>
@@ -128,5 +128,5 @@ int sceCommonDialogUpdate(const SceCommonDialogUpdateParam *updateParam);
 }
 #endif
 
-#endif /* _PSP2_COMMON_API_H_ */
+#endif /* _PSP2_COMMON_DIALOG_H_ */
 

--- a/include/psp2/ctrl.h
+++ b/include/psp2/ctrl.h
@@ -329,4 +329,4 @@ int sceCtrlIsMultiControllerSupported(void);
 }
 #endif
 
-#endif /* _PSP2CTRL_H_ */
+#endif /* _PSP2_CTRL_H_ */

--- a/include/psp2/defs.h
+++ b/include/psp2/defs.h
@@ -9,4 +9,4 @@
 
 #define PSP2_SDK_VERSION 0x03570011
 
-#endif
+#endif /* _PSP2_DEFS_H_ */

--- a/include/psp2/hid.h
+++ b/include/psp2/hid.h
@@ -72,5 +72,5 @@ int sceHidMouseRead(SceUInt32 handle, SceHidMouseReport *reports[], int nReports
 }
 #endif
 
-#endif
+#endif /* _PSP2_HID_H_ */
 

--- a/include/psp2/io/dirent.h
+++ b/include/psp2/io/dirent.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_IO_DRENT_H_
-#define _PSP2_IO_DRENT_H_
+#ifndef _PSP2_IO_DIRENT_H_
+#define _PSP2_IO_DIRENT_H_
 
 #include <psp2/types.h>
 #include <psp2/io/stat.h>
@@ -62,5 +62,5 @@ int sceIoDclose(SceUID fd);
 }
 #endif
 
-#endif /* _PSP2_IO_DRENT_H_ */
+#endif /* _PSP2_IO_DIRENT_H_ */
 

--- a/include/psp2/jpegenc.h
+++ b/include/psp2/jpegenc.h
@@ -3,8 +3,8 @@
  * \usage{psp2/jpegenc.h,SceJpegEnc_stub}
  */
 
-#ifndef _JPEGENC_H_
-#define _JPEGENC_H_
+#ifndef _PSP2_JPEGENC_H_
+#define _PSP2_JPEGENC_H_
 
 #include <psp2/types.h>
 
@@ -160,5 +160,5 @@ int sceJpegEncoderSetHeaderMode(SceJpegEncoderContext context, int mode);
 }
 #endif /* __cplusplus */
 
-#endif /* _JPEGENC_H_ */
+#endif /* _PSP2_JPEGENC_H_ */
 

--- a/include/psp2/jpegenc.h
+++ b/include/psp2/jpegenc.h
@@ -160,5 +160,5 @@ int sceJpegEncoderSetHeaderMode(SceJpegEncoderContext context, int mode);
 }
 #endif /* __cplusplus */
 
-#endif /* _PSP2_JPEGENC_H_ */
+#endif /* _JPEGENC_H_ */
 

--- a/include/psp2/kernel/dmac.h
+++ b/include/psp2/kernel/dmac.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_DMAC_H_
-#define _PSP2_DMAC_H_
+#ifndef _PSP2_KERNEL_DMAC_H_
+#define _PSP2_KERNEL_DMAC_H_
 
 #include <psp2/types.h>
 
@@ -39,4 +39,4 @@ void *sceDmacMemset(void *dst, int c, SceSize size);
 }
 #endif
 
-#endif /* _PSP2_DMAC_H_ */
+#endif /* _PSP2_KERNEL_DMAC_H_ */

--- a/include/psp2/kernel/error.h
+++ b/include/psp2/kernel/error.h
@@ -326,5 +326,5 @@ typedef enum SceKernelErrorCode {
 	SCE_KERNEL_ERROR_NO_AUTH                                     = 0x8002F001
 } SceKernelErrorCode;
 
-#endif
+#endif /* _PSP2_KERNEL_ERROR_H_ */
 

--- a/include/psp2/kernel/openpsid.h
+++ b/include/psp2/kernel/openpsid.h
@@ -21,5 +21,5 @@ int sceKernelGetOpenPsId(SceKernelOpenPsId *id);
 }
 #endif
 
-#endif
+#endif /* _PSP2_KERNEL_OPENPSID_H_ */
 

--- a/include/psp2/kernel/sysmem.h
+++ b/include/psp2/kernel/sysmem.h
@@ -132,5 +132,5 @@ int sceKernelIsPSVitaTV(void);
 }
 #endif
 
-#endif
+#endif /* _PSP2_KERNEL_SYSMEM_H_ */
 

--- a/include/psp2/message_dialog.h
+++ b/include/psp2/message_dialog.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_MSG_DIALOG_H_
-#define _PSP2_MSG_DIALOG_H_
+#ifndef _PSP2_MESSAGE_DIALOG_H_
+#define _PSP2_MESSAGE_DIALOG_H_
 
 #include <psp2/common_dialog.h>
 #include <psp2/types.h>
@@ -199,5 +199,5 @@ int sceMsgDialogProgressBarSetMsg( SceMsgDialogProgressBarTarget target, const S
 }
 #endif
 
-#endif /* _PSP2_MSG_DIALOG_H_ */
+#endif /* _PSP2_MESSAGE_DIALOG_H_ */
 

--- a/include/psp2/message_dialog.h
+++ b/include/psp2/message_dialog.h
@@ -199,5 +199,5 @@ int sceMsgDialogProgressBarSetMsg( SceMsgDialogProgressBarTarget target, const S
 }
 #endif
 
-#endif
+#endif /* _PSP2_MSG_DIALOG_H_ */
 

--- a/include/psp2/musicexport.h
+++ b/include/psp2/musicexport.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_MUSIC_EXPORT_H_
-#define _PSP2_MUSIC_EXPORT_H_
+#ifndef _PSP2_MUSICEXPORT_H_
+#define _PSP2_MUSICEXPORT_H_
 
 #include <psp2/types.h>
 #include <stdint.h>
@@ -24,5 +24,5 @@ int sceMusicExportFromFile(const char* path, const MusicExportParam* param, void
 }
 #endif
 
-#endif /* _PSP2_MUSIC_EXPORT_H_ */
+#endif /* _PSP2_MUSICEXPORT_H_ */
 

--- a/include/psp2/net/netctl.h
+++ b/include/psp2/net/netctl.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_NET_CTL_H_
-#define _PSP2_NET_CTL_H_
+#ifndef _PSP2_NET_NETCTL_H_
+#define _PSP2_NET_NETCTL_H_
 
 #include <psp2/net/net.h>
 
@@ -124,5 +124,5 @@ int sceNetCtlAdhocGetInAddr(SceNetInAddr *inaddr);
 }
 #endif
 
-#endif /* _PSP2_NET_CTL_H_ */
+#endif /* _PSP2_NET_NETCTL_H_ */
 

--- a/include/psp2/netcheck_dialog.h
+++ b/include/psp2/netcheck_dialog.h
@@ -118,5 +118,5 @@ SceInt32 sceNetCheckDialogTerm(void);
 }
 #endif
 
-#endif
+#endif /* _PSP2_NETCHECK_DIALOG_H_ */
 

--- a/include/psp2/photoexport.h
+++ b/include/psp2/photoexport.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_PHOTO_EXPORT_H_
-#define _PSP2_PHOTO_EXPORT_H_
+#ifndef _PSP2_PHOTOEXPORT_H_
+#define _PSP2_PHOTOEXPORT_H_
 
 #include <psp2/types.h>
 #include <stdint.h>
@@ -29,4 +29,4 @@ int scePhotoExportFromFile(const char* path, const PhotoExportParam* param, void
 }
 #endif
 
-#endif /* _PSP2_PHOTO_EXPORT_H_ */
+#endif /* _PSP2_PHOTOEXPORT_H_ */

--- a/include/psp2/pspnet_adhoc.h
+++ b/include/psp2/pspnet_adhoc.h
@@ -143,5 +143,5 @@ int sceNetAdhocGetPtpStat(int *buflen, void *buf);
 }
 #endif
 
-#endif
+#endif /* _PSP2_PSPNET_ADHOC_H_ */
 

--- a/include/psp2/pspnet_adhocctl.h
+++ b/include/psp2/pspnet_adhocctl.h
@@ -78,5 +78,5 @@ int sceNetAdhocctlGetEtherAddr(struct SceNetEtherAddr *addr);
 }
 #endif
 
-#endif
+#endif /* _PSP2_PSPNET_ADHOCCTL_H_ */
 

--- a/include/psp2/shutter_sound.h
+++ b/include/psp2/shutter_sound.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_SHUTTERSOUND_H_
-#define _PSP2_SHUTTERSOUND_H_
+#ifndef _PSP2_SHUTTER_SOUND_H_
+#define _PSP2_SHUTTER_SOUND_H_
 
 #include <stdint.h>
 
@@ -38,5 +38,5 @@ int sceShutterSoundPlay(uint32_t type);
 }
 #endif
 
-#endif /* _PSP2_SHUTTERSOUND_H_ */
+#endif /* _PSP2_SHUTTER_SOUND_H_ */
 

--- a/include/psp2/system_param.h
+++ b/include/psp2/system_param.h
@@ -104,4 +104,4 @@ typedef enum SceSystemParamTimeFormat {
 }
 #endif
 
-#endif
+#endif /* _PSP2_SYSTEM_PARAM_H_ */

--- a/include/psp2/touch.h
+++ b/include/psp2/touch.h
@@ -147,5 +147,5 @@ int sceTouchDisableTouchForce(SceUInt32 port);
 }
 #endif
 
-#endif
+#endif /* _PSP2_TOUCH_H_ */
 

--- a/include/psp2/types.h
+++ b/include/psp2/types.h
@@ -9,4 +9,4 @@
 
 #include <psp2common/types.h>
 
-#endif
+#endif /* _PSP2_TYPES_H_ */

--- a/include/psp2/update.h
+++ b/include/psp2/update.h
@@ -3,8 +3,8 @@
  * \usage{psp2/update.h,SceSblSsUpdateMgr_stub}
  */
 
-#ifndef _PSP2_UPDATE_MGR_H_
-#define _PSP2_UPDATE_MGR_H_
+#ifndef _PSP2_UPDATE_H_
+#define _PSP2_UPDATE_H_
 
 #include <psp2/types.h>
 
@@ -46,4 +46,4 @@ int sceSblUsSetUpdateMode(SceUpdateMode mode);
  */
 int sceSblUsVerifyPup(const char *path);
 
-#endif /* _PSP2_UPDATE_MGR_H_ */
+#endif /* _PSP2_UPDATE_H_ */

--- a/include/psp2/usbserial.h
+++ b/include/psp2/usbserial.h
@@ -86,4 +86,4 @@ unsigned int sceUsbSerialRecv(void *buffer, unsigned int max_len, int unk1, int 
 #ifdef __cplusplus
 }
 #endif
-#endif
+#endif /* _PSP2_USBSERIAL_H_ */

--- a/include/psp2/videoexport.h
+++ b/include/psp2/videoexport.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_VIDEO_EXPORT_H_
-#define _PSP2_VIDEO_EXPORT_H_
+#ifndef _PSP2_VIDEOEXPORT_H_
+#define _PSP2_VIDEOEXPORT_H_
 
 #include <psp2/types.h>
 #include <stdint.h>
@@ -44,4 +44,4 @@ int sceVideoExportFromFile(const VideoExportInputParam* in_param, int unk, void*
 }
 #endif
 
-#endif /* _PSP2_VIDEO_EXPORT_H_ */
+#endif /* _PSP2_VIDEOEXPORT_H_ */

--- a/include/psp2common/kernel/msif.h
+++ b/include/psp2common/kernel/msif.h
@@ -30,4 +30,4 @@ typedef struct SceMsInfo {
 }
 #endif
 
-#endif /* _PSP2_COMMON_TYPES__KERNEL_MSIF_H_ */
+#endif /* _PSP2_COMMON_TYPES_KERNEL_MSIF_H_ */

--- a/include/psp2common/kernel/msif.h
+++ b/include/psp2common/kernel/msif.h
@@ -3,8 +3,8 @@
  * \usage{psp2common/kernel/msif.h}
  */
 
-#ifndef _PSP2_COMMON_TYPES_KERNEL_MSIF_H_
-#define _PSP2_COMMON_TYPES_KERNEL_MSIF_H_
+#ifndef _PSP2COMMON_KERNEL_MSIF_H_
+#define _PSP2COMMON_KERNEL_MSIF_H_
 
 #include <psp2common/types.h>
 
@@ -30,4 +30,4 @@ typedef struct SceMsInfo {
 }
 #endif
 
-#endif /* _PSP2_COMMON_TYPES_KERNEL_MSIF_H_ */
+#endif /* _PSP2COMMON_KERNEL_MSIF_H_ */

--- a/include/psp2common/kernel/sysmem.h
+++ b/include/psp2common/kernel/sysmem.h
@@ -3,8 +3,8 @@
  * \usage{psp2common/kernel/sysmem.h}
  */
 
-#ifndef _PSP2_COMMON_TYPES_KERNEL_SYSMEM_H_
-#define _PSP2_COMMON_TYPES_KERNEL_SYSMEM_H_
+#ifndef _PSP2COMMON_KERNEL_SYSMEM_H_
+#define _PSP2COMMON_KERNEL_SYSMEM_H_
 
 #include <psp2common/types.h>
 
@@ -52,4 +52,4 @@ typedef SceUInt32 SceKernelMemBlockType;
 }
 #endif
 
-#endif /* _PSP2_COMMON_TYPES_KERNEL_SYSMEM_H_ */
+#endif /* _PSP2COMMON_KERNEL_SYSMEM_H_ */

--- a/include/psp2common/types.h
+++ b/include/psp2common/types.h
@@ -3,8 +3,8 @@
  * \usage{psp2common/types.h}
  */
 
-#ifndef _PSP2_COMMON_TYPES_H_
-#define _PSP2_COMMON_TYPES_H_
+#ifndef _PSP2COMMON_TYPES_H_
+#define _PSP2COMMON_TYPES_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -198,4 +198,4 @@ typedef struct SceDateTime {
 }
 #endif
 
-#endif /* _PSP2_COMMON_TYPES_H_ */
+#endif /* _PSP2COMMON_TYPES_H_ */

--- a/include/psp2kern/appmgr.h
+++ b/include/psp2kern/appmgr.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_APPMGR_H_
-#define _PSP2_KERNEL_APPMGR_H_
+#ifndef _PSP2KERN_APPMGR_H_
+#define _PSP2KERN_APPMGR_H_
 
 #include <psp2kern/types.h>
 
@@ -55,4 +55,4 @@ int ksceAppMgrLaunchAppByPath(const char *path, const char *args, SceSize arg_si
 }
 #endif
 
-#endif /* _PSP2_KERNEL_APPMGR_H_ */
+#endif /* _PSP2KERN_APPMGR_H_ */

--- a/include/psp2kern/avcodec/jpegenc.h
+++ b/include/psp2kern/avcodec/jpegenc.h
@@ -128,5 +128,5 @@ int ksceJpegEncoderSetValidRegion(SceJpegEncoderContext context, int inWidth, in
  */
 int ksceJpegEncoderSetHeaderMode(SceJpegEncoderContext context, int mode);
 
-#endif
+#endif /* _PSP2_KERNEL_AVCODEC_JPEGENC_H_ */
 

--- a/include/psp2kern/avcodec/jpegenc.h
+++ b/include/psp2kern/avcodec/jpegenc.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/avcodec/jpegenc.h,SceAvcodecForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_AVCODEC_JPEGENC_H_
-#define _PSP2_KERNEL_AVCODEC_JPEGENC_H_
+#ifndef _PSP2KERN_AVCODEC_JPEGENC_H_
+#define _PSP2KERN_AVCODEC_JPEGENC_H_
 
 #include <psp2kern/types.h>
 
@@ -128,5 +128,5 @@ int ksceJpegEncoderSetValidRegion(SceJpegEncoderContext context, int inWidth, in
  */
 int ksceJpegEncoderSetHeaderMode(SceJpegEncoderContext context, int mode);
 
-#endif /* _PSP2_KERNEL_AVCODEC_JPEGENC_H_ */
+#endif /* _PSP2KERN_AVCODEC_JPEGENC_H_ */
 

--- a/include/psp2kern/bt.h
+++ b/include/psp2kern/bt.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_BT_H_
-#define _PSP2_KERNEL_BT_H_
+#ifndef _PSP2KERN_BT_H_
+#define _PSP2KERN_BT_H_
 
 #include <psp2kern/types.h>
 
@@ -343,4 +343,4 @@ int ksceBtUnregisterCallback(SceUID cb);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_BT_H_ */
+#endif /* _PSP2KERN_BT_H_ */

--- a/include/psp2kern/coredump.h
+++ b/include/psp2kern/coredump.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_COREDUMP_H_
-#define _PSP2_KERNEL_COREDUMP_H_
+#ifndef _PSP2KERN_COREDUMP_H_
+#define _PSP2KERN_COREDUMP_H_
 
 #include <psp2kern/types.h>
 
@@ -38,4 +38,4 @@ typedef int (* SceKernelCoredumpStateFinishCallback)(int task_id, SceUID pid, in
 }
 #endif
 
-#endif /* _PSP2_KERNEL_COREDUMP_H_ */
+#endif /* _PSP2KERN_COREDUMP_H_ */

--- a/include/psp2kern/ctrl.h
+++ b/include/psp2kern/ctrl.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERN_CTRL_H_
-#define _PSP2_KERN_CTRL_H_
+#ifndef _PSP2KERN_CTRL_H_
+#define _PSP2KERN_CTRL_H_
 
 #include <psp2kern/types.h>
 
@@ -343,4 +343,4 @@ int ksceCtrlGetMaskForAll(uint32_t *mask);
 }
 #endif
 
-#endif /* _PSP2_KERN_CTRL_H_ */
+#endif /* _PSP2KERN_CTRL_H_ */

--- a/include/psp2kern/display.h
+++ b/include/psp2kern/display.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_DISPLAY_H_
-#define _PSP2_KERNEL_DISPLAY_H_
+#ifndef _PSP2KERN_DISPLAY_H_
+#define _PSP2KERN_DISPLAY_H_
 
 #include <psp2kern/types.h>
 
@@ -287,5 +287,5 @@ int ksceDisplaySetOwner(int head, int index, SceUID pid);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_DISPLAY_H_ */
+#endif /* _PSP2KERN_DISPLAY_H_ */
 

--- a/include/psp2kern/fios2.h
+++ b/include/psp2kern/fios2.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/fios2.h,SceFios2KernelForDriver}
  */
 
-#ifndef _PSP2_KERNEL_FIOS2KERNEL_H_
-#define _PSP2_KERNEL_FIOS2KERNEL_H_
+#ifndef _PSP2KERN_FIOS2_H_
+#define _PSP2KERN_FIOS2_H_
 
 #include <psp2kern/types.h>
 
@@ -93,4 +93,4 @@ int ksceFiosKernelOverlayResolveSync(SceUID pid, int resolveFlag, const char *in
 }
 #endif
 
-#endif /* _PSP2_KERNEL_FIOS2KERNEL_H_ */
+#endif /* _PSP2KERN_FIOS2_H_ */

--- a/include/psp2kern/idstorage.h
+++ b/include/psp2kern/idstorage.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/idstorage.h,SceIdStorageForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_IDSTORAGE_H_
-#define _PSP2_KERNEL_IDSTORAGE_H_
+#ifndef _PSP2KERN_IDSTORAGE_H_
+#define _PSP2KERN_IDSTORAGE_H_
 
 #include <psp2kern/types.h>
 
@@ -34,4 +34,4 @@ int ksceIdStorageWriteLeaf(SceSize leafnum, const void *buf);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_IDSTORAGE_H_ */
+#endif /* _PSP2KERN_IDSTORAGE_H_ */

--- a/include/psp2kern/io/devctl.h
+++ b/include/psp2kern/io/devctl.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_IO_DEVCTL_H_
-#define _PSP2_IO_DEVCTL_H_
+#ifndef _PSP2KERN_IO_DEVCTL_H_
+#define _PSP2KERN_IO_DEVCTL_H_
 
 #include <psp2kern/types.h>
 
@@ -43,5 +43,5 @@ int ksceIoDevctl(const char *dev, unsigned int cmd, void *indata, int inlen, voi
 }
 #endif
 
-#endif /* _PSP2_IO_DEVCTL_H_ */
+#endif /* _PSP2KERN_IO_DEVCTL_H_ */
 

--- a/include/psp2kern/io/dirent.h
+++ b/include/psp2kern/io/dirent.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_IO_DRENT_H_
-#define _PSP2_IO_DRENT_H_
+#ifndef _PSP2KERN_IO_DIRENT_H_
+#define _PSP2KERN_IO_DIRENT_H_
 
 #include <psp2kern/types.h>
 #include <psp2kern/io/stat.h>
@@ -62,5 +62,5 @@ int ksceIoDclose(SceUID fd);
 }
 #endif
 
-#endif /* _PSP2_IO_DRENT_H_ */
+#endif /* _PSP2KERN_IO_DIRENT_H_ */
 

--- a/include/psp2kern/io/fcntl.h
+++ b/include/psp2kern/io/fcntl.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_IO_FCNTL_H_
-#define _PSP2_IO_FCNTL_H_
+#ifndef _PSP2KERN_IO_FCNTL_H_
+#define _PSP2KERN_IO_FCNTL_H_
 
 #include <psp2kern/types.h>
 #include <psp2kern/kernel/iofilemgr.h>
@@ -272,5 +272,5 @@ int ksceIoCancel(SceUID fd);
 }
 #endif
 
-#endif /* _PSP2_IO_FCNTL_H_ */
+#endif /* _PSP2KERN_IO_FCNTL_H_ */
 

--- a/include/psp2kern/io/stat.h
+++ b/include/psp2kern/io/stat.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_IO_STAT_H_
-#define _PSP2_IO_STAT_H_
+#ifndef _PSP2KERN_IO_STAT_H_
+#define _PSP2KERN_IO_STAT_H_
 
 #include <psp2kern/types.h>
 
@@ -135,5 +135,5 @@ int ksceIoChstatByFd(SceUID fd, SceIoStat *stat, int bits);
 }
 #endif
 
-#endif /* _PSP2_IO_STAT_H_ */
+#endif /* _PSP2KERN_IO_STAT_H_ */
 

--- a/include/psp2kern/kernel/cpu.h
+++ b/include/psp2kern/kernel/cpu.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_CPU_H_
-#define _PSP2_KERNEL_CPU_H_
+#ifndef _PSP2KERN_KERNEL_CPU_H_
+#define _PSP2KERN_KERNEL_CPU_H_
 
 #include <psp2kern/types.h>
 #include <psp2kern/kernel/sysclib.h>
@@ -269,5 +269,5 @@ void ksceKernelCorelockUnlock(SceCorelockContext *ctx);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_CPU_H_ */
+#endif /* _PSP2KERN_KERNEL_CPU_H_ */
 

--- a/include/psp2kern/kernel/debug.h
+++ b/include/psp2kern/kernel/debug.h
@@ -5,8 +5,8 @@
 
 // or SceDebugForKernel_stub
 
-#ifndef _PSP2_KERNEL_DEBUD_H_
-#define _PSP2_KERNEL_DEBUD_H_
+#ifndef _PSP2KERN_KERNEL_DEBUG_H_
+#define _PSP2KERN_KERNEL_DEBUG_H_
 
 #include <psp2kern/types.h>
 #include <stdarg.h>
@@ -196,4 +196,4 @@ int ksceKernelGetTtyInfo(char *buf, SceSize buf_size);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_DEBUD_H_ */
+#endif /* _PSP2KERN_KERNEL_DEBUG_H_ */

--- a/include/psp2kern/kernel/debugled.h
+++ b/include/psp2kern/kernel/debugled.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/debugled.h,SceDebugLedForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_DEBUGLED_H_
-#define _PSP2_KERNEL_DEBUGLED_H_
+#ifndef _PSP2KERN_KERNEL_DEBUGLED_H_
+#define _PSP2KERN_KERNEL_DEBUGLED_H_
 
 #include <psp2kern/types.h>
 
@@ -28,4 +28,4 @@ void ksceDebugLedInvokeHandle1(int a1, int a2, int a3, int a4);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_DEBUGLED_H_ */
+#endif /* _PSP2KERN_KERNEL_DEBUGLED_H_ */

--- a/include/psp2kern/kernel/dipsw.h
+++ b/include/psp2kern/kernel/dipsw.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/dipsw.h,SceDipswForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_DIPSW_H_
-#define _PSP2_KERNEL_DIPSW_H_
+#ifndef _PSP2KERN_KERNEL_DIPSW_H_
+#define _PSP2KERN_KERNEL_DIPSW_H_
 
 #include <psp2kern/types.h>
 
@@ -72,4 +72,4 @@ void ksceKernelClearDipsw(unsigned int bit);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_DIPSW_H_ */
+#endif /* _PSP2KERN_KERNEL_DIPSW_H_ */

--- a/include/psp2kern/kernel/dmac.h
+++ b/include/psp2kern/kernel/dmac.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_DMAC_H_
-#define _PSP2_KERNEL_DMAC_H_
+#ifndef _PSP2KERN_KERNEL_DMAC_H_
+#define _PSP2KERN_KERNEL_DMAC_H_
 
 #include <psp2kern/types.h>
 
@@ -39,4 +39,4 @@ int ksceDmacMemset(void *dst, int c, SceSize size);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_DMAC_H_ */
+#endif /* _PSP2KERN_KERNEL_DMAC_H_ */

--- a/include/psp2kern/kernel/excpmgr.h
+++ b/include/psp2kern/kernel/excpmgr.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_EXCPMGR_H_
-#define _PSP2_KERNEL_EXCPMGR_H_
+#ifndef _PSP2KERN_KERNEL_EXCPMGR_H_
+#define _PSP2KERN_KERNEL_EXCPMGR_H_
 
 #include <psp2kern/types.h>
 
@@ -129,4 +129,4 @@ int ksceExcpmgrRegisterHandler(SceExcpKind kind, int priority, void *handler);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_EXCPMGR_H_ */
+#endif /* _PSP2KERN_KERNEL_EXCPMGR_H_ */

--- a/include/psp2kern/kernel/intrmgr.h
+++ b/include/psp2kern/kernel/intrmgr.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/intrmgr.h,SceIntrmgrForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_INTRMGR_H_
-#define _PSP2_KERNEL_INTRMGR_H_
+#ifndef _PSP2KERN_KERNEL_INTRMGR_H_
+#define _PSP2KERN_KERNEL_INTRMGR_H_
 
 #include <psp2kern/types.h>
 
@@ -74,5 +74,5 @@ int ksceKernelDisableSubIntr(int intr_code, int subintr_code);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_INTRMGR_H_ */
+#endif /* _PSP2KERN_KERNEL_INTRMGR_H_ */
 

--- a/include/psp2kern/kernel/iofilemgr.h
+++ b/include/psp2kern/kernel/iofilemgr.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/iofilemgr.h,SceIofilemgrForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_IOFILEMGR_H_
-#define _PSP2_KERNEL_IOFILEMGR_H_
+#ifndef _PSP2KERN_KERNEL_IOFILEMGR_H_
+#define _PSP2KERN_KERNEL_IOFILEMGR_H_
 
 #include <psp2kern/types.h>
 #include <psp2kern/io/devctl.h>
@@ -114,4 +114,4 @@ int ksceIoGetRemoteKPLSData(SceUID pid, void *dst);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_IOFILEMGR_H_ */
+#endif /* _PSP2KERN_KERNEL_IOFILEMGR_H_ */

--- a/include/psp2kern/kernel/kbl/kbl.h
+++ b/include/psp2kern/kernel/kbl/kbl.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/kbl/kbl.h}
  */
 
-#ifndef _PSP2_KERNEL_KBL_H_
-#define _PSP2_KERNEL_KBL_H_
+#ifndef _PSP2KERN_KERNEL_KBL_KBL_H_
+#define _PSP2KERN_KERNEL_KBL_KBL_H_
 
 #include <psp2kern/types.h>
 #include <psp2kern/kernel/dipsw.h>
@@ -66,4 +66,4 @@ typedef struct SceKblParam { // size is 0x100 or 0x200. must 0x200 on 3.60.
 }
 #endif
 
-#endif /* _PSP2_KERNEL_KBL_H_ */
+#endif /* _PSP2KERN_KERNEL_KBL_KBL_H_ */

--- a/include/psp2kern/kernel/modulemgr.h
+++ b/include/psp2kern/kernel/modulemgr.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/modulemgr.h,SceModulemgrForKernel_stub}
  */
 
-#ifndef _PSP2_KERNEL_MODULEMGR_H_
-#define _PSP2_KERNEL_MODULEMGR_H_
+#ifndef _PSP2KERN_KERNEL_MODULEMGR_H_
+#define _PSP2KERN_KERNEL_MODULEMGR_H_
 
 #include <psp2kern/types.h>
 
@@ -516,4 +516,4 @@ int ksceKernelGetModuleLibraryInfo(SceUID pid, SceUID library_id, SceKernelModul
 }
 #endif
 
-#endif /* _PSP2_KERNEL_MODULEMGR_H_ */
+#endif /* _PSP2KERN_KERNEL_MODULEMGR_H_ */

--- a/include/psp2kern/kernel/msif.h
+++ b/include/psp2kern/kernel/msif.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/msif.h,SceMsifForDriver_stub}
  */
 
-#ifndef _PSP2_KERN_MSIF_H_
-#define _PSP2_KERN_MSIF_H_
+#ifndef _PSP2KERN_KERNEL_MSIF_H_
+#define _PSP2KERN_KERNEL_MSIF_H_
 
 #include <psp2common/kernel/msif.h>
 
@@ -18,5 +18,5 @@ int ksceMsifGetMsInfo(SceMsInfo *info);
 }
 #endif
 
-#endif /* _PSP2_KERN_MSIF_H_ */
+#endif /* _PSP2KERN_KERNEL_MSIF_H_ */
 

--- a/include/psp2kern/kernel/pm_mgr.h
+++ b/include/psp2kern/kernel/pm_mgr.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/pm_mgr.h,ScePmMgrForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_PM_MGR_H_
-#define _PSP2_KERNEL_PM_MGR_H_
+#ifndef _PSP2KERN_KERNEL_PM_MGR_H_
+#define _PSP2KERN_KERNEL_PM_MGR_H_
 
 #include <psp2kern/types.h>
 
@@ -22,4 +22,4 @@ int kscePmMgrIsExternalBootMode(void);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_PM_MGR_H_ */
+#endif /* _PSP2KERN_KERNEL_PM_MGR_H_ */

--- a/include/psp2kern/kernel/proc_event.h
+++ b/include/psp2kern/kernel/proc_event.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/proc_event.h,SceProcEventForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_PROC_EVENT_H_
-#define _PSP2_KERNEL_PROC_EVENT_H_
+#ifndef _PSP2KERN_KERNEL_PROC_EVENT_H_
+#define _PSP2KERN_KERNEL_PROC_EVENT_H_
 
 #include <psp2kern/types.h>
 
@@ -75,4 +75,4 @@ int ksceKernelInvokeProcEventHandler(SceUID pid, int event_id, int event_type, v
 }
 #endif
 
-#endif /* _PSP2_KERNEL_PROC_EVENT_H_ */
+#endif /* _PSP2KERN_KERNEL_PROC_EVENT_H_ */

--- a/include/psp2kern/kernel/processmgr.h
+++ b/include/psp2kern/kernel/processmgr.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_PROCESSMGR_H_
-#define _PSP2_KERNEL_PROCESSMGR_H_
+#ifndef _PSP2KERN_KERNEL_PROCESSMGR_H_
+#define _PSP2KERN_KERNEL_PROCESSMGR_H_
 
 #include <psp2kern/types.h>
 
@@ -114,5 +114,5 @@ int ksceKernelGetProcessSelfAuthInfo(SceUID pid, SceSelfAuthInfo *self_auth_info
 }
 #endif
 
-#endif /* _PSP2_KERNEL_PROCESSMGR_H_ */
+#endif /* _PSP2KERN_KERNEL_PROCESSMGR_H_ */
 

--- a/include/psp2kern/kernel/rtc.h
+++ b/include/psp2kern/kernel/rtc.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/rtc.h,SceRtcForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_RTC_H_
-#define _PSP2_KERNEL_RTC_H_
+#ifndef _PSP2KERN_KERNEL_RTC_H_
+#define _PSP2KERN_KERNEL_RTC_H_
 
 #include <psp2kern/types.h>
 
@@ -71,4 +71,4 @@ int ksceRtcConvertDateTimeToUnixTime(const SceDateTime *src, SceUInt64 *dst);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_RTC_H_ */
+#endif /* _PSP2KERN_KERNEL_RTC_H_ */

--- a/include/psp2kern/kernel/ssmgr.h
+++ b/include/psp2kern/kernel/ssmgr.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/ssmgr.h,SceSblSsMgrForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_SBL_SS_MGR_H_
-#define _PSP2_KERNEL_SBL_SS_MGR_H_
+#ifndef _PSP2KERN_KERNEL_SSMGR_H_
+#define _PSP2KERN_KERNEL_SSMGR_H_
 
 #include <psp2kern/types.h>
 
@@ -61,4 +61,4 @@ int ksceSblSsDecryptWithPortability(SceUInt32 key_type, void *iv, ScePortability
 }
 #endif
 
-#endif /* _PSP2_KERNEL_SBL_SS_MGR_H_ */
+#endif /* _PSP2KERN_KERNEL_SSMGR_H_ */

--- a/include/psp2kern/kernel/suspend.h
+++ b/include/psp2kern/kernel/suspend.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_SUSPEND_H_
-#define _PSP2_KERNEL_SUSPEND_H_
+#ifndef _PSP2KERN_KERNEL_SUSPEND_H_
+#define _PSP2KERN_KERNEL_SUSPEND_H_
 
 #include <psp2kern/types.h>
 
@@ -51,4 +51,4 @@ int ksceKernelRegisterSysEventHandler(const char *name, SceSysEventHandler handl
 }
 #endif
 
-#endif /* _PSP2_KERNEL_SUSPEND_H_ */
+#endif /* _PSP2KERN_KERNEL_SUSPEND_H_ */

--- a/include/psp2kern/kernel/sysclib.h
+++ b/include/psp2kern/kernel/sysclib.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/sysclib.h,SceSysclibForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_SYSCLIB_H_
-#define _PSP2_KERNEL_SYSCLIB_H_
+#ifndef _PSP2KERN_KERNEL_SYSCLIB_H_
+#define _PSP2KERN_KERNEL_SYSCLIB_H_
 
 #include <stdarg.h>
 
@@ -153,4 +153,4 @@ void __stack_chk_fail(void);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_SYSCLIB_H_ */
+#endif /* _PSP2KERN_KERNEL_SYSCLIB_H_ */

--- a/include/psp2kern/kernel/sysmem.h
+++ b/include/psp2kern/kernel/sysmem.h
@@ -294,4 +294,4 @@ int ksceKernelMemRangeReleaseWithPerm(SceKernelMemoryRefPerm perm, void *addr, S
 }
 #endif
 
-#endif
+#endif /* _PSP2_KERNEL_SYSMEM_H_ */

--- a/include/psp2kern/kernel/sysmem.h
+++ b/include/psp2kern/kernel/sysmem.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/sysmem.h,SceSysmemForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_SYSMEM_H_
-#define _PSP2_KERNEL_SYSMEM_H_
+#ifndef _PSP2KERN_KERNEL_SYSMEM_H_
+#define _PSP2KERN_KERNEL_SYSMEM_H_
 
 #include <psp2kern/types.h>
 #include <psp2kern/kernel/sysmem/uid_class.h>
@@ -294,4 +294,4 @@ int ksceKernelMemRangeReleaseWithPerm(SceKernelMemoryRefPerm perm, void *addr, S
 }
 #endif
 
-#endif /* _PSP2_KERNEL_SYSMEM_H_ */
+#endif /* _PSP2KERN_KERNEL_SYSMEM_H_ */

--- a/include/psp2kern/kernel/sysmem/data_transfers.h
+++ b/include/psp2kern/kernel/sysmem/data_transfers.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/sysmem/data_transfers.h,SceSysmemForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_SYSMEM_DATA_TRANSFERS_H_
-#define _PSP2_KERNEL_SYSMEM_DATA_TRANSFERS_H_
+#ifndef _PSP2KERN_KERNEL_SYSMEM_DATA_TRANSFERS_H_
+#define _PSP2KERN_KERNEL_SYSMEM_DATA_TRANSFERS_H_
 
 #include <psp2kern/types.h>
 
@@ -268,4 +268,4 @@ int ksceKernelProcUserMemcpy(SceUID pid, void *dst, const void *src, SceSize len
 }
 #endif
 
-#endif /* _PSP2_KERNEL_SYSMEM_DATA_TRANSFERS_H_ */
+#endif /* _PSP2KERN_KERNEL_SYSMEM_DATA_TRANSFERS_H_ */

--- a/include/psp2kern/kernel/sysmem/data_transfers.h
+++ b/include/psp2kern/kernel/sysmem/data_transfers.h
@@ -268,4 +268,4 @@ int ksceKernelProcUserMemcpy(SceUID pid, void *dst, const void *src, SceSize len
 }
 #endif
 
-#endif
+#endif /* _PSP2_KERNEL_SYSMEM_DATA_TRANSFERS_H_ */

--- a/include/psp2kern/kernel/sysmem/heap.h
+++ b/include/psp2kern/kernel/sysmem/heap.h
@@ -114,4 +114,4 @@ int ksceKernelFree(void *ptr);
 }
 #endif
 
-#endif
+#endif /* _PSP2_KERNEL_SYSMEM_HEAP_H_ */

--- a/include/psp2kern/kernel/sysmem/heap.h
+++ b/include/psp2kern/kernel/sysmem/heap.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/sysmem/heap.h,SceSysmemForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_SYSMEM_HEAP_H_
-#define _PSP2_KERNEL_SYSMEM_HEAP_H_
+#ifndef _PSP2KERN_KERNEL_SYSMEM_HEAP_H_
+#define _PSP2KERN_KERNEL_SYSMEM_HEAP_H_
 
 #include <psp2kern/types.h>
 
@@ -114,4 +114,4 @@ int ksceKernelFree(void *ptr);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_SYSMEM_HEAP_H_ */
+#endif /* _PSP2KERN_KERNEL_SYSMEM_HEAP_H_ */

--- a/include/psp2kern/kernel/sysmem/memtype.h
+++ b/include/psp2kern/kernel/sysmem/memtype.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/sysmem/memtype.h}
  */
 
-#ifndef _PSP2_KERNEL_SYSMEM_MEMTYPE_H_
-#define _PSP2_KERNEL_SYSMEM_MEMTYPE_H_
+#ifndef _PSP2KERN_KERNEL_SYSMEM_MEMTYPE_H_
+#define _PSP2KERN_KERNEL_SYSMEM_MEMTYPE_H_
 
 #include <psp2kern/types.h>
 #include <psp2common/kernel/sysmem.h>
@@ -113,4 +113,4 @@ extern "C" {
 }
 #endif
 
-#endif /* _PSP2_KERNEL_SYSMEM_MEMTYPE_H_ */
+#endif /* _PSP2KERN_KERNEL_SYSMEM_MEMTYPE_H_ */

--- a/include/psp2kern/kernel/sysmem/memtype.h
+++ b/include/psp2kern/kernel/sysmem/memtype.h
@@ -113,4 +113,4 @@ extern "C" {
 }
 #endif
 
-#endif
+#endif /* _PSP2_KERNEL_SYSMEM_MEMTYPE_H_ */

--- a/include/psp2kern/kernel/sysmem/mmu.h
+++ b/include/psp2kern/kernel/sysmem/mmu.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/sysmem/mmu.h,SceSysmemForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_SYSMEM_MMU_H_
-#define _PSP2_KERNEL_SYSMEM_MMU_H_
+#ifndef _PSP2KERN_KERNEL_SYSMEM_MMU_H_
+#define _PSP2KERN_KERNEL_SYSMEM_MMU_H_
 
 #include <psp2kern/types.h>
 
@@ -50,4 +50,4 @@ int ksceKernelSwitchVmaForPid(SceUID pid);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_SYSMEM_MMU_H_ */
+#endif /* _PSP2KERN_KERNEL_SYSMEM_MMU_H_ */

--- a/include/psp2kern/kernel/sysmem/mmu.h
+++ b/include/psp2kern/kernel/sysmem/mmu.h
@@ -50,4 +50,4 @@ int ksceKernelSwitchVmaForPid(SceUID pid);
 }
 #endif
 
-#endif
+#endif /* _PSP2_KERNEL_SYSMEM_MMU_H_ */

--- a/include/psp2kern/kernel/sysmem/uid_class.h
+++ b/include/psp2kern/kernel/sysmem/uid_class.h
@@ -53,4 +53,4 @@ int ksceKernelFindClassByName(const char *name, SceClass **cls);
 }
 #endif
 
-#endif
+#endif /* _PSP2_KERNEL_SYSMEM_UID_CLASS_H_ */

--- a/include/psp2kern/kernel/sysmem/uid_class.h
+++ b/include/psp2kern/kernel/sysmem/uid_class.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/sysmem/uid_class.h,SceSysmemForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_SYSMEM_UID_CLASS_H_
-#define _PSP2_KERNEL_SYSMEM_UID_CLASS_H_
+#ifndef _PSP2KERN_KERNEL_SYSMEM_UID_CLASS_H_
+#define _PSP2KERN_KERNEL_SYSMEM_UID_CLASS_H_
 
 #include <psp2kern/types.h>
 
@@ -53,4 +53,4 @@ int ksceKernelFindClassByName(const char *name, SceClass **cls);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_SYSMEM_UID_CLASS_H_ */
+#endif /* _PSP2KERN_KERNEL_SYSMEM_UID_CLASS_H_ */

--- a/include/psp2kern/kernel/sysmem/uid_guid.h
+++ b/include/psp2kern/kernel/sysmem/uid_guid.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/sysmem/uid_guid.h,SceSysmemForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_SYSMEM_UID_GUID_H_
-#define _PSP2_KERNEL_SYSMEM_UID_GUID_H_
+#ifndef _PSP2KERN_KERNEL_SYSMEM_UID_GUID_H_
+#define _PSP2KERN_KERNEL_SYSMEM_UID_GUID_H_
 
 #include <psp2kern/types.h>
 #include <psp2kern/kernel/sysmem/uid_class.h>
@@ -129,4 +129,4 @@ typedef SceGUIDKernelCreateOpt SceCreateUidObjOpt;
 }
 #endif
 
-#endif /* _PSP2_KERNEL_SYSMEM_UID_GUID_H_ */
+#endif /* _PSP2KERN_KERNEL_SYSMEM_UID_GUID_H_ */

--- a/include/psp2kern/kernel/sysmem/uid_guid.h
+++ b/include/psp2kern/kernel/sysmem/uid_guid.h
@@ -129,4 +129,4 @@ typedef SceGUIDKernelCreateOpt SceCreateUidObjOpt;
 }
 #endif
 
-#endif
+#endif /* _PSP2_KERNEL_SYSMEM_UID_GUID_H_ */

--- a/include/psp2kern/kernel/sysmem/uid_puid.h
+++ b/include/psp2kern/kernel/sysmem/uid_puid.h
@@ -50,4 +50,4 @@ SceUID kscePUIDtoGUID(SceUID pid, SceUID puid);
 }
 #endif
 
-#endif
+#endif /* _PSP2_KERNEL_SYSMEM_UID_PUID_H_ */

--- a/include/psp2kern/kernel/sysmem/uid_puid.h
+++ b/include/psp2kern/kernel/sysmem/uid_puid.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/kernel/sysmem/uid_puid.h,SceSysmemForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_SYSMEM_UID_PUID_H_
-#define _PSP2_KERNEL_SYSMEM_UID_PUID_H_
+#ifndef _PSP2KERN_KERNEL_SYSMEM_UID_PUID_H_
+#define _PSP2KERN_KERNEL_SYSMEM_UID_PUID_H_
 
 #include <psp2kern/types.h>
 
@@ -50,4 +50,4 @@ SceUID kscePUIDtoGUID(SceUID pid, SceUID puid);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_SYSMEM_UID_PUID_H_ */
+#endif /* _PSP2KERN_KERNEL_SYSMEM_UID_PUID_H_ */

--- a/include/psp2kern/kernel/sysroot.h
+++ b/include/psp2kern/kernel/sysroot.h
@@ -5,8 +5,8 @@
 
 // or SceSysrootForKernel_stub
 
-#ifndef _PSP2_KERNEL_SYSROOT_H_
-#define _PSP2_KERNEL_SYSROOT_H_
+#ifndef _PSP2KERN_KERNEL_SYSROOT_H_
+#define _PSP2KERN_KERNEL_SYSROOT_H_
 
 #include <psp2kern/types.h>
 #include <psp2kern/kernel/kbl/kbl.h>
@@ -364,4 +364,4 @@ void ksceKernelSysrootRegisterCoredumpTrigger(SceKernelCoredumpTriggerFunc func)
 }
 #endif
 
-#endif /* _PSP2_KERNEL_SYSROOT_H_ */
+#endif /* _PSP2KERN_KERNEL_SYSROOT_H_ */

--- a/include/psp2kern/kernel/threadmgr.h
+++ b/include/psp2kern/kernel/threadmgr.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_THREADMGR_H_
-#define _PSP2_KERNEL_THREADMGR_H_
+#ifndef _PSP2KERN_KERNEL_THREADMGR_H_
+#define _PSP2KERN_KERNEL_THREADMGR_H_
 
 #include <psp2kern/kernel/threadmgr/thread.h>
 #include <psp2kern/kernel/threadmgr/cond.h>
@@ -20,4 +20,4 @@
 #include <psp2kern/kernel/threadmgr/workqueues.h>
 #include <psp2kern/kernel/threadmgr/debugger.h>
 
-#endif /* _PSP2_KERNEL_THREADMGR_H_ */
+#endif /* _PSP2KERN_KERNEL_THREADMGR_H_ */

--- a/include/psp2kern/kernel/threadmgr/callback.h
+++ b/include/psp2kern/kernel/threadmgr/callback.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_THREADMGR_CALLBACK_H_
-#define _PSP2_KERNEL_THREADMGR_CALLBACK_H_
+#ifndef _PSP2KERN_KERNEL_THREADMGR_CALLBACK_H_
+#define _PSP2KERN_KERNEL_THREADMGR_CALLBACK_H_
 
 #include <psp2kern/types.h>
 
@@ -103,4 +103,4 @@ int ksceKernelCheckCallback(void);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_THREADMGR_CALLBACK_H_ */
+#endif /* _PSP2KERN_KERNEL_THREADMGR_CALLBACK_H_ */

--- a/include/psp2kern/kernel/threadmgr/cond.h
+++ b/include/psp2kern/kernel/threadmgr/cond.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_THREADMGR_COND_H_
-#define _PSP2_KERNEL_THREADMGR_COND_H_
+#ifndef _PSP2KERN_KERNEL_THREADMGR_COND_H_
+#define _PSP2KERN_KERNEL_THREADMGR_COND_H_
 
 #include <psp2kern/types.h>
 
@@ -103,4 +103,4 @@ int ksceKernelSignalCondTo(SceUID condId, SceUID threadId);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_THREADMGR_COND_H_ */
+#endif /* _PSP2KERN_KERNEL_THREADMGR_COND_H_ */

--- a/include/psp2kern/kernel/threadmgr/debugger.h
+++ b/include/psp2kern/kernel/threadmgr/debugger.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_THREADMGR_DEBUGGER_H_
-#define _PSP2_KERNEL_THREADMGR_DEBUGGER_H_
+#ifndef _PSP2KERN_KERNEL_THREADMGR_DEBUGGER_H_
+#define _PSP2KERN_KERNEL_THREADMGR_DEBUGGER_H_
 
 #include <psp2kern/types.h>
 
@@ -157,4 +157,4 @@ int ksceKernelDebugResumeThread(SceUID thid, int status);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_THREADMGR_DEBUGGER_H_ */
+#endif /* _PSP2KERN_KERNEL_THREADMGR_DEBUGGER_H_ */

--- a/include/psp2kern/kernel/threadmgr/event_flags.h
+++ b/include/psp2kern/kernel/threadmgr/event_flags.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_THREADMGR_EVENT_FLAGS_H_
-#define _PSP2_KERNEL_THREADMGR_EVENT_FLAGS_H_
+#ifndef _PSP2KERN_KERNEL_THREADMGR_EVENT_FLAGS_H_
+#define _PSP2KERN_KERNEL_THREADMGR_EVENT_FLAGS_H_
 
 #include <psp2kern/types.h>
 
@@ -145,4 +145,4 @@ int ksceKernelDeleteEventFlag(SceUID evfid);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_THREADMGR_EVENT_FLAGS_H_ */
+#endif /* _PSP2KERN_KERNEL_THREADMGR_EVENT_FLAGS_H_ */

--- a/include/psp2kern/kernel/threadmgr/lw_cond.h
+++ b/include/psp2kern/kernel/threadmgr/lw_cond.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_THREADMGR_LW_COND_H_
-#define _PSP2_KERNEL_THREADMGR_LW_COND_H_
+#ifndef _PSP2KERN_KERNEL_THREADMGR_LW_COND_H_
+#define _PSP2KERN_KERNEL_THREADMGR_LW_COND_H_
 
 #include <psp2kern/types.h>
 #include <psp2kern/kernel/threadmgr/lw_mutex.h>
@@ -39,4 +39,4 @@ int ksceKernelGetLwCondInfo(SceUID lwcond_id, SceKernelLwCondInfo *info);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_THREADMGR_LW_COND_H_ */
+#endif /* _PSP2KERN_KERNEL_THREADMGR_LW_COND_H_ */

--- a/include/psp2kern/kernel/threadmgr/lw_mutex.h
+++ b/include/psp2kern/kernel/threadmgr/lw_mutex.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_THREADMGR_LW_MUTEX_H_
-#define _PSP2_KERNEL_THREADMGR_LW_MUTEX_H_
+#ifndef _PSP2KERN_KERNEL_THREADMGR_LW_MUTEX_H_
+#define _PSP2KERN_KERNEL_THREADMGR_LW_MUTEX_H_
 
 #include <psp2kern/types.h>
 
@@ -46,4 +46,4 @@ int ksceKernelDeleteFastMutex(void *mutex);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_THREADMGR_LW_MUTEX_H_ */
+#endif /* _PSP2KERN_KERNEL_THREADMGR_LW_MUTEX_H_ */

--- a/include/psp2kern/kernel/threadmgr/misc.h
+++ b/include/psp2kern/kernel/threadmgr/misc.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_THREADMGR_MISC_H_
-#define _PSP2_KERNEL_THREADMGR_MISC_H_
+#ifndef _PSP2KERN_KERNEL_THREADMGR_MISC_H_
+#define _PSP2KERN_KERNEL_THREADMGR_MISC_H_
 
 #include <psp2kern/types.h>
 
@@ -118,4 +118,4 @@ int ksceKernelRunWithStack(SceSize stack_size, int (* to_call)(void *), void *ar
 }
 #endif
 
-#endif /* _PSP2_KERNEL_THREADMGR_MISC_H_ */
+#endif /* _PSP2KERN_KERNEL_THREADMGR_MISC_H_ */

--- a/include/psp2kern/kernel/threadmgr/msg_pipe.h
+++ b/include/psp2kern/kernel/threadmgr/msg_pipe.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_THREADMGR_MSG_PIPE_H_
-#define _PSP2_KERNEL_THREADMGR_MSG_PIPE_H_
+#ifndef _PSP2KERN_KERNEL_THREADMGR_MSG_PIPE_H_
+#define _PSP2KERN_KERNEL_THREADMGR_MSG_PIPE_H_
 
 #include <psp2kern/types.h>
 
@@ -139,4 +139,4 @@ int ksceKernelCancelMsgPipe(SceUID uid, int *psend, int *precv);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_THREADMGR_MSG_PIPE_H_ */
+#endif /* _PSP2KERN_KERNEL_THREADMGR_MSG_PIPE_H_ */

--- a/include/psp2kern/kernel/threadmgr/mutex.h
+++ b/include/psp2kern/kernel/threadmgr/mutex.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_THREADMGR_MUTEX_H_
-#define _PSP2_KERNEL_THREADMGR_MUTEX_H_
+#ifndef _PSP2KERN_KERNEL_THREADMGR_MUTEX_H_
+#define _PSP2KERN_KERNEL_THREADMGR_MUTEX_H_
 
 #include <psp2kern/types.h>
 
@@ -123,4 +123,4 @@ int ksceKernelGetMutexInfo(SceUID mutexid, SceKernelMutexInfo *info);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_THREADMGR_MUTEX_H_ */
+#endif /* _PSP2KERN_KERNEL_THREADMGR_MUTEX_H_ */

--- a/include/psp2kern/kernel/threadmgr/semaphores.h
+++ b/include/psp2kern/kernel/threadmgr/semaphores.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_THREADMGR_SEMAPHORE_H_
-#define _PSP2_KERNEL_THREADMGR_SEMAPHORE_H_
+#ifndef _PSP2KERN_KERNEL_THREADMGR_SEMAPHORES_H_
+#define _PSP2KERN_KERNEL_THREADMGR_SEMAPHORES_H_
 
 #include <psp2kern/types.h>
 
@@ -125,4 +125,4 @@ int ksceKernelPollSema(SceUID semaid, int signal);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_THREADMGR_SEMAPHORE_H_ */
+#endif /* _PSP2KERN_KERNEL_THREADMGR_SEMAPHORES_H_ */

--- a/include/psp2kern/kernel/threadmgr/thread.h
+++ b/include/psp2kern/kernel/threadmgr/thread.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_THREADMGR_THREAD_H_
-#define _PSP2_KERNEL_THREADMGR_THREAD_H_
+#ifndef _PSP2KERN_KERNEL_THREADMGR_THREAD_H_
+#define _PSP2KERN_KERNEL_THREADMGR_THREAD_H_
 
 #include <psp2kern/types.h>
 
@@ -248,4 +248,4 @@ int ksceKernelGetThreadStackFreeSize(SceUID thid);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_THREADMGR_THREAD_H_ */
+#endif /* _PSP2KERN_KERNEL_THREADMGR_THREAD_H_ */

--- a/include/psp2kern/kernel/threadmgr/workqueues.h
+++ b/include/psp2kern/kernel/threadmgr/workqueues.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_THREADMGR_WORKQUEUE_H_
-#define _PSP2_KERNEL_THREADMGR_WORKQUEUE_H_
+#ifndef _PSP2KERN_KERNEL_THREADMGR_WORKQUEUES_H_
+#define _PSP2KERN_KERNEL_THREADMGR_WORKQUEUES_H_
 
 #include <psp2kern/types.h>
 
@@ -33,4 +33,4 @@ int ksceKernelEnqueueWorkQueue(SceUID uid, const char *name, SceKernelWorkQueueW
 }
 #endif
 
-#endif /* _PSP2_KERNEL_THREADMGR_WORKQUEUE_H_ */
+#endif /* _PSP2KERN_KERNEL_THREADMGR_WORKQUEUES_H_ */

--- a/include/psp2kern/kernel/utils.h
+++ b/include/psp2kern/kernel/utils.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_UTILS_H_
-#define _PSP2_KERNEL_UTILS_H_
+#ifndef _PSP2KERN_KERNEL_UTILS_H_
+#define _PSP2KERN_KERNEL_UTILS_H_
 
 #include <psp2kern/types.h>
 
@@ -208,4 +208,4 @@ int ksceAesEncrypt2(SceAesContext *ctx, const void *src, void *dst);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_UTILS_H_ */
+#endif /* _PSP2KERN_KERNEL_UTILS_H_ */

--- a/include/psp2kern/lowio/dsi.h
+++ b/include/psp2kern/lowio/dsi.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/lowio/dsi.h,SceDsiForDriver_stub}
  */
 
-#ifndef _PSP2_KERN_LOWIO_DSI_H_
-#define _PSP2_KERN_LOWIO_DSI_H_
+#ifndef _PSP2KERN_LOWIO_DSI_H_
+#define _PSP2KERN_LOWIO_DSI_H_
 
 #include <psp2kern/types.h>
 
@@ -40,5 +40,5 @@ int ksceDsiDcsRead(int head, unsigned short param, void *buff, unsigned int size
 }
 #endif
 
-#endif /* _PSP2_KERN_LOWIO_DSI_H_ */
+#endif /* _PSP2KERN_LOWIO_DSI_H_ */
 

--- a/include/psp2kern/lowio/gpio.h
+++ b/include/psp2kern/lowio/gpio.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/lowio/gpio.h,SceGpioForDriver_stub}
  */
 
-#ifndef _PSP2_KERN_LOWIO_GPIO_H_
-#define _PSP2_KERN_LOWIO_GPIO_H_
+#ifndef _PSP2KERN_LOWIO_GPIO_H_
+#define _PSP2KERN_LOWIO_GPIO_H_
 
 #include <psp2kern/types.h>
 
@@ -43,5 +43,5 @@ int ksceGpioQueryIntr(int bus, int port);
 }
 #endif
 
-#endif /* _PSP2_KERN_LOWIO_GPIO_H_ */
+#endif /* _PSP2KERN_LOWIO_GPIO_H_ */
 

--- a/include/psp2kern/lowio/i2c.h
+++ b/include/psp2kern/lowio/i2c.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/lowio/i2c.h,SceI2cForDriver_stub}
  */
 
-#ifndef _PSP2_KERN_LOWIO_I2C_H_
-#define _PSP2_KERN_LOWIO_I2C_H_
+#ifndef _PSP2KERN_LOWIO_I2C_H_
+#define _PSP2KERN_LOWIO_I2C_H_
 
 #include <psp2kern/types.h>
 
@@ -43,5 +43,5 @@ int ksceI2cSetDebugHandlers(int bus, SceI2cDebugHandlers *debug_handlers);
 }
 #endif
 
-#endif /* _PSP2_KERN_LOWIO_I2C_H_ */
+#endif /* _PSP2KERN_LOWIO_I2C_H_ */
 

--- a/include/psp2kern/lowio/iftu.h
+++ b/include/psp2kern/lowio/iftu.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/lowio/iftu.h,SceIftuForDriver_stub}
  */
 
-#ifndef _PSP2_KERN_LOWIO_IFTU_H_
-#define _PSP2_KERN_LOWIO_IFTU_H_
+#ifndef _PSP2KERN_LOWIO_IFTU_H_
+#define _PSP2KERN_LOWIO_IFTU_H_
 
 #include <psp2kern/types.h>
 
@@ -95,5 +95,5 @@ int ksceIftuCsc(SceIftuFrameBuf *dst, SceIftuPlaneState *src, SceIftuConvParams 
 }
 #endif
 
-#endif /* _PSP2_KERN_LOWIO_IFTU_H_ */
+#endif /* _PSP2KERN_LOWIO_IFTU_H_ */
 

--- a/include/psp2kern/lowio/pervasive.h
+++ b/include/psp2kern/lowio/pervasive.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/lowio/pervasive.h,ScePervasiveForDriver_stub}
  */
 
-#ifndef _PSP2_KERN_LOWIO_PERVASIVE_H_
-#define _PSP2_KERN_LOWIO_PERVASIVE_H_
+#ifndef _PSP2KERN_LOWIO_PERVASIVE_H_
+#define _PSP2KERN_LOWIO_PERVASIVE_H_
 
 #include <psp2kern/types.h>
 
@@ -48,5 +48,5 @@ SceUInt32 kscePervasiveGetSoCRevision(void);
 }
 #endif
 
-#endif /* _PSP2_KERN_LOWIO_PERVASIVE_H_ */
+#endif /* _PSP2KERN_LOWIO_PERVASIVE_H_ */
 

--- a/include/psp2kern/net/net.h
+++ b/include/psp2kern/net/net.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_NET_NET_H_
-#define _PSP2_KERNEL_NET_NET_H_
+#ifndef _PSP2KERN_NET_NET_H_
+#define _PSP2KERN_NET_NET_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -564,4 +564,4 @@ int ksceNetClose(int s);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_NET_NET_H_ */
+#endif /* _PSP2KERN_NET_NET_H_ */

--- a/include/psp2kern/npdrm.h
+++ b/include/psp2kern/npdrm.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/npdrm.h,SceNpDrmForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_NPDRM_H_
-#define _PSP2_KERNEL_NPDRM_H_
+#ifndef _PSP2KERN_NPDRM_H_
+#define _PSP2KERN_NPDRM_H_
 
 #include <psp2kern/types.h>
 
@@ -94,4 +94,4 @@ int ksceNpDrmGetRifInfo(const void *license, SceSize license_size, int check_sig
 }
 #endif
 
-#endif /* _PSP2_KERNEL_NPDRM_H_ */
+#endif /* _PSP2KERN_NPDRM_H_ */

--- a/include/psp2kern/pfsmgr.h
+++ b/include/psp2kern/pfsmgr.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/pfsmgr.h,ScePfsMgrForKernel_stub}
  */
 
-#ifndef _PSP2_KERNEL_PFSMGR_H_
-#define _PSP2_KERNEL_PFSMGR_H_
+#ifndef _PSP2KERN_PFSMGR_H_
+#define _PSP2KERN_PFSMGR_H_
 
 #include <psp2kern/types.h>
 
@@ -57,4 +57,4 @@ int kscePfsDisapprove(const ScePfsRndDriveId *rnd_drive_id, SceUInt64 program_au
 }
 #endif
 
-#endif /* _PSP2_KERNEL_PFSMGR_H_ */
+#endif /* _PSP2KERN_PFSMGR_H_ */

--- a/include/psp2kern/power.h
+++ b/include/psp2kern/power.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/power.h,ScePowerForDriver_stub}
  */
 
-#ifndef _PSP2_KERN_POWER_H_
-#define _PSP2_KERN_POWER_H_
+#ifndef _PSP2KERN_POWER_H_
+#define _PSP2KERN_POWER_H_
 
 #include <psp2kern/types.h>
 
@@ -255,4 +255,4 @@ int kscePowerSetGpuXbarClockFrequency(int freq);
 }
 #endif
 
-#endif /* _PSP2_KERN_POWER_H_ */
+#endif /* _PSP2KERN_POWER_H_ */

--- a/include/psp2kern/registrymgr.h
+++ b/include/psp2kern/registrymgr.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/registrymgr.h,SceRegMgrForDriver_stub}
  */
 
-#ifndef _PSP2_REGISTRYMGR_H_
-#define _PSP2_REGISTRYMGR_H_
+#ifndef _PSP2KERN_REGISTRYMGR_H_
+#define _PSP2KERN_REGISTRYMGR_H_
 
 #include <psp2kern/types.h>
 
@@ -86,4 +86,4 @@ int ksceRegMgrSetKeyStr(const char *category, const char *name, char *buf, SceSi
 }
 #endif
 
-#endif /* _PSP2_REGISTRYMGR_H_ */
+#endif /* _PSP2KERN_REGISTRYMGR_H_ */

--- a/include/psp2kern/sblacmgr.h
+++ b/include/psp2kern/sblacmgr.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/sblacmgr.h,SceSblACMgrForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_SBLACMGR_H_
-#define _PSP2_KERNEL_SBLACMGR_H_
+#ifndef _PSP2KERN_SBLACMGR_H_
+#define _PSP2KERN_SBLACMGR_H_
 
 #include <psp2kern/types.h>
 
@@ -100,4 +100,4 @@ int ksceSblACMgrIsDevelopmentMode(void);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_SBLACMGR_H_ */
+#endif /* _PSP2KERN_SBLACMGR_H_ */

--- a/include/psp2kern/sblaimgr.h
+++ b/include/psp2kern/sblaimgr.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/sblaimgr.h,SceSblAIMgrForDriver_stub}
  */
 
-#ifndef _PSP2_KERNEL_SBLAIMGR_H_
-#define _PSP2_KERNEL_SBLAIMGR_H_
+#ifndef _PSP2KERN_SBLAIMGR_H_
+#define _PSP2KERN_SBLAIMGR_H_
 
 #include <psp2kern/types.h>
 
@@ -113,4 +113,4 @@ int ksceSblAimgrIsGenuineDolce(void);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_SBLAIMGR_H_ */
+#endif /* _PSP2KERN_SBLAIMGR_H_ */

--- a/include/psp2kern/sblauthmgr.h
+++ b/include/psp2kern/sblauthmgr.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_SBLAUTHMGR_H_
-#define _PSP2_KERNEL_SBLAUTHMGR_H_
+#ifndef _PSP2KERN_SBLAUTHMGR_H_
+#define _PSP2KERN_SBLAUTHMGR_H_
 
 #include <psp2kern/types.h>
 
@@ -20,5 +20,5 @@ int ksceSblAuthMgrSetDmac5Key(const void *key, SceSize keylen, int slot_id, int 
 }
 #endif
 
-#endif /* _PSP2_KERNEL_SBLAUTHMGR_H_ */
+#endif /* _PSP2KERN_SBLAUTHMGR_H_ */
 

--- a/include/psp2kern/syscon.h
+++ b/include/psp2kern/syscon.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/syscon.h,SceSysconForDriver_stub}
  */
 
-#ifndef _PSP2_KERN_SYSCON_H_
-#define _PSP2_KERN_SYSCON_H_
+#ifndef _PSP2KERN_SYSCON_H_
+#define _PSP2KERN_SYSCON_H_
 
 #include <psp2kern/types.h>
 
@@ -267,5 +267,5 @@ int ksceSysconGetControlsInfo(SceUInt32 *ctrl);
 }
 #endif
 
-#endif /* _PSP2_KERN_SYSCON_H_ */
+#endif /* _PSP2KERN_SYSCON_H_ */
 

--- a/include/psp2kern/touch.h
+++ b/include/psp2kern/touch.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_TOUCH_H_
-#define _PSP2_KERNEL_TOUCH_H_
+#ifndef _PSP2KERN_TOUCH_H_
+#define _PSP2KERN_TOUCH_H_
 
 #include <psp2kern/types.h>
 
@@ -27,4 +27,4 @@ int ksceTouchSetEnableFlag(SceUInt32 port, SceBool enable);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_TOUCH_H_ */
+#endif /* _PSP2KERN_TOUCH_H_ */

--- a/include/psp2kern/types.h
+++ b/include/psp2kern/types.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/types.h}
  */
 
-#ifndef _PSP2_KERNEL_TYPES_H_
-#define _PSP2_KERNEL_TYPES_H_
+#ifndef _PSP2KERN_TYPES_H_
+#define _PSP2KERN_TYPES_H_
 
 #include <psp2common/types.h>
 
@@ -121,4 +121,4 @@ typedef struct SceSelfAuthInfo { // size is 0x90-bytes
 }
 #endif
 
-#endif /* _PSP2_KERNEL_TYPES_H_ */
+#endif /* _PSP2KERN_TYPES_H_ */

--- a/include/psp2kern/uart.h
+++ b/include/psp2kern/uart.h
@@ -3,8 +3,8 @@
  * \usage{psp2kern/uart.h,SceUartForKernel_stub}
  */
 
-#ifndef _PSP2_KERN_UART_H_
-#define _PSP2_KERN_UART_H_
+#ifndef _PSP2KERN_UART_H_
+#define _PSP2KERN_UART_H_
 
 #include <psp2kern/types.h>
 
@@ -21,5 +21,5 @@ int ksceUartWrite(int port, char data);
 }
 #endif
 
-#endif /* _PSP2_KERN_UART_H_ */
+#endif /* _PSP2KERN_UART_H_ */
 

--- a/include/psp2kern/udcd.h
+++ b/include/psp2kern/udcd.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_UDCD_H_
-#define _PSP2_KERNEL_UDCD_H_
+#ifndef _PSP2KERN_UDCD_H_
+#define _PSP2KERN_UDCD_H_
 
 #include <psp2kern/types.h>
 #include <vitasdk/align.h>
@@ -716,4 +716,4 @@ int ksceUdcdReqRecvInternal(SceUdcdDeviceRequest *req, int bus);
 }
 #endif
 
-#endif /* _PSP2_KERNEL_UDCD_H_ */
+#endif /* _PSP2KERN_UDCD_H_ */

--- a/include/psp2kern/usbd.h
+++ b/include/psp2kern/usbd.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_USBD_H_
-#define _PSP2_KERNEL_USBD_H_
+#ifndef _PSP2KERN_USBD_H_
+#define _PSP2KERN_USBD_H_
 
 #include <psp2kern/kernel/threadmgr.h>
 
@@ -103,4 +103,4 @@ int ksceUsbdInterruptTransfer(int endpoint_id,
 }
 #endif
 
-#endif /* _PSP2_KERNEL_USBD_H_ */
+#endif /* _PSP2KERN_USBD_H_ */

--- a/include/psp2kern/usbserial.h
+++ b/include/psp2kern/usbserial.h
@@ -4,8 +4,8 @@
  */
 
 
-#ifndef _PSP2_KERNEL_USBSERIAL_H_
-#define _PSP2_KERNEL_USBSERIAL_H_
+#ifndef _PSP2KERN_USBSERIAL_H_
+#define _PSP2KERN_USBSERIAL_H_
 
 #include <psp2kern/types.h>
 
@@ -75,4 +75,4 @@ SceSize ksceUsbSerialRecv(void *buffer, SceSize max_len, int unk1, int unk2);
 #ifdef __cplusplus
 }
 #endif
-#endif /* _PSP2_KERNEL_USBSERIAL_H_ */
+#endif /* _PSP2KERN_USBSERIAL_H_ */

--- a/include/psp2kern/usbserial.h
+++ b/include/psp2kern/usbserial.h
@@ -75,4 +75,4 @@ SceSize ksceUsbSerialRecv(void *buffer, SceSize max_len, int unk1, int unk2);
 #ifdef __cplusplus
 }
 #endif
-#endif
+#endif /* _PSP2_KERNEL_USBSERIAL_H_ */

--- a/include/vitasdk.h
+++ b/include/vitasdk.h
@@ -106,4 +106,4 @@
 #include <psp2/net/net_syscalls.h>
 #include <psp2/net/netctl.h>
 
-#endif
+#endif /* _VITASDK_H_ */

--- a/include/vitasdk/align.h
+++ b/include/vitasdk/align.h
@@ -16,4 +16,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif
+#endif /* _VITASDKALIGN_H_ */

--- a/include/vitasdk/align.h
+++ b/include/vitasdk/align.h
@@ -1,5 +1,5 @@
-#ifndef _VITASDKALIGN_H_
-#define _VITASDKALIGN_H_
+#ifndef _VITASDK_ALIGN_H_
+#define _VITASDK_ALIGN_H_
 
 #ifdef  __cplusplus
 extern "C" {
@@ -16,4 +16,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* _VITASDKALIGN_H_ */
+#endif /* _VITASDK_ALIGN_H_ */

--- a/include/vitasdk/utils.h
+++ b/include/vitasdk/utils.h
@@ -1,5 +1,5 @@
-#ifndef _VITASDKUTILS_H_
-#define _VITASDKUTILS_H_
+#ifndef _VITASDK_UTILS_H_
+#define _VITASDK_UTILS_H_
 
 #ifdef  __cplusplus
 extern "C" {
@@ -31,4 +31,4 @@ int vitasdk_delete_thread_reent(SceUID thid);
 #ifdef __cplusplus
 }
 #endif
-#endif /* _VITASDKUTILS_H_ */
+#endif /* _VITASDK_UTILS_H_ */

--- a/include/vitasdk/utils.h
+++ b/include/vitasdk/utils.h
@@ -31,4 +31,4 @@ int vitasdk_delete_thread_reent(SceUID thid);
 #ifdef __cplusplus
 }
 #endif
-#endif
+#endif /* _VITASDKUTILS_H_ */

--- a/include/vitasdkkern.h
+++ b/include/vitasdkkern.h
@@ -67,4 +67,4 @@
 
 #include <psp2kern/net/net.h>
 
-#endif
+#endif /* _VITASDKKERN_H_ */


### PR DESCRIPTION
Came up in #701. Fixes header guard collisions. Corrects and adds `#endif /* <guard name> */` comments.

This PR renames header guards, according to these rules:
1. Directory names must be lowercase and contain only one word;
2. Header file names can contain multiple words separated with underscores, but otherwise are the same as directory names;
3. Header guard names are to be written in uppercase and mimic the path from include directory of the repo.

It allows current naming for header files, but defines consistent naming for the guards. However it would allow guard collisions for files like `module_sub.h` and `module/sub.h`, but that would be not very plausible, i believe. However it isn't required to enforce these rules in the future, i have defined them just for this PR.

