### PR TITLE
Fix owner/others access modes. Null group modes. Convert values to octal

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2059,7 +2059,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2067,7 +2067,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2099,7 +2099,8 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = __cplusplus
+PREDEFINED             = __cplusplus \
+                         SCE_DEPRECATED(x)=x
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/include/psp2common/kernel/iofilemgr.h
+++ b/include/psp2common/kernel/iofilemgr.h
@@ -60,31 +60,44 @@ typedef enum SceIoDevType {
 } SceIoDevType;
 
 
-/** Access modes for st_mode in ::SceIoStat. */
+/**
+  * Access modes for st_mode in ::SceIoStat.
+  *
+  * @note
+  * System always requires RW access.
+  * For safe homebrew system software will force system permission field to RW.
+  * For unsafe homebrew, you need to set it yourself `( mode | SCE_S_IWSYS | SCE_S_IRSYS)`
+  *
+  */
 typedef enum SceIoAccessMode {
-	SCE_S_IXUSR		= 0x0001,  //!< User execute permission
-	SCE_S_IWUSR		= 0x0002,  //!< User write permission
-	SCE_S_IRUSR		= 0x0004,  //!< User read permission
-	SCE_S_IRWXU		= 0x0007,  //!< User access rights mask
+	SCE_S_IXUSR		= 000100, //!< User execute permission
+	SCE_S_IWUSR		= 000200, //!< User write permission
+	SCE_S_IRUSR		= 000400, //!< User read permission
+	SCE_S_IRWXU		= 000700, //!< User access rights mask
 
-	SCE_S_IXGRP		= 0x0008,  //!< Group execute permission
-	SCE_S_IWGRP		= 0x0010,  //!< Group write permission
-	SCE_S_IRGRP		= 0x0020,  //!< Group read permission
-	SCE_S_IRWXG		= 0x0038,  //!< Group access rights mask
+	SCE_S_IXGRP		= 000000, //!< Group execute permission. Ignored and reset to 0 by system
+	SCE_S_IWGRP		= 000000, //!< Group write permission. Ignored and reset to 0 by system
+	SCE_S_IRGRP		= 000000, //!< Group read permission. Ignored and reset to 0 by system
+	SCE_S_IRWXG		= 000000, //!< Group access rights mask. Ignored and reset to 0 by system
 
-	SCE_S_IXOTH		= 0x0040,  //!< Others execute permission
-	SCE_S_IWOTH		= 0x0080,  //!< Others write permission
-	SCE_S_IROTH		= 0x0100,  //!< Others read permission
-	SCE_S_IRWXO		= 0x01C0,  //!< Others access rights mask
+	SCE_S_IXSYS		= 000001, //!< System execute permission
+	SCE_S_IWSYS		= 000002, //!< System write permission
+	SCE_S_IRSYS		= 000004, //!< System read permission
+	SCE_S_IRWXS		= 000007, //!< System access rights mask
 
-	SCE_S_ISVTX		= 0x0200,  //!< Sticky
-	SCE_S_ISGID		= 0x0400,  //!< Set GID
-	SCE_S_ISUID		= 0x0800,  //!< Set UID
+	SCE_DEPRECATED(SCE_S_IXOTH)		= 000001, //!< Others execute permission. Deprecated, use ::SCE_S_IXSYS
+	SCE_DEPRECATED(SCE_S_IWOTH)		= 000002, //!< Others write permission. Deprecated, use ::SCE_S_IXSYS
+	SCE_DEPRECATED(SCE_S_IROTH)		= 000004, //!< Others read permission. Deprecated, use ::SCE_S_IXSYS
+	SCE_DEPRECATED(SCE_S_IRWXO)		= 000007, //!< Others access rights mask. Deprecated, use ::SCE_S_IRWXS
 
-	SCE_S_IFDIR		= 0x1000,  //!< Directory
-	SCE_S_IFREG		= 0x2000,  //!< Regular file
-	SCE_S_IFLNK		= 0x4000,  //!< Symbolic link
-	SCE_S_IFMT		= 0xF000,  //!< Format bits mask
+	SCE_DEPRECATED(SCE_S_ISVTX)		= 000000, //!< Sticky. Deprecated
+	SCE_DEPRECATED(SCE_S_ISGID)		= 000000, //!< Set GID. Deprecated
+	SCE_DEPRECATED(SCE_S_ISUID)		= 000000, //!< Set UID. Deprecated
+
+	SCE_S_IFDIR		= 0010000, //!< Directory
+	SCE_S_IFREG		= 0020000, //!< Regular file
+	SCE_S_IFLNK		= 0040000, //!< Symbolic link
+	SCE_S_IFMT		= 0170000, //!< Format bits mask
 } SceIoAccessMode;
 
 // File mode checking macros

--- a/include/psp2common/types.h
+++ b/include/psp2common/types.h
@@ -18,9 +18,11 @@ extern "C" {
 
 #if defined(_MSC_VER)
 #define SCE_ALIGN(x) __declspec(align(x))
+#define SCE_DEPRECATED(name) __declspec(deprecated) name
 #else
 #if defined(__GNUC__)
 #define SCE_ALIGN(x) __attribute__ ((aligned(x)))
+#define SCE_DEPRECATED(name) name __attribute__ ((deprecated))
 #endif
 #endif
 


### PR DESCRIPTION
1. https://github.com/vitasdk/vita-headers/commit/d111c38703bc6b2323f96a0c055afad124fae0ce was wrong. Modes aren't swapped.
That confusion came from a fact that for "safe" homebrew (without extended perm given by henkaku in https://github.com/henkaku/henkaku/blob/784e483f3a81346ccdd0cef8b5405f899bc91b3c/plugin/kernel.c#L65 )
"other" permission is force-set to RW (e.g. 0600 -> 0606). Can be checked by creating directory from safe homebrew with 0600 mode and then doing sceKernelGetstat on it - it returns 10606.
This doesn't happen with "unsafe" homebrew, mode stays 0600 instead of 0606, and 0 in "other" isn't allowed, so, e.g., creating directory with 0600 access mode will fail.
This is the check that fails https://github.com/Princess-of-Sleeping/PSP2Modules/blob/ce7440d4f6f3561f1f412df4eeb589aabad92f9d/SceSblACMgr/src/acmgr_pfs_attr.c#L478 and also list of possible modes (see below).
2. No modes ever contain "group" access field (see above), moreover, creating directory with, e.g. 0666 and doing sceKernelGetstat yields 10606 - group field is ignored and isn't set. Thus group modes were set to 0.
3. All values were converted from hex to octal, because, well, access modes *are* octal and that makes it more readable.
4. there's no sticky/uid/guid bits. well, vita doesn't even have a concept of users/groups. So those were removed.