### PR TITLE
fix: `SceKernelTimeval` fields

### DIFF
--- a/include/psp2/kernel/processmgr.h
+++ b/include/psp2/kernel/processmgr.h
@@ -112,7 +112,8 @@ SceKernelClock sceKernelLibcClock(void);
 SceKernelTime sceKernelLibcTime(SceKernelTime *tloc);
 
 typedef struct SceKernelTimeval {
-	SceUInt64 value;
+	SceInt32 sec;
+	SceInt32 usec;
 } SceKernelTimeval;
 
 typedef struct SceKernelTimezone {


### PR DESCRIPTION
Based upon boost's `xtime` definition and implementation of `_Thrd_sleep`.