### PR TITLE
Usb

### DIFF
--- a/db/360/SceSyscon.yml
+++ b/db/360/SceSyscon.yml
@@ -21,7 +21,9 @@ modules:
           ksceSysconCmdSync: 0x6E517D22
           ksceSysconCommitConfigstorageTransaction: 0x7B9B3617
           ksceSysconCtrlAccPower: 0x8D1D97E8
+          ksceSysconCtrlDevKitUsbPower: 0xB1F88B11
           ksceSysconCtrlDeviceReset: 0x40FF3898
+          ksceSysconCtrlDolceUsbPower: 0x3274A925
           ksceSysconCtrlHdmiCecPower: 0x62155962
           ksceSysconCtrlHostOutputViaDongle: 0xDECCB2B4
           ksceSysconCtrlLED: 0x04EC7579
@@ -78,5 +80,3 @@ modules:
           ksceSysconUpdaterSetSegment: 0x9B00BC7F
           ksceSysconVerifyConfigstorageScript: 0xCC6F90A8
           ksceSysconWaitInitialized: 0x55DF1C9B
-          ksceSysconCtrlDolceUsbPower: 0x3274A925
-          ksceSysconCtrlDevKitUsbPower: 0xB1F88B11

--- a/db/360/SceSyscon.yml
+++ b/db/360/SceSyscon.yml
@@ -78,3 +78,5 @@ modules:
           ksceSysconUpdaterSetSegment: 0x9B00BC7F
           ksceSysconVerifyConfigstorageScript: 0xCC6F90A8
           ksceSysconWaitInitialized: 0x55DF1C9B
+          ksceSysconCtrlDolceUsbPower: 0x3274A925
+          ksceSysconCtrlDevKitUsbPower: 0xB1F88B11

--- a/db/360/SceUsbServ.yml
+++ b/db/360/SceUsbServ.yml
@@ -10,3 +10,14 @@ modules:
         functions:
           sceUsbServAccessoryActivate: 0xB33AA2EB
           sceUsbServAccessoryDeactivate: 0x154246A9
+      SceUsbServForDriver:
+        kernel: true
+        nid: 0xA75BBDF2
+        functions:
+          ksceUsbServEtherEnable: 0x30AE5F66
+          ksceUsbServEtherDisable: 0xD787B191
+          ksceUsbServAccessoryActivate: 0xAA6D4409
+          ksceUsbServAccessoryDeactivate: 0x853CB8E4
+          ksceUsbServMacSelect: 0x7AD36284
+          ksceUsbServMacGet: 0xF0553A69
+          ksceUsbServDisableEtherSuspend: 0x6D738018

--- a/db/360/SceUsbServ.yml
+++ b/db/360/SceUsbServ.yml
@@ -14,10 +14,10 @@ modules:
         kernel: true
         nid: 0xA75BBDF2
         functions:
-          ksceUsbServEtherEnable: 0x30AE5F66
-          ksceUsbServEtherDisable: 0xD787B191
           ksceUsbServAccessoryActivate: 0xAA6D4409
           ksceUsbServAccessoryDeactivate: 0x853CB8E4
-          ksceUsbServMacSelect: 0x7AD36284
-          ksceUsbServMacGet: 0xF0553A69
           ksceUsbServDisableEtherSuspend: 0x6D738018
+          ksceUsbServEtherDisable: 0xD787B191
+          ksceUsbServEtherEnable: 0x30AE5F66
+          ksceUsbServMacGet: 0xF0553A69
+          ksceUsbServMacSelect: 0x7AD36284

--- a/db/360/SceUsbd.yml
+++ b/db/360/SceUsbd.yml
@@ -8,27 +8,27 @@ modules:
         kernel: true
         nid: 0xA0EBCA41
         functions:
+          ksceUsbdBulkTransfer: 0x235C094A
+          ksceUsbdBulkTransfer2: 0x470D5289
           ksceUsbdClosePipe: 0xF304DC5C
           ksceUsbdControlTransfer: 0x2E05660F
-          ksceUsbdScanStaticDescriptor: 0xBC3EF82B
+          ksceUsbdGetDeviceLocation: 0x0E73D253
+          ksceUsbdGetDeviceSpeed: 0xC3BECF5F
+          ksceUsbdHostStart: 0x5E301E18
+          ksceUsbdHostStop: 0x3C3396BB
           ksceUsbdInterruptTransfer: 0xA0BF85B8
+          ksceUsbdIsochronousTransfer: 0x2249BF99
           ksceUsbdOpenPipe: 0x1CDBFF9F
           ksceUsbdRegisterCompositeLdd: 0x6E53D7F4
           ksceUsbdRegisterDriver: 0x1EC94F18
+          ksceUsbdResume: 0x206634f9
+          ksceUsbdScanStaticDescriptor: 0xBC3EF82B
+          ksceUsbdSuspend: 0x3EBF5FFE
           ksceUsbdSuspendPhase2: 0xD7AA730D
+          ksceUsbdUnregisterCompositeLdd: 0x7934bb4a
           ksceUsbdUnregisterDriver: 0x216F108D
           ksceUsbd_05073925: 0x05073925
-          ksceUsbdGetDeviceLocation: 0x0E73D253
-          ksceUsbdResume: 0x206634f9
-          ksceUsbdIsochronousTransfer: 0x2249BF99
-          ksceUsbdBulkTransfer: 0x235C094A
-          ksceUsbdHostStop: 0x3C3396BB
-          ksceUsbdSuspend: 0x3EBF5FFE
-          ksceUsbdBulkTransfer2: 0x470D5289
-          ksceUsbdHostStart: 0x5E301E18
-          ksceUsbdUnregisterCompositeLdd: 0x7934bb4a
           ksceUsbd_7938DAC7: 0x7938DAC7
-          ksceUsbdGetDeviceSpeed: 0xC3BECF5F
       SceUsbdForUser:
         kernel: false
         nid: 0xC3AEAB67

--- a/db/360/SceUsbd.yml
+++ b/db/360/SceUsbd.yml
@@ -8,15 +8,27 @@ modules:
         kernel: true
         nid: 0xA0EBCA41
         functions:
-          ksceUsbdCloseEndpoint: 0xF304DC5C
+          ksceUsbdClosePipe: 0xF304DC5C
           ksceUsbdControlTransfer: 0x2E05660F
-          ksceUsbdGetDescriptor: 0xBC3EF82B
+          ksceUsbdScanStaticDescriptor: 0xBC3EF82B
           ksceUsbdInterruptTransfer: 0xA0BF85B8
-          ksceUsbdOpenEndpoint: 0x1CDBFF9F
+          ksceUsbdOpenPipe: 0x1CDBFF9F
           ksceUsbdRegisterCompositeLdd: 0x6E53D7F4
           ksceUsbdRegisterDriver: 0x1EC94F18
           ksceUsbdSuspendPhase2: 0xD7AA730D
           ksceUsbdUnregisterDriver: 0x216F108D
+          ksceUsbdForDriver_05073925: 0x05073925
+          ksceUsbdGetDeviceLocation: 0x0E73D253
+          ksceUsbdResume: 0x206634f9
+          ksceUsbdIsochronousTransfer: 0x2249BF99
+          ksceUsbdBulkTransfer: 0x235C094A
+          ksceUsbdHostStop: 0x3C3396BB
+          ksceUsbdSuspend: 0x3EBF5FFE
+          ksceUsbdBulkTransfer2: 0x470D5289
+          ksceUsbdHostStart: 0x5E301E18
+          ksceUsbdUnregisterCompositeLdd: 0x7934bb4a
+          ksceUsbdForDriver_7938DAC7: 0x7938DAC7
+          ksceUsbdGetDeviceSpeed: 0xC3BECF5F
       SceUsbdForUser:
         kernel: false
         nid: 0xC3AEAB67

--- a/db/360/SceUsbd.yml
+++ b/db/360/SceUsbd.yml
@@ -17,7 +17,7 @@ modules:
           ksceUsbdRegisterDriver: 0x1EC94F18
           ksceUsbdSuspendPhase2: 0xD7AA730D
           ksceUsbdUnregisterDriver: 0x216F108D
-          ksceUsbdForDriver_05073925: 0x05073925
+          ksceUsbd_05073925: 0x05073925
           ksceUsbdGetDeviceLocation: 0x0E73D253
           ksceUsbdResume: 0x206634f9
           ksceUsbdIsochronousTransfer: 0x2249BF99
@@ -27,7 +27,7 @@ modules:
           ksceUsbdBulkTransfer2: 0x470D5289
           ksceUsbdHostStart: 0x5E301E18
           ksceUsbdUnregisterCompositeLdd: 0x7934bb4a
-          ksceUsbdForDriver_7938DAC7: 0x7938DAC7
+          ksceUsbd_7938DAC7: 0x7938DAC7
           ksceUsbdGetDeviceSpeed: 0xC3BECF5F
       SceUsbdForUser:
         kernel: false

--- a/docs/definitions.dox
+++ b/docs/definitions.dox
@@ -366,6 +366,9 @@
  *     \defgroup SceUsbd USB Driver Library
  *      Control USB driver interface
  *
+ *     \defgroup SceUsbServ USB Service library
+ *      Control USB bus
+ *
  *     \defgroup SceUdcd USB Device Controller Driver Library
  *      Setting, control UDCD
  *

--- a/include/psp2/usbd.h
+++ b/include/psp2/usbd.h
@@ -7,89 +7,505 @@
 #ifndef _PSP2_USBD_H_
 #define _PSP2_USBD_H_
 
-#include <psp2/kernel/threadmgr.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef enum SceUsbdErrorCode {
-	SCE_USBD_ERROR_IO            = 0x80240001,
-	SCE_USBD_ERROR_INVALID_ARG   = 0x80240002,
-	SCE_USBD_ERROR_ACCESS        = 0x80240003,
-	SCE_USBD_ERROR_NO_DEVICE     = 0x80240004,
-	SCE_USBD_ERROR_NOT_FOUND     = 0x80240005,
-	SCE_USBD_ERROR_BUSY          = 0x80240006,
-	SCE_USBD_ERROR_TIMEOUT       = 0x80240007,
-	SCE_USBD_ERROR_OVERFLOW      = 0x80240008,
-	SCE_USBD_ERROR_PIPE          = 0x80240009,
-	SCE_USBD_ERROR_INTERRUPTED   = 0x8024000A,
-	SCE_USBD_ERROR_NO_MEM        = 0x8024000B,
-	SCE_USBD_ERROR_NOT_SUPPORTED = 0x8024000C,
-	SCE_USBD_ERROR_FATAL         = 0x802400FF
+    SCE_USBD_ERROR_NOT_INITIALIZED     = 0x80240001,
+    SCE_USBD_ERROR_ALREADY_INITIALIZED = 0x80240002,
+    SCE_USBD_ERROR_INVALID_PARAM       = 0x80240003,
+
+    SCE_USBD_ERROR_PIPE_NOT_FOUND      = 0x80240004,
+
+    SCE_USBD_ERROR_NO_MEMORY           = 0x80240005,
+    SCE_USBD_ERROR_DEVICE_NOT_FOUND    = 0x80240006,
+
+    SCE_USBD_ERROR_80240007            = 0x80240007, //
+    SCE_USBD_ERROR_80240009            = 0x80240009, //
+    SCE_USBD_ERROR_8024000A            = 0x8024000A, //
+
+    SCE_USBD_ERROR_FATAL               = 0x802400FF
 } SceUsbdErrorCode;
 
 typedef struct SceUsbdDeviceInfo {
-	unsigned int unk0;
-	unsigned int device_id;
-	unsigned int unk2;
-} SceUsbdDeviceInfo; /* size = 0xC */
-
-typedef struct SceUsbdDeviceAddress {
-	unsigned int unk0;
-	unsigned short unk1;
-} SceUsbdDeviceAddress; /* size = 0x6 */
+    unsigned int port;
+    unsigned int device_num;
+    unsigned int unk3; // handled? 0, 1, 2
+} SceUsbdDeviceInfo;
 
 typedef struct SceUsbdTransferData {
-	unsigned int pipe;
-	const void *buff1;
-	unsigned int size1;
-	void *buff2;
-	unsigned int size2;
+    unsigned int pipe; // 0x00
+    const void *data; // 0x04
+    unsigned int data_size;  // 0x08
+    void *transferred; //  // 0x0C // ptr to 8 bytes?
+    unsigned int timeout;  // 0x10 // size of above ptr? only 8 allowed?
 } SceUsbdTransferData; /* size = 0x14 */
 
 typedef struct SceUsbdReceiveEvent {
-	unsigned int unk0;
-	unsigned int unk1;
-	unsigned int unk2;
-	unsigned int unk3;
-	unsigned int unk4;
-	unsigned int unk5;
-	unsigned int transfer_id;
+    unsigned int unk0; // 0
+    unsigned int unk1; // next ptr?
+    unsigned int unk2; // != 8, set to 1, 2, 4? // transfer flags? type?
+    unsigned int unk3; // ??
+    unsigned int unk4; // ??
+    unsigned int unk5; // ??
+    unsigned int transfer_id; // ??
 } SceUsbdReceiveEvent; /* size = 0x1C */
 
+typedef struct SceUsbdDeviceAddress {
+        unsigned int unk0;
+        unsigned short unk1;
+} SceUsbdDeviceAddress; /* size = 0x6 */
+
+#define USB_DESCRIPTOR_DEVICE                   0x01    // bDescriptorType for a Device Descriptor.
+#define USB_DESCRIPTOR_CONFIGURATION            0x02    // bDescriptorType for a Configuration Descriptor.
+#define USB_DESCRIPTOR_STRING                   0x03    // bDescriptorType for a String Descriptor.
+#define USB_DESCRIPTOR_INTERFACE                0x04    // bDescriptorType for an Interface Descriptor.
+#define USB_DESCRIPTOR_ENDPOINT                 0x05    // bDescriptorType for an Endpoint Descriptor.
+
+#define USB_DESCRIPTOR_DEVICE_QUALIFIER         0x06    // bDescriptorType for a Device Qualifier.
+#define USB_DESCRIPTOR_OTHER_SPEED              0x07    // bDescriptorType for a Other Speed Configuration.
+#define USB_DESCRIPTOR_INTERFACE_POWER          0x08    // bDescriptorType for Interface Power.
+#define USB_DESCRIPTOR_OTG                      0x09    // bDescriptorType for an OTG Descriptor.
+
+/**
+ * Init usb subsystem
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param[out] uid Pointer to uid
+ *
+ */
 int sceUsbdInit(SceUID *uid);
+
+/**
+ * Stop usb subsystem
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param uid uid
+ *
+ */
 int sceUsbdEnd(SceUID uid);
 
-int sceUsbdRegisterCallback(SceUID cbid, int);
+/**
+ * Get usb devices list
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[in] num max number of devices to return (8 max)
+ * @param[out] info pointer to receive device info
+ *
+ */
+int sceUsbdGetDeviceList(SceUID uid, SceSize num, SceUsbdDeviceInfo *info); // 8 devices max
+
+
+/**
+ * Get usb device descriptors data size
+ *
+ * @return size on success, < 0 on error
+ *
+ * @param uid uid
+ * @param device_id device id
+ *
+ */
+int sceUsbdGetDescriptorSize(SceUID uid, unsigned int device_id);
+
+/**
+ * Get usb device descriptors (all)
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[in] device_id device id
+ * @param[out] descriptor buffer for descriptor data
+ * @param[in] size buffer size
+ *
+ */
+int sceUsbdGetDescriptor(SceUID uid, SceUID device_id, unsigned char *descriptor, SceSize size);
+
+#define SCE_USBD_CLASS_PER_INTERFACE                 0x00
+#define SCE_USBD_CLASS_AUDIO                         0x01
+#define SCE_USBD_CLASS_COMMUNICATIONS                0x02
+#define SCE_USBD_CLASS_HID                           0x03
+#define SCE_USBD_CLASS_MONITOR                       0x04
+#define SCE_USBD_CLASS_PHYSICAL                      0x05
+#define SCE_USBD_CLASS_POWER                         0x06
+#define SCE_USBD_CLASS_PRINTER                       0x07
+#define SCE_USBD_CLASS_STORAGE                       0x08
+#define SCE_USBD_CLASS_HUB                           0x09
+#define SCE_USBD_CLASS_DATA                          0x0a
+#define SCE_USBD_CLASS_VENDOR_SPECIFIC               0xff
+
+typedef enum SceUsbdDescriptorType {
+    SCE_USBD_DESCRIPTOR_DEVICE            = 0x01,    // bDescriptorType for a Device Descriptor.
+    SCE_USBD_DESCRIPTOR_CONFIGURATION     = 0x02,    // bDescriptorType for a Configuration Descriptor.
+    SCE_USBD_DESCRIPTOR_STRING            = 0x03,    // bDescriptorType for a String Descriptor.
+    SCE_USBD_DESCRIPTOR_INTERFACE         = 0x04,    // bDescriptorType for an Interface Descriptor.
+    SCE_USBD_DESCRIPTOR_ENDPOINT          = 0x05,    // bDescriptorType for an Endpoint Descriptor.
+
+    SCE_USBD_DESCRIPTOR_DEVICE_QUALIFIER  = 0x06,    // bDescriptorType for a Device Qualifier.
+    SCE_USBD_DESCRIPTOR_OTHER_SPEED       = 0x07,    // bDescriptorType for a Other Speed Configuration.
+    SCE_USBD_DESCRIPTOR_INTERFACE_POWER   = 0x08,    // bDescriptorType for Interface Power.
+    SCE_USBD_DESCRIPTOR_OTG               = 0x09,    // bDescriptorType for an OTG Descriptor.
+    SCE_USBD_DESCRIPTOR_HID               = 0x21,    // bDescriptorType for an HID descriptor.
+    SCE_USBD_DESCRIPTOR_REPORT            = 0x22     // bDescriptorType for an HID report descriptor.
+} SceUsbdDescriptorType;
+
+typedef struct SceUsbdDeviceDescriptor {
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint16_t bcdUSB;
+    uint8_t bDeviceClass;
+    uint8_t bDeviceSubclass;
+    uint8_t bDeviceProtocol;
+    uint8_t bMaxPacketSize0;
+    uint16_t idVendor;
+    uint16_t idProduct;
+    uint16_t bcdDevice;
+    uint8_t iManufacturer;
+    uint8_t iProduct;
+    uint8_t iSerialNumber;
+    uint8_t bNumConfigurations;
+} SceUsbdDeviceDescriptor;
+
+typedef struct SceUsbdConfigurationDescriptor {
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint16_t wTotalLength;
+    uint8_t bNumInterfaces;
+    uint8_t bConfigurationValue;
+    uint8_t iConfiguration;
+    uint8_t bmAttributes;
+    uint8_t MaxPower;
+} SceUsbdConfigurationDescriptor;
+
+#define SCE_USBD_CONFIGURATION_RESERVED_ZERO         0x1f
+#define SCE_USBD_CONFIGURATION_REMOTE_WAKEUP         0x20
+#define SCE_USBD_CONFIGURATION_SELF_POWERED          0x40
+#define SCE_USBD_CONFIGURATION_RESERVED_ONE          0x80
+
+typedef struct SceUsbdInterfaceDescriptor {
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint8_t bInterfaceNumber;
+    uint8_t bAlternateSetting;
+    uint8_t bNumEndpoints;
+    uint8_t bInterfaceClass;
+    uint8_t bInterfaceSubclass;
+    uint8_t bInterfaceProtocol;
+    uint8_t iInterface;
+} SceUsbdInterfaceDescriptor;
+
+typedef struct SceUsbdEndpointDescriptor {
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint8_t bEndpointAddress;
+    uint8_t bmAttributes;
+    uint16_t wMaxPacketSize;
+    uint8_t bInterval;
+} SceUsbdEndpointDescriptor;
+
+/* bmAttributes */
+#define SCE_USBD_ENDPOINT_TRANSFER_TYPE_BITS         0x03
+#define SCE_USBD_ENDPOINT_TRANSFER_TYPE_SHIFT        0
+#define SCE_USBD_ENDPOINT_TRANSFER_TYPE_CONTROL      0x00
+
+#define SCE_USBD_ENDPOINT_TRANSFER_TYPE_ISOCHRONOUS  0x01
+#define SCE_USBD_ENDPOINT_TRANSFER_TYPE_BULK         0x02
+#define SCE_USBD_ENDPOINT_TRANSFER_TYPE_INTERRUPT    0x03
+
+/* bEndpointAddress */
+#define SCE_USBD_ENDPOINT_NUMBER_BITS                0x1f
+#define SCE_USBD_ENDPOINT_NUMBER_SHIFT               0
+#define SCE_USBD_ENDPOINT_DIRECTION_BITS             0x80
+#define SCE_USBD_ENDPOINT_DIRECTION_SHIFT            7
+#define SCE_USBD_ENDPOINT_DIRECTION_OUT              0x00
+#define SCE_USBD_ENDPOINT_DIRECTION_IN               0x80
+
+typedef struct SceUsbdStringDescriptor {
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint8_t bString[0];
+} SceUsbdStringDescriptor;
+
+typedef struct SceUsbdHidSubDescriptorInfo {
+    uint8_t bDescriptorType;
+    uint8_t wDescriptorLength0;
+    uint8_t wDescriptorLength1;
+} SceUsbdHidSubDescriptorInfo;
+
+typedef struct SceUsbdHidDescriptor {
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint8_t bcdHID0;
+    uint8_t bcdHID1;
+    uint8_t bCountryCode;
+    uint8_t bNumDescriptors;  /* SubDescriptor count */
+    SceUsbdHidSubDescriptorInfo SubDescriptorInfo[0];
+} SceUsbdHidDescriptor;
+
+
+/**
+ * Get usb device speed
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[in] device_id device id
+ * @param[out] speed device speed
+ *
+ */
+int sceUsbdGetDeviceSpeed(SceUID uid, SceUID device_id, unsigned int *speed);
+#define SCE_USBD_DEVICE_SPEED_LS   (0)
+#define SCE_USBD_DEVICE_SPEED_FS   (1)
+#define SCE_USBD_DEVICE_SPEED_HS   (2)
+
+/**
+ * Register callback to usb event
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param[in] cbid callback uid
+ * @param[in] flag if 1 - trigger events immediately
+ *
+ * @note there may be only one callback registered through whole system.
+ *       And it's currently taken up by shell.
+ *
+ */
+int sceUsbdRegisterCallback(SceUID cbid, int flag);
+
+/**
+ * Remove callback to usb event
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param[in] cbid callback uid
+ *
+ * @note this checks process id
+ *
+ */
 int sceUsbdUnregisterCallback(SceUID cbid);
 
-int sceUsbdResetDevice(SceUID uid, unsigned int device_id);
-int sceUsbdAttach(SceUID uid, int, int, int);
+/**
+ * Reset usb device
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[in] device_id device id
+ *
+ */
+int sceUsbdResetDevice(SceUID uid, SceUID device_id);
 
-int sceUsbdGetDeviceList(SceUID uid, unsigned int num, SceUsbdDeviceInfo *info);
-int sceUsbdGetDescriptor(SceUID uid, unsigned int device_id, unsigned char *descriptor, unsigned int size);
-int sceUsbdGetDescriptorSize(SceUID uid, unsigned int device_id);
-int sceUsbdGetDeviceAddress(SceUID uid, unsigned int device_id, SceUsbdDeviceAddress *addr);
-int sceUsbdGetDeviceSpeed(SceUID uid, unsigned int device_id, unsigned int *speed);
-int sceUsbdGetTransferStatus(SceUID uid, unsigned char buff[0x10]);
-int sceUsbdGetIsochTransferStatus(SceUID uid, unsigned char buff[0x10]);
+/**
+ * Attach specified driver to device
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[in] driver_id driver id (result of Register(Composite)Ldd)
+ * @param[in] bus usb port number
+ * @param[in] device usb device number
+ *
+ * @note device_id = (bus << 16) + device
+ */
+int sceUsbdAttach(SceUID uid, SceUID driver_id, SceUInt bus, SceUInt device);
 
-int sceUsbdOpenDefaultPipe(SceUID uid, unsigned int device_id);
-int sceUsbdOpenPipe(SceUID uid, unsigned char unk[0x18]);
-int sceUsbdClosePipe(SceUID uid, unsigned int device_id);
+/**
+ * Get device address
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[in] device_id device id
+ * @param[out] addr buffer for return value
+ *
+ * @note it is unknown what that function actually returns in addr, observed only 0
+ */
+int sceUsbdGetDeviceAddress(SceUID uid, SceUID device_id, SceUsbdDeviceAddress *addr);
 
-int sceUsbdTransferData(SceUID uid, SceUsbdTransferData *data);
-int sceUsbdIsochTransferData(SceUID uid, int unk, unsigned char buff[0x28]);
+typedef struct SceUsbdTransferStatus {
+    uint32_t unk0; // < 0x40 - transfer id (result of sceUsbdTransferData)
+    uint32_t unk1; // unused
+    uint32_t unk2; // ret 4. ptr? // status? 
+    uint32_t unk3; // ret 4. ptr? // transferred?
+} SceUsbdTransferStatus;
+
+typedef struct SceUsbdIsochTransferStatus {
+    uint32_t unk0; // < 0x40 - size? pipe? transfer id?
+    uint32_t unk1; // unused
+    uintptr_t* unk2; // ret up to 0x28 buff. 10 * 4 bytes. or 8*5 bytes
+    uint32_t unk3; // ret 4. ptr?
+} SceUsbdTransferStatus;
+
+/**
+ * Get transfer status
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param[in] transfer_id transfer uid
+ * @param[out] status buffer for return value
+ *
+ * @note it is unknown what that function actually returns in addr, observed only 0
+ */
+int sceUsbdGetTransferStatus(SceUID transfer_id, SceUsbdTransferStatus* status);
+
+/**
+ * Get isochronous transfer status
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param[in] transfer_id transfer uid
+ * @param[out] status buffer for return value
+ *
+ * @note it is unknown what that function actually returns in addr, observed only 0
+ */
+int sceUsbdGetIsochTransferStatus(SceUID transfer_id, SceUsbdIsochTransferStatus* status);
+
+typedef struct SceUsbdDevicePipe {
+    unsigned int device_id;
+    unsigned int unk1;
+    unsigned int unk2;
+    unsigned int unk3;
+    unsigned int unk4;
+    unsigned int unk5;
+} SceUsbdDevicePipe; /* size = 0x18 */
+
+/**
+ * Open endpoint communication pipe
+ *
+ * @return pipe_id on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[in] pipe endpoint to open
+ *
+ */
+SceUID sceUsbdOpenPipe(SceUID uid, SceUsbdDevicePipe* pipe);
+
+/**
+ * Open endpoint communication pipe for default config endpoint
+ *
+ * @return pipe_id on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[in] device_id device id
+ *
+ */
+SceUID sceUsbdOpenDefaultPipe(SceUID uid, SceUID device_id);
+
+/**
+ * Close endpoint communication pipe
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[in] pipe_id pipe uid
+ *
+ */
+int sceUsbdClosePipe(SceUID uid, SceUID pipe_id);
+
+/**
+ * Transfer data to/from endpoint
+ *
+ * @return transfer_id on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[in] data data to transfer
+ *
+ */
+SceUID sceUsbdTransferData(SceUID uid, SceUsbdTransferData *data);
+
+typedef struct SceUsbdIsochTransfer {
+    unsigned int unk0; // array of num_packets? ptrs to 4 
+    unsigned int unk1; // num packets?
+    unsigned int unk2;
+    unsigned int unk3;
+
+    unsigned int unk4;
+    unsigned int unk5;
+    unsigned int unk6;
+    unsigned int unk7;
+
+    unsigned int unk8;
+    unsigned int unk9;
+} SceUsbdIsochTransfer; /* size = 0x28 */
+
+/**
+ * Transfer data to/from endpoint isochronously
+ *
+ * @return transfer_id on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[in] pipe_id pipe uid
+ * @param[in] transfer data to transfer
+ *
+ */
+int sceUsbdIsochTransferData(SceUID uid, SceUID pipe_id, SceUsbdIsochTransfer* transfer);
+
+/**
+ * Receive usb event
+ *
+ * @return transfer_id on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[out] event
+ *
+ */
 int sceUsbdReceiveEvent(SceUID uid, SceUsbdReceiveEvent *event);
 
-int sceUsbdRegisterLdd(SceUID uid, const char str[0x100]);
-int sceUsbdUnregisterLdd(SceUID uid, const char str[0x100]);
-int sceUsbdRegisterCompositeLdd(SceUID uid, const char str[0x100]);
-int sceUsbdAttachCompositeLdd(SceUID, unsigned char unk[0x14]);
+/**
+ * Register logical device driver
+ *
+ * @return driver_id on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[in] name driver name, 255 max
+ *
+ */
+SceUID sceUsbdRegisterLdd(SceUID uid, char* name);
 
-#ifdef __cplusplus
-}
-#endif
+/**
+ * Register logical device driver for composite devices
+ *
+ * @return driver_id on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[in] name driver name, 255 max
+ *
+ */
+SceUID sceUsbdRegisterCompositeLdd(SceUID uid, char* name);
+
+/**
+ * De-register logical device driver
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[in] name driver name, 255 max
+ *
+ */
+int sceUsbdUnregisterLdd(SceUID uid, char* name);
+
+typedef struct SceUsbdAttachCompositeParam {
+    uint32_t driver_id;
+    uint32_t bus;
+    uint32_t device;
+    uint32_t unk3; // num devices?
+    uint32_t unk4;
+} SceUsbdAttachCompisiteParam; /* size = 0x14 */
+
+/**
+ * Attach composite driver to device
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param[in] uid uid
+ * @param[in] param parameters
+ *
+ */
+int sceUsbdAttachCompositeLdd(SceUID uid, SceUsbdAttachCompositeParam* param);
+
 
 #endif /* _PSP2_USBD_H_ */

--- a/include/psp2/usbd.h
+++ b/include/psp2/usbd.h
@@ -7,6 +7,8 @@
 #ifndef _PSP2_USBD_H_
 #define _PSP2_USBD_H_
 
+#include <psp2common/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -53,8 +55,8 @@ typedef struct SceUsbdReceiveEvent {
 } SceUsbdReceiveEvent; /* size = 0x1C */
 
 typedef struct SceUsbdDeviceAddress {
-        unsigned int unk0;
-        unsigned short unk1;
+    unsigned int unk0;
+    unsigned short unk1;
 } SceUsbdDeviceAddress; /* size = 0x6 */
 
 #define USB_DESCRIPTOR_DEVICE                   0x01    // bDescriptorType for a Device Descriptor.
@@ -338,7 +340,7 @@ typedef struct SceUsbdIsochTransferStatus {
     uint32_t unk1; // unused
     uintptr_t* unk2; // ret up to 0x28 buff. 10 * 4 bytes. or 8*5 bytes
     uint32_t unk3; // ret 4. ptr?
-} SceUsbdTransferStatus;
+} SceUsbdIsochTransferStatus;
 
 /**
  * Get transfer status
@@ -494,7 +496,7 @@ typedef struct SceUsbdAttachCompositeParam {
     uint32_t device;
     uint32_t unk3; // num devices?
     uint32_t unk4;
-} SceUsbdAttachCompisiteParam; /* size = 0x14 */
+} SceUsbdAttachCompositeParam; /* size = 0x14 */
 
 /**
  * Attach composite driver to device
@@ -507,5 +509,8 @@ typedef struct SceUsbdAttachCompositeParam {
  */
 int sceUsbdAttachCompositeLdd(SceUID uid, SceUsbdAttachCompositeParam* param);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _PSP2_USBD_H_ */

--- a/include/psp2/usbserv.h
+++ b/include/psp2/usbserv.h
@@ -1,0 +1,41 @@
+/**
+ * \usergroup{SceUsbSerc}
+ * \usage{psp2/usbserv.h,SceUsbServ_stub}
+ */
+
+#ifndef _PSP2_USBSERV_H_
+#define _PSP2_USBSERV_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum SceUsbservErrorCode {
+    SCE_USBSERV_ERROR_UNAVAILABLE    = 0x80248002,
+    SCE_USBSERV_ERROR_INVALID_PARAM  = 0x80248003,
+    SCE_USBSERV_ERROR_NOT_SUPPPORTED = 0x80248004,
+
+    SCE_USBSERV_ERROR_FATAL          = 0x802480FF
+} SceUsbservErrorCode;
+
+/**
+ * Enable accessory port
+ *
+ * @return 0 on success, < 0 on error
+ *
+ */
+int sceUsbServAccessoryActivate(void);
+
+/**
+ * Disable accessory port
+ *
+ * @return 0 on success, < 0 on error
+ *
+ */
+int sceUsbServAccessoryDeactivate(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PSP2_USBSERV_H_ */

--- a/include/psp2/usbserv.h
+++ b/include/psp2/usbserv.h
@@ -1,5 +1,5 @@
 /**
- * \usergroup{SceUsbSerc}
+ * \usergroup{SceUsbServ}
  * \usage{psp2/usbserv.h,SceUsbServ_stub}
  */
 
@@ -13,7 +13,7 @@ extern "C" {
 typedef enum SceUsbservErrorCode {
     SCE_USBSERV_ERROR_UNAVAILABLE    = 0x80248002,
     SCE_USBSERV_ERROR_INVALID_PARAM  = 0x80248003,
-    SCE_USBSERV_ERROR_NOT_SUPPPORTED = 0x80248004,
+    SCE_USBSERV_ERROR_NOT_SUPPORTED = 0x80248004,
 
     SCE_USBSERV_ERROR_FATAL          = 0x802480FF
 } SceUsbservErrorCode;

--- a/include/psp2kern/usbd.h
+++ b/include/psp2kern/usbd.h
@@ -7,6 +7,8 @@
 #ifndef _PSP2KERN_USBD_H_
 #define _PSP2KERN_USBD_H_
 
+#include <psp2common/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -300,7 +302,7 @@ void *ksceUsbdScanStaticDescriptor(SceUID device_id, void *start, SceUsbdDescrip
  * @param endpoint endpoint (may be null for default configuration endpoint)
  *
  */
-ScCeUID ksceUsbdOpenPipe(int device_id, SceUsbdEndpointDescriptor *endpoint);
+SceUID ksceUsbdOpenPipe(int device_id, SceUsbdEndpointDescriptor *endpoint);
 
 /**
  * Close communication pipe to endpoint
@@ -384,6 +386,7 @@ int ksceUsbdIsochronousTransfer(
  * @param cb transfer callback
  * @param user_data userdata to pass to callback
  *
+ * @note buffer pointer must be 64b aligned
  */
 int ksceUsbdBulkTransfer(
     SceUID pipe_id,
@@ -404,6 +407,7 @@ int ksceUsbdBulkTransfer(
  * @param cb transfer callback
  * @param user_data userdata to pass to callback
  *
+ * @note buffer pointer must be 64b aligned
  */
 int ksceUsbdBulkTransfer2(
     int pipe_id,

--- a/include/psp2kern/usbd.h
+++ b/include/psp2kern/usbd.h
@@ -7,97 +7,660 @@
 #ifndef _PSP2KERN_USBD_H_
 #define _PSP2KERN_USBD_H_
 
-#include <psp2kern/kernel/threadmgr.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#define SCE_USBD_PROBE_SUCCEEDED       (0)
+#define SCE_USBD_PROBE_FAILED          (-1)
+#define SCE_USBD_ATTACH_SUCCEEDED      (0)
+#define SCE_USBD_ATTACH_FAILED         (-1)
+#define SCE_USBD_DETACH_SUCCEEDED      (0)
+#define SCE_USBD_DETACH_FAILED         (-1)
+
+#define SCE_USBD_MAX_LS_CONTROL_PACKET_SIZE      8
+#define SCE_USBD_MAX_FS_CONTROL_PACKET_SIZE      64
+#define SCE_USBD_MAX_ISOCHRONOUS_PACKET_SIZE     1023
+#define SCE_USBD_MAX_LS_INTERRUPT_PACKET_SIZE    8
+#define SCE_USBD_MAX_FS_INTERRUPT_PACKET_SIZE    64
+#define SCE_USBD_MAX_BULK_PACKET_SIZE            64
+
+#define SCE_USBD_FEATURE_ENDPOINT_HALT               0x00
+#define SCE_USBD_FEATURE_DEVICE_REMOTE_WAKEUP        0x01
+
+#define SCE_USBD_CLASS_PER_INTERFACE                 0x00
+#define SCE_USBD_CLASS_AUDIO                         0x01
+#define SCE_USBD_CLASS_COMMUNICATIONS                0x02
+#define SCE_USBD_CLASS_HID                           0x03
+#define SCE_USBD_CLASS_MONITOR                       0x04
+#define SCE_USBD_CLASS_PHYSICAL                      0x05
+#define SCE_USBD_CLASS_POWER                         0x06
+#define SCE_USBD_CLASS_PRINTER                       0x07
+#define SCE_USBD_CLASS_STORAGE                       0x08
+#define SCE_USBD_CLASS_HUB                           0x09
+#define SCE_USBD_CLASS_DATA                          0x0a
+#define SCE_USBD_CLASS_VENDOR_SPECIFIC               0xff
+
+typedef enum SceUsbdDescriptorType {
+    SCE_USBD_DESCRIPTOR_DEVICE            = 0x01,    // bDescriptorType for a Device Descriptor.
+    SCE_USBD_DESCRIPTOR_CONFIGURATION     = 0x02,    // bDescriptorType for a Configuration Descriptor.
+    SCE_USBD_DESCRIPTOR_STRING            = 0x03,    // bDescriptorType for a String Descriptor.
+    SCE_USBD_DESCRIPTOR_INTERFACE         = 0x04,    // bDescriptorType for an Interface Descriptor.
+    SCE_USBD_DESCRIPTOR_ENDPOINT          = 0x05,    // bDescriptorType for an Endpoint Descriptor.
+
+    SCE_USBD_DESCRIPTOR_DEVICE_QUALIFIER  = 0x06,    // bDescriptorType for a Device Qualifier.
+    SCE_USBD_DESCRIPTOR_OTHER_SPEED       = 0x07,    // bDescriptorType for a Other Speed Configuration.
+    SCE_USBD_DESCRIPTOR_INTERFACE_POWER   = 0x08,    // bDescriptorType for Interface Power.
+    SCE_USBD_DESCRIPTOR_OTG               = 0x09,    // bDescriptorType for an OTG Descriptor.
+    SCE_USBD_DESCRIPTOR_HID               = 0x21,    // bDescriptorType for an HID descriptor.
+    SCE_USBD_DESCRIPTOR_REPORT            = 0x22     // bDescriptorType for an HID report descriptor.
+} SceUsbdDescriptorType;
+
 typedef enum SceUsbdErrorCode {
-	SCE_USBD_ERROR_IO             = 0x80240001,
-	SCE_USBD_ERROR_INVALID_ARG    = 0x80240002,
-	SCE_USBD_ERROR_ACCESS         = 0x80240003,
-	SCE_USBD_ERROR_NO_DEVICE      = 0x80240004,
-	SCE_USBD_ERROR_NOT_FOUND      = 0x80240005,
-	SCE_USBD_ERROR_BUSY           = 0x80240006,
-	SCE_USBD_ERROR_TIMEOUT        = 0x80240007,
-	SCE_USBD_ERROR_OVERFLOW       = 0x80240008,
-	SCE_USBD_ERROR_PIPE           = 0x80240009,
-	SCE_USBD_ERROR_INTERRUPTED    = 0x8024000A,
-	SCE_USBD_ERROR_NO_MEM         = 0x8024000B,
-	SCE_USBD_ERROR_NOT_SUPPORTED  = 0x8024000C,
-	SCE_USBD_ERROR_FATAL          = 0x802400FF
+    SCE_USBD_ERROR_NOT_INITIALIZED     = 0x80240001,
+    SCE_USBD_ERROR_ALREADY_INITIALIZED = 0x80240002,
+    SCE_USBD_ERROR_INVALID_PARAM       = 0x80240003,
+
+    SCE_USBD_ERROR_PIPE_NOT_FOUND      = 0x80240004,
+
+    SCE_USBD_ERROR_NO_MEMORY           = 0x80240005,
+    SCE_USBD_ERROR_DEVICE_NOT_FOUND    = 0x80240006,
+
+    SCE_USBD_ERROR_80240007            = 0x80240007, //
+
+    SCE_USBD_ERROR_80240009            = 0x80240009, //
+    SCE_USBD_ERROR_8024000A            = 0x8024000A, //
+
+
+    SCE_USBD_ERROR_FATAL               = 0x802400FF
 } SceUsbdErrorCode;
 
 typedef struct SceUsbdDeviceDescriptor {
-	unsigned char  bLength;
-	unsigned char  bDescriptorType;
-	unsigned short bcdUSB;
-	unsigned char  bDeviceClass;
-	unsigned char  bDeviceSubClass;
-	unsigned char  bDeviceProtocol;
-	unsigned char  bMaxPacketSize0;
-	unsigned short idVendor;
-	unsigned short idProduct;
-	unsigned short bcdDevice;
-	unsigned char  iManufacturer;
-	unsigned char  iProduct;
-	unsigned char  iSerialNumber;
-	unsigned char  bNumConfigurations;
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint16_t bcdUSB;
+    uint8_t bDeviceClass;
+    uint8_t bDeviceSubclass;
+    uint8_t bDeviceProtocol;
+    uint8_t bMaxPacketSize0;
+    uint16_t idVendor;
+    uint16_t idProduct;
+    uint16_t bcdDevice;
+    uint8_t iManufacturer;
+    uint8_t iProduct;
+    uint8_t iSerialNumber;
+    uint8_t bNumConfigurations;
 } SceUsbdDeviceDescriptor;
 
+typedef struct SceUsbdConfigurationDescriptor {
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint16_t wTotalLength;
+    uint8_t bNumInterfaces;
+    uint8_t bConfigurationValue;
+    uint8_t iConfiguration;
+    uint8_t bmAttributes;
+    uint8_t MaxPower;
+} SceUsbdConfigurationDescriptor;
+
+#define SCE_USBD_CONFIGURATION_RESERVED_ZERO         0x1f
+#define SCE_USBD_CONFIGURATION_REMOTE_WAKEUP         0x20
+#define SCE_USBD_CONFIGURATION_SELF_POWERED          0x40
+#define SCE_USBD_CONFIGURATION_RESERVED_ONE          0x80
+
+typedef struct SceUsbdInterfaceDescriptor {
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint8_t bInterfaceNumber;
+    uint8_t bAlternateSetting;
+    uint8_t bNumEndpoints;
+    uint8_t bInterfaceClass;
+    uint8_t bInterfaceSubclass;
+    uint8_t bInterfaceProtocol;
+    uint8_t iInterface;
+} SceUsbdInterfaceDescriptor;
+
 typedef struct SceUsbdEndpointDescriptor {
-	unsigned char  bLength;
-	unsigned char  bDescriptorType;
-	unsigned char  bEndpointAddress;
-	unsigned char  bmAttributes;
-	unsigned short wMaxPacketSize;
-	unsigned char  bInterval;
-	unsigned char *extra;             //!< Extra descriptors
-	int extraLength;
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint8_t bEndpointAddress;
+    uint8_t bmAttributes;
+    uint16_t wMaxPacketSize;
+    uint8_t bInterval;
 } SceUsbdEndpointDescriptor;
 
+/* bmAttributes */
+#define SCE_USBD_ENDPOINT_TRANSFER_TYPE_BITS         0x03
+#define SCE_USBD_ENDPOINT_TRANSFER_TYPE_SHIFT        0
+#define SCE_USBD_ENDPOINT_TRANSFER_TYPE_CONTROL      0x00
+
+#define SCE_USBD_ENDPOINT_TRANSFER_TYPE_ISOCHRONOUS  0x01
+#define SCE_USBD_ENDPOINT_TRANSFER_TYPE_BULK         0x02
+#define SCE_USBD_ENDPOINT_TRANSFER_TYPE_INTERRUPT    0x03
+
+/* bEndpointAddress */
+#define SCE_USBD_ENDPOINT_NUMBER_BITS                0x1f
+#define SCE_USBD_ENDPOINT_NUMBER_SHIFT               0
+#define SCE_USBD_ENDPOINT_DIRECTION_BITS             0x80
+#define SCE_USBD_ENDPOINT_DIRECTION_SHIFT            7
+#define SCE_USBD_ENDPOINT_DIRECTION_OUT              0x00
+#define SCE_USBD_ENDPOINT_DIRECTION_IN               0x80
+
+
+typedef struct SceUsbdStringDescriptor {
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint8_t bString[0];
+} SceUsbdStringDescriptor;
+
+typedef struct SceUsbdHidSubDescriptorInfo {
+    uint8_t bDescriptorType;
+    uint8_t wDescriptorLength0;
+    uint8_t wDescriptorLength1;
+} SceUsbdHidSubDescriptorInfo;
+
+typedef struct SceUsbdHidDescriptor {
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint8_t bcdHID0;
+    uint8_t bcdHID1;
+    uint8_t bCountryCode;
+    uint8_t bNumDescriptors;  /* SubDescriptor count */
+    SceUsbdHidSubDescriptorInfo SubDescriptorInfo[0];
+} SceUsbdHidDescriptor;
+
 typedef struct SceUsbdDeviceAddress {
-	unsigned int   unk0;
-	unsigned short unk1;
+    uint32_t unk0;
+    uint16_t unk1;
 } SceUsbdDeviceAddress;
 
 typedef struct SceUsbdDriver {
-	const char *name;
-	int (*probe)(int device_id);
-	int (*attach)(int device_id);
-	int (*detach)(int device_id);
+    const char *name;
+    int (*probe)(int device_id);
+    int (*attach)(int device_id);
+    int (*detach)(int device_id);
 } SceUsbdDriver;
 
-typedef struct SceUsbdControlTransferRequest {
-	unsigned char bmRequestType;
-	unsigned char bRequest;
-	unsigned short wValue;
-	unsigned short wIndex;
-	unsigned short wLength;
-} SceUsbdControlTransferRequest;
+typedef struct SceUsbdCompositeDriver {
+    const char *name;
+    int (*probe)(int device_id, SceUsbdEndpointDescriptor* desc); // endpoint descriptor should be interface one
+    int (*attach)(int device_id);
+    int (*detach)(int device_id);
+} SceUsbdCompositeDriver;
 
+typedef struct SceUsbdDeviceRequest {
+    uint8_t bmRequestType;
+    uint8_t bRequest;
+    uint16_t wValue;
+    uint16_t wIndex;
+    uint16_t wLength;
+} SceUsbdDeviceRequest;
+
+typedef enum SceUsbdReqtype {
+    SCE_USBD_REQTYPE_DIR_BITS                  = 0x80,
+    SCE_USBD_REQTYPE_DIR_TO_DEVICE             = 0x00,
+    SCE_USBD_REQTYPE_DIR_TO_HOST               = 0x80,
+    SCE_USBD_REQTYPE_TYPE_BITS                 = 0x60,
+    SCE_USBD_REQTYPE_TYPE_STANDARD             = 0x00,
+    SCE_USBD_REQTYPE_TYPE_CLASS                = 0x20,
+    SCE_USBD_REQTYPE_TYPE_VENDOR               = 0x40,
+    SCE_USBD_REQTYPE_TYPE_RESERVED             = 0x60,
+    SCE_USBD_REQTYPE_RECIP_BITS                = 0x1f,
+    SCE_USBD_REQTYPE_RECIP_DEVICE              = 0x00,
+    SCE_USBD_REQTYPE_RECIP_INTERFACE           = 0x01,
+    SCE_USBD_REQTYPE_RECIP_ENDPOINT            = 0x02,
+    SCE_USBD_REQTYPE_RECIP_OTHER               = 0x03
+} SceUsbdReqtype;
+
+typedef enum SceUsbdRequest {
+    SCE_USBD_REQUEST_GET_STATUS                = 0x00,
+    SCE_USBD_REQUEST_CLEAR_FEATURE             = 0x01,
+    SCE_USBD_REQUEST_SET_FEATURE               = 0x03,
+    SCE_USBD_REQUEST_SET_ADDRESS               = 0x05,
+    SCE_USBD_REQUEST_GET_DESCRIPTOR            = 0x06,
+    SCE_USBD_REQUEST_SET_DESCRIPTOR            = 0x07,
+    SCE_USBD_REQUEST_GET_CONFIGURATION         = 0x08,
+    SCE_USBD_REQUEST_SET_CONFIGURATION         = 0x09,
+    SCE_USBD_REQUEST_GET_INTERFACE             = 0x0a,
+    SCE_USBD_REQUEST_SET_INTERFACE             = 0x0b,
+    SCE_USBD_REQUEST_SYNCH_FRAME               = 0x0c
+} SceUsbdRequest;
+
+typedef struct ksceUsbdIsochPswLen {
+    uint16_t len:12;
+    uint16_t PSW:4;
+} ksceUsbdIsochPswLen;
+
+typedef struct ksceUsbdIsochTransfer {
+    void *buffer_base;
+    int32_t relative_start_frame;
+    int32_t num_packets;
+    ksceUsbdIsochPswLen packets[8];
+} ksceUsbdIsochTransfer;
+
+/**
+ * Register USB driver
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param driver driver struct
+ *
+ */
 int ksceUsbdRegisterDriver(const SceUsbdDriver *driver);
-int ksceUsbdRegisterCompositeLdd(const SceUsbdDriver *driver);
+
+/**
+ * Register USB driver for composite devices
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param driver driver struct
+ *
+ */
+int ksceUsbdRegisterCompositeLdd(const SceUsbdCompositeDriver *driver);
+
+/**
+ * De-register USB driver
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param driver driver struct
+ *
+ */
 int ksceUsbdUnregisterDriver(const SceUsbdDriver *driver);
 
-void *ksceUsbdGetDescriptor(int device_id, void *prevDescriptor, unsigned char bDescriptorType);
+/**
+ * De-register USB driver for composite devices
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param driver driver struct
+ *
+ */
+int ksceUsbdUnregisterCompositeLdd(const SceUsbdCompositeDriver *driver);
 
-// endpoint = NULL to open the default control endpoint
-int ksceUsbdOpenEndpoint(int device_id, SceUsbdEndpointDescriptor *endpoint);
-int ksceUsbdCloseEndpoint(int endpoint_id);
 
-int ksceUsbdControlTransfer(int endpoint_id,
-	const SceUsbdControlTransferRequest *req,
-	unsigned char *buffer,
-	int (*cb)(int, int, int),
-	void *user_data);
+/**
+ * Return usb descriptor
+ *
+ * @return descriptor data on success, NULL on error
+ *
+ * @param device_id device id
+ * @param start pointer to descriptor to start scanning from (may be NULL)
+ * @param type descriptor type
+ *
+ */
+void *ksceUsbdScanStaticDescriptor(SceUID device_id, void *start, SceUsbdDescriptorType type);
 
-int ksceUsbdInterruptTransfer(int endpoint_id,
-	unsigned char *buffer,
-	unsigned int length,
-	int (*cb)(int, int, int),
-	void *user_data);
+/**
+ * Open communication pipe to endpoint
+ *
+ * @return pipe uid on success, < 0 on error
+ *
+ * @param device_id device id
+ * @param endpoint endpoint (may be null for default configuration endpoint)
+ *
+ */
+ScCeUID ksceUsbdOpenPipe(int device_id, SceUsbdEndpointDescriptor *endpoint);
+
+/**
+ * Close communication pipe to endpoint
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param pipe_id pipe id
+ *
+ */
+int ksceUsbdClosePipe(SceUID pipe_id);
+
+typedef void (*ksceUsbdDoneCallback)(int32_t result, int32_t count, void* arg);
+typedef void (*ksceUsbdIsochDoneCallback)(int32_t result, ksceUsbdIsochTransfer *req, void *arg);
+
+/**
+ * Transfer data to/from endpoint
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param pipe_id pipe id
+ * @param req transfer request
+ * @param buffer data
+ * @param cb transfer callback
+ * @param user_data userdata to pass to callback
+ *
+ */
+int ksceUsbdControlTransfer(
+    SceUID pipe_id,
+    const SceUsbdDeviceRequest *req,
+    unsigned char *buffer,
+    ksceUsbdDoneCallback cb,
+    void *user_data
+);
+
+/**
+ * Transfer data to/from interrupt endpoint
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param pipe_id pipe id
+ * @param buffer data
+ * @param length data length
+ * @param cb transfer callback
+ * @param user_data userdata to pass to callback
+ *
+ */
+int ksceUsbdInterruptTransfer(
+    SceUID pipe_id,
+    unsigned char *buffer,
+    SceSize length,
+    ksceUsbdDoneCallback cb,
+    void *user_data
+);
+
+/**
+ * Transfer isochronous data to/from endpoint
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param pipe_id pipe id
+ * @param transfer transfer request
+ * @param cb transfer callback
+ * @param user_data userdata to pass to callback
+ *
+ */
+int ksceUsbdIsochronousTransfer(
+    SceUID pipe_id,
+    ksceUsbdIsochTransfer* transfer,
+    ksceUsbdIsochDoneCallback cb,
+    void *user_data
+);
+
+/**
+ * Transfer data to/from endpoint
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param pipe_id pipe id
+ * @param buffer data
+ * @param length data length
+ * @param cb transfer callback
+ * @param user_data userdata to pass to callback
+ *
+ */
+int ksceUsbdBulkTransfer(
+    SceUID pipe_id,
+    unsigned char *buffer,
+    unsigned int length,
+    ksceUsbdDoneCallback cb,
+    void *user_data
+);
+
+/**
+ * Transfer data to/from endpoint
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param pipe_id pipe id
+ * @param buffer data
+ * @param length data length
+ * @param cb transfer callback
+ * @param user_data userdata to pass to callback
+ *
+ */
+int ksceUsbdBulkTransfer2(
+    int pipe_id,
+    unsigned char *buffer,
+    unsigned int length,
+    ksceUsbdDoneCallback cb,
+    void *user_data
+);
+
+
+/**
+ * Get device location
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param device_id device id
+ * @param[out] location device location data (port)
+ *
+ */
+int ksceUsbdGetDeviceLocation(SceUID device_id, uint8_t *location);
+
+int ksceUsbdSuspend(int port);
+int ksceUsbdSuspendPhase2(int port, int flag);
+int ksceUsbdResume(int port);
+
+int ksceUsbdHostStop(int port);
+int ksceUsbdHostStart(int port);
+
+/**
+ * Get device speed
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param device_id device id
+ * @param[out] speed device speed
+ *
+ */
+int ksceUsbdGetDeviceSpeed(int device_id, uint8_t *speed);
+#define SCE_USBD_DEVICE_SPEED_LS   (0)
+#define SCE_USBD_DEVICE_SPEED_FS   (1)
+#define SCE_USBD_DEVICE_SPEED_HS   (2)
+
+
+#define ksceUsbdSetConfiguration(pid, config, cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x00; \
+  _dr.bRequest = SCE_USBD_REQUEST_SET_CONFIGURATION; \
+  _dr.wValue = (config); \
+  _dr.wIndex = 0; \
+  _dr.wLength = 0; \
+  ksceUsbdControlTransfer((pid), (&_dr), NULL, (cb), (arg)); })
+
+
+#define ksceUsbdClearDeviceFeature(pid, fs, cb, arg) ({  \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x00; \
+  _dr.bRequest = SCE_USBD_REQUEST_CLEAR_FEATURE; \
+  _dr.wValue = (fs); \
+  _dr.wIndex = 0; \
+  _dr.wLength = 0; \
+  ksceUsbdControlTransfer((pid), (&_dr), NULL, (cb), (arg)); })
+
+#define ksceUsbdClearInterfaceFeature(pid, fs, interface, cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x01; \
+  _dr.bRequest = SCE_USBD_REQUEST_CLEAR_FEATURE; \
+  _dr.wValue = (fs); \
+  _dr.wIndex = (interface); \
+  _dr.wLength = 0; \
+  ksceUsbdControlTransfer((pid), (&_dr), NULL, (cb), (arg)); })
+
+#define ksceUsbdClearEndpointFeature(pid, fs, endpoint, cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x02; \
+  _dr.bRequest = SCE_USBD_REQUEST_CLEAR_FEATURE; \
+  _dr.wValue = (fs); \
+  _dr.wIndex = (endpoint); \
+  _dr.wLength = 0; \
+  ksceUsbdControlTransfer((pid), (&_dr), NULL, (cb), (arg)); })
+
+#define ksceUsbdGetConfiguration(pid, ptr, cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x80; \
+  _dr.bRequest = SCE_USBD_REQUEST_GET_CONFIGURATION; \
+  _dr.wValue = 0; \
+  _dr.wIndex = 0; \
+  _dr.wLength = 1; \
+  ksceUsbdControlTransfer((pid), (&_dr), (ptr), (cb), (arg)); })
+
+#define ksceUsbdGetDescriptor(pid, type, index, lang_id, ptr, len, cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x80; \
+  _dr.bRequest = SCE_USBD_REQUEST_GET_DESCRIPTOR; \
+  _dr.wValue = ((type) << 8) | (index); \
+  _dr.wIndex = (lang_id); \
+  _dr.wLength = (len); \
+  ksceUsbdControlTransfer((pid), (&_dr), (ptr), (cb), (arg)); })
+
+#define ksceUsbdGetInterface(pid, interface, ptr, cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x81; \
+  _dr.bRequest = SCE_USBD_REQUEST_GET_INTERFACE; \
+  _dr.wValue = 0; \
+  _dr.wIndex = (interface); \
+  _dr.wLength = 1; \
+  ksceUsbdControlTransfer((pid), (&_dr), (ptr), (cb), (arg)); })
+
+#define ksceUsbdGetDeviceStatus(pid, ptr, cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x80; \
+  _dr.bRequest = SCE_USBD_REQUEST_GET_STATUS; \
+  _dr.wValue = 0; \
+  _dr.wIndex = 0; \
+  _dr.wLength = 2; \
+  ksceUsbdControlTransfer((pid), (&_dr), (ptr), (cb), (arg)); })
+
+#define ksceUsbdGetInterfaceStatus(pid, interface, ptr, cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x81; \
+  _dr.bRequest = SCE_USBD_REQUEST_GET_STATUS; \
+  _dr.wValue = 0; \
+  _dr.wIndex = (interface); \
+  _dr.wLength = 2; \
+  ksceUsbdControlTransfer((pid), (&_dr), (ptr), (cb), (arg)); })
+
+#define ksceUsbdGetEndpointStatus(pid, endpoint, ptr, cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x82; \
+  _dr.bRequest = SCE_USBD_REQUEST_GET_STATUS; \
+  _dr.wValue = 0; \
+  _dr.wIndex = (endpoint); \
+  _dr.wLength = 2; \
+  ksceUsbdControlTransfer((pid), (&_dr), (ptr), (cb), (arg)); })
+
+#define ksceUsbdSetAddress(pid, address, cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x00; \
+  _dr.bRequest = SCE_USBD_REQUEST_SET_ADDRESS; \
+  _dr.wValue = (address); \
+  _dr.wIndex = 0; \
+  _dr.wLength = 0; \
+  ksceUsbdControlTransfer((pid), (&_dr), NULL, (cb), (arg)); })
+
+#define ksceUsbdSetConfiguration(pid, config, cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x00; \
+  _dr.bRequest = SCE_USBD_REQUEST_SET_CONFIGURATION; \
+  _dr.wValue = (config); \
+  _dr.wIndex = 0; \
+  _dr.wLength = 0; \
+  ksceUsbdControlTransfer((pid), (&_dr), NULL, (cb), (arg)); })
+
+#define ksceUsbdSetDeviceDescriptor(pid, type, index, lang_id, ptr, len, \
+              cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x00; \
+  _dr.bRequest = SCE_USBD_REQUEST_SET_DESCRIPTOR; \
+  _dr.wValue = ((type) << 8) | (index); \
+  _dr.wIndex = (lang_id); \
+  _dr.wLength = (len); \
+  ksceUsbdControlTransfer((pid), (&_dr), (ptr), (cb), (arg)); })
+
+#define ksceUsbdSetInterfaceDescriptor(pid, type, index, lang_id, ptr, len, \
+              cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x01; \
+  _dr.bRequest = SCE_USBD_REQUEST_SET_DESCRIPTOR; \
+  _dr.wValue = ((type) << 8) | (index); \
+  _dr.wIndex = (lang_id); \
+  _dr.wLength = (len); \
+  ksceUsbdControlTransfer((pid), (&_dr), (ptr), (cb), (arg)); })
+
+#define ksceUsbdSetEndpointDescriptor(pid, type, index, lang_id, ptr, len, \
+                cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x02; \
+  _dr.bRequest = SCE_USBD_REQUEST_SET_DESCRIPTOR; \
+  _dr.wValue = ((type) << 8) | (index); \
+  _dr.wIndex = (lang_id); \
+  _dr.wLength = (len); \
+  ksceUsbdControlTransfer((pid), (&_dr), (ptr), (cb), (arg)); })
+
+#define ksceUsbdSetDeviceFeature(pid, fs, cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x00; \
+  _dr.bRequest = SCE_USBD_REQUEST_SET_FEATURE; \
+  _dr.wValue = (fs); \
+  _dr.wIndex = 0; \
+  _dr.wLength = 0; \
+  ksceUsbdControlTransfer((pid), (&_dr), NULL, (cb), (arg)); })
+
+#define ksceUsbdSetInterfaceFeature(pid, fs, interface, cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x01; \
+  _dr.bRequest = SCE_USBD_REQUEST_SET_FEATURE; \
+  _dr.wValue = (fs); \
+  _dr.wIndex = (interface); \
+  _dr.wLength = 0; \
+  ksceUsbdControlTransfer((pid), (&_dr), NULL, (cb), (arg)); })
+
+#define ksceUsbdSetEndpointFeature(pid, fs, endpoint, cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x02; \
+  _dr.bRequest = SCE_USBD_REQUEST_SET_FEATURE; \
+  _dr.wValue = (fs); \
+  _dr.wIndex = (endpoint); \
+  _dr.wLength = 0; \
+  ksceUsbdControlTransfer((pid), (&_dr), NULL, (cb), (arg)); })
+
+#define ksceUsbdSetInterface(pid, interface, alt_setting, cb, arg) ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x01; \
+  _dr.bRequest = SCE_USBD_REQUEST_SET_INTERFACE; \
+  _dr.wValue = (alt_setting); \
+  _dr.wIndex = (interface); \
+  _dr.wLength = 0; \
+  ksceUsbdControlTransfer((pid), (&_dr), NULL, (cb), (arg)); })
+
+#define ksceUsbdSynchFrame(pid, endpoint, pfn, cb, arg)  ({ \
+  SceUsbdDeviceRequest _dr; \
+  _dr.bmRequestType = 0x82; \
+  _dr.bRequest = SCE_USBD_REQUEST_SYNCH_FRAME; \
+  _dr.wValue = 0; \
+  _dr.wIndex = (endpoint); \
+  _dr.wLength = 2; \
+  ksceUsbdControlTransfer((pid), (&_dr), pfn, (cb), (arg)); })
+
+// OHCI/EHCI completion codes
+#define OHCI_CC_NO_ERROR                      0x0
+#define OHCI_CC_CRC                           0x1
+#define OHCI_CC_BIT_STUFFING                  0x2
+#define OHCI_CC_DATA_TOGGLE_MISMATCH          0x3
+#define OHCI_CC_STALL                         0x4
+#define OHCI_CC_DEVICE_NOT_RESPONDING         0x5
+#define OHCI_CC_PID_CHECK_FAILURE             0x6
+#define OHCI_CC_UNEXPECTED_PID                0x7
+#define OHCI_CC_DATA_OVERRUN                  0x8
+#define OHCI_CC_DATA_UNDERRUN                 0x9
+#define OHCI_CC_BUFFER_OVERRUN                0xc
+#define OHCI_CC_BUFFER_UNDERRUN               0xd
+#define OHCI_CC_NOT_ACCESSED1                 0xe
+#define OHCI_CC_NOT_ACCESSED2                 0xf
+#define EHCI_CC_MISSED_MICRO_FRAME            0x10
+#define EHCI_CC_XACT                          0x20
+#define EHCI_CC_BABBLE                        0x30
+#define EHCI_CC_DATABUF                       0x40
+#define EHCI_CC_HALTED                        0x50
+
+// Isochronous transfer(PSW) completion codes
+#define USBD_CC_NOERR               0x0
+#define USBD_CC_MISSED_MICRO_FRAME  0x1
+#define USBD_CC_XACTERR             0x2
+#define USBD_CC_BABBLE              0x4
+#define USBD_CC_DATABUF             0x8
+
+int ksceUsbd_05073925(SceUID device_id, int* unk1, int* unk2);
+int ksceUsbd_7938DAC7(SceUID pipe_id); // clear halt?
 
 #ifdef __cplusplus
 }

--- a/include/psp2kern/usbserv.h
+++ b/include/psp2kern/usbserv.h
@@ -1,0 +1,95 @@
+/**
+ * \kernelgroup{SceUsbServ}
+ * \usage{psp2kernel/usbserv.h,SceUsbServForDriver_stub}
+ */
+
+#ifndef _PSP2KERN_USBSERV_H_
+#define _PSP2KERN_USBSERV_H_
+
+#include <psp2common/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum SceUsbservErrorCode {
+    SCE_USBSERV_ERROR_UNAVAILABLE   = 0x80248002,
+    SCE_USBSERV_ERROR_INVALID_PARAM = 0x80248003,
+    SCE_USBSERV_ERROR_NOT_SUPPORTED = 0x80248004,
+
+    SCE_USBSERV_ERROR_FATAL         = 0x802480FF
+} SceUsbservErrorCode;
+
+/**
+ * Enable PSTV ethernet
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @note NID 0x30AE5F66
+ */
+int ksceUsbServEtherEnable(void);
+
+/**
+ * Disable PSTV ethernet
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @note NID 0xD787B191
+ */
+int ksceUsbServEtherDisable(void);
+
+/**
+ * Enable accessory port
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @note NID 0xAA6D4409
+ */
+int ksceUsbServAccessoryActivate(void);
+
+/**
+ * Disable accessory port
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @note NID 0x853CB8E4
+ */
+int ksceUsbServAccessoryDeactivate(void);
+
+/**
+ * Set USB port mode
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @param usbPort usb port number (0,1,2)
+ * @param clientMode 0 = host mode, 1 = client mode
+ *
+ * @note NID 0x7AD36284
+ */
+int ksceUsbServMacSelect(SceUInt usbPort, SceBool clientMode);
+
+/**
+ * Get USB port mode
+ *
+ * @return usb port mode (1 = client, 0 = host)
+ *
+ * @param usbPort usb port number (0,1,2)
+ *
+ * @note NID 0xF0553A69
+ */
+SceBool ksceUsbServMacGet(SceUInt usbPort);
+
+/**
+ * Prevent PSTV ethernet hibernation
+ *
+ * @return 0 on success, < 0 on error
+ *
+ * @note NID 0x6D738018, guessed name
+ */
+int ksceUsbServDisableEtherSuspend(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PSP2KERN_USBSERV_H_ */

--- a/include/vitasdk.h
+++ b/include/vitasdk.h
@@ -77,6 +77,7 @@
 #include <psp2/update.h>
 #include <psp2/usbd.h>
 #include <psp2/usbserial.h>
+#include <psp2/usbserv.h>
 #include <psp2/usbstorvstor.h>
 #include <psp2/videodec.h>
 #include <psp2/videoexport.h>

--- a/include/vitasdkkern.h
+++ b/include/vitasdkkern.h
@@ -24,6 +24,7 @@
 #include <psp2kern/udcd.h>
 #include <psp2kern/usbd.h>
 #include <psp2kern/usbserial.h>
+#include <psp2kern/usbserv.h>
 
 #include <psp2kern/avcodec/jpegenc.h>
 


### PR DESCRIPTION
* Add missing nids
* Properly name functions
* Add SceUsbserv headers
* Fix SceUsbd headers
current ones are partly copypasted from ps4 sdk, which is wrong, since ps4 uses totally different api (libusb), vita uses same api as ps2/ps3
those come from RE and usb specs