### PR TITLE
Fixed spelling error in struct SceFontNewLibParams in pgf.h

### DIFF
--- a/include/psp2/pgf.h
+++ b/include/psp2/pgf.h
@@ -30,7 +30,7 @@ typedef enum SceFontErrorCode {
 	SCE_FONT_ERROR_INVALID_FONT_DATA    = 0x8046000A,
 } SceFontErrorCode;
 
-typedef struct SceSceFontNewLibParams {
+typedef struct SceFontNewLibParams {
 	void *userData;
 	unsigned int numFonts;
 	void *cacheData;


### PR DESCRIPTION
Sce was spelled twice in the struct name instead of once. I am assuming since it was typedef with its correct name afterward this probably didn't make any real issue