### PR TITLE
Add headers for sceNpDrmEbootSigGen Psp/Ps1 and the vshBridge equivilent, and also sceNpDrmGetRifKeyPsp

### DIFF
--- a/include/psp2/vshbridge.h
+++ b/include/psp2/vshbridge.h
@@ -52,6 +52,7 @@ SceUID _vshKernelSearchModuleByName(const char *module_name, const void *buffer)
  */
 int _vshIoMount(int id, const char *path, int permission, void *buf);
 
+
 /**
  * @param[in] id - mount id
  * @param[in] force - Set to 1 to force umount
@@ -83,6 +84,32 @@ int vshIdStorageReadLeaf(SceSize leafnum, void *buf);
  * note - Writing to leaf requires manufacturing mode.
  */
 int vshIdStorageWriteLeaf(SceSize leafnum, const void *buf);
+
+
+/**
+ * Generate eboot.pbp signature "__sce_ebootpbp" for a PSP game
+ *
+ * @param[in]  eboot_pbp_path         - The pointer of the file path of the EBOOT.PBP file
+ * @param[in]  eboot_sha256           - The pointer of SHA256 hash of first 0x1D900 bytes of EBOOT.PBP??
+ * @param[out] eboot_signature        - The pointer of the output eboot signature data. size is 0x200
+ * @param[in]  sw_version             - The pointer of the minimum firmware version the signature can be used on. cannot be lower than current firmware
+ *
+ * @return 0 on success, < 0 on error.
+*/
+int _vshNpDrmEbootSigGenPsp(char* eboot_pbp_file, char* sha256_header, char* __sce_ebootpbp, int* systemSwVer);
+
+
+/**
+ * Generate eboot.pbp signature "__sce_ebootpbp" for a PS1 game
+ *
+ * @param[in]  eboot_pbp_path         - The pointer of the file path of the EBOOT.PBP file
+ * @param[in]  eboot_sha256           - The pointer of SHA256 hash of first 0x1D900 bytes of EBOOT.PBP??
+ * @param[out] eboot_signature        - The pointer of the output eboot signature data. size is 0x200
+ * @param[in]  sw_version             - The pointer of the minimum firmware version the signature can be used on. cannot be lower than current firmware
+ *
+ * @return 0 on success, < 0 on error.
+*/
+int _vshNpDrmEbootSigGenPs1(char* eboot_pbp_file, char* sha256_header, char* __sce_ebootpbp, int* systemSwVer);
 
 int vshSblAimgrIsCEX(void);
 int vshSblAimgrIsDEX(void);

--- a/include/psp2/vshbridge.h
+++ b/include/psp2/vshbridge.h
@@ -90,7 +90,7 @@ int vshIdStorageWriteLeaf(SceSize leafnum, const void *buf);
  * Generate eboot.pbp signature "__sce_ebootpbp" for a PSP game
  *
  * @param[in]  eboot_pbp_path         - The pointer of the file path of the EBOOT.PBP file
- * @param[in]  eboot_sha256           - The pointer of SHA256 hash of first 0x1D900 bytes of EBOOT.PBP??
+ * @param[in]  eboot_sha256           - The pointer of SHA256 hash of first (data.psar offset + 0x1C0000) bytes into the EBOOT.PBP file
  * @param[out] eboot_signature        - The pointer of the output eboot signature data. size is 0x200
  * @param[in]  sw_version             - The pointer of the minimum firmware version the signature can be used on. cannot be lower than current firmware
  *
@@ -103,7 +103,7 @@ int _vshNpDrmEbootSigGenPsp(const char *eboot_pbp_path, const void* eboot_sha256
  * Generate eboot.pbp signature "__sce_ebootpbp" for a PS1 game
  *
  * @param[in]  eboot_pbp_path         - The pointer of the file path of the EBOOT.PBP file
- * @param[in]  eboot_sha256           - The pointer of SHA256 hash of first 0x1D900 bytes of EBOOT.PBP??
+ * @param[in]  eboot_sha256           - The pointer of SHA256 hash of first (data.psar offset + 0x1C0000) bytes into the EBOOT.PBP file
  * @param[out] eboot_signature        - The pointer of the output eboot signature data. size is 0x200
  * @param[in]  sw_version             - The pointer of the minimum firmware version the signature can be used on. cannot be lower than current firmware
  *

--- a/include/psp2/vshbridge.h
+++ b/include/psp2/vshbridge.h
@@ -96,7 +96,7 @@ int vshIdStorageWriteLeaf(SceSize leafnum, const void *buf);
  *
  * @return 0 on success, < 0 on error.
 */
-int _vshNpDrmEbootSigGenPsp(const char *eboot_pbp_path, const void* eboot_sha256, void *eboot_signature, int *sw_version));
+int _vshNpDrmEbootSigGenPsp(const char *eboot_pbp_path, const void* eboot_sha256, void *eboot_signature, int *sw_version);
 
 
 /**
@@ -109,7 +109,7 @@ int _vshNpDrmEbootSigGenPsp(const char *eboot_pbp_path, const void* eboot_sha256
  *
  * @return 0 on success, < 0 on error.
 */
-int _vshNpDrmEbootSigGenPs1(const char *eboot_pbp_path, const void *eboot_sha256, void *eboot_signature, int *sw_version));
+int _vshNpDrmEbootSigGenPs1(const char *eboot_pbp_path, const void *eboot_sha256, void *eboot_signature, int *sw_version);
 
 int vshSblAimgrIsCEX(void);
 int vshSblAimgrIsDEX(void);

--- a/include/psp2/vshbridge.h
+++ b/include/psp2/vshbridge.h
@@ -96,7 +96,7 @@ int vshIdStorageWriteLeaf(SceSize leafnum, const void *buf);
  *
  * @return 0 on success, < 0 on error.
 */
-int _vshNpDrmEbootSigGenPsp(char* eboot_pbp_file, char* sha256_header, char* __sce_ebootpbp, int* systemSwVer);
+int _vshNpDrmEbootSigGenPsp(const char *eboot_pbp_path, const void* eboot_sha256, void *eboot_signature, int *sw_version));
 
 
 /**
@@ -109,7 +109,7 @@ int _vshNpDrmEbootSigGenPsp(char* eboot_pbp_file, char* sha256_header, char* __s
  *
  * @return 0 on success, < 0 on error.
 */
-int _vshNpDrmEbootSigGenPs1(char* eboot_pbp_file, char* sha256_header, char* __sce_ebootpbp, int* systemSwVer);
+int _vshNpDrmEbootSigGenPs1(const char *eboot_pbp_path, const void *eboot_sha256, void *eboot_signature, int *sw_version));
 
 int vshSblAimgrIsCEX(void);
 int vshSblAimgrIsDEX(void);

--- a/include/psp2kern/npdrm.h
+++ b/include/psp2kern/npdrm.h
@@ -49,6 +49,19 @@ int ksceNpDrmGetFixedRifName(char *name, SceUInt64 aid);
 int ksceNpDrmGetRifVitaKey(const void *license, void *klicense, int *flags, int *sku_flags, SceUInt64 *lic_start_time, SceUInt64 *lic_exp_time);
 
 /**
+ * Get license key info for a PSP game
+ *
+ * @param[in]  license        - The pointer of license data. see:SceNpDrmLicense
+ * @param[out] klicense       - The pointer of klicense output buffer. size is 0x10.
+ * @param[out] flags          - The pointer of flags output.
+ * @param[out] lic_start_time - The pointer of license start time output.
+ * @param[out] lic_exp_time   - The pointer of license exp time output.
+ *
+ * @return 0 on success, < 0 on error.
+*/
+int ksceNpDrmGetRifPspKey(const void *license, void *klicense, int *flags, SceUInt64 *lic_start_time, SceUInt64 *lic_exp_time);
+
+/**
  * Get license info
  *
  * @param[in]  license         - The pointer of license data. see:SceNpDrmLicense
@@ -67,6 +80,30 @@ int ksceNpDrmGetRifVitaKey(const void *license, void *klicense, int *flags, int 
  * @return 0 on success, < 0 on error.
 */
 int ksceNpDrmGetRifInfo(const void *license, SceSize license_size, int check_sign, char *content_id, SceUInt64 *account_id, int *license_version, int *license_flags, int *flags, int *sku_flags, SceInt64 *lic_start_time, SceInt64 *lic_exp_time, SceUInt64 *flags2);
+
+/**
+ * Generate eboot.pbp signature "__sce_ebootpbp"  for a PSP game
+ *
+ * @param[in]  eboot_pbp_path         - The pointer of the file path of the EBOOT.PBP file
+ * @param[in]  eboot_sha256           - The pointer of SHA256 hash of first 0x1D900 bytes of EBOOT.PBP??
+ * @param[out] eboot_signature        - The pointer of the output eboot signature data. size is 0x200
+ * @param[in]  sw_version             - The minimum firmware version the signature can be used on. cannot be lower than current firmware
+ *
+ * @return 0 on success, < 0 on error.
+*/
+int ksceNpDrmEbootSigGenPsp(const char* eboot_pbp_path, const void* eboot_sha256, void* eboot_signature, int sw_version);
+
+/**
+ * Generate eboot.pbp signature "__sce_ebootpbp"  for a PS1 game
+ *
+ * @param[in]  eboot_pbp_path         - The pointer of the file path of the EBOOT.PBP file
+ * @param[in]  eboot_sha256           - The pointer of SHA256 hash of first 0x1D900 bytes of EBOOT.PBP??
+ * @param[out] eboot_signature        - The pointer of the output eboot signature data. size is 0x200
+ * @param[in]  sw_version             - The minimum firmware version the signature can be used on. cannot be lower than current firmware
+ *
+ * @return 0 on success, < 0 on error.
+*/
+int ksceNpDrmEbootSigGenPs1(const char* eboot_pbp_path, const void* eboot_sha256, void* eboot_signature, int sw_version);
 
 #ifdef __cplusplus
 }

--- a/include/psp2kern/npdrm.h
+++ b/include/psp2kern/npdrm.h
@@ -91,7 +91,7 @@ int ksceNpDrmGetRifInfo(const void *license, SceSize license_size, int check_sig
  *
  * @return 0 on success, < 0 on error.
 */
-int ksceNpDrmEbootSigGenPsp(const char* eboot_pbp_path, const void* eboot_sha256, void* eboot_signature, int sw_version);
+int ksceNpDrmEbootSigGenPsp(const char *eboot_pbp_path, const void *eboot_sha256, void *eboot_signature, int sw_version);
 
 /**
  * Generate eboot.pbp signature "__sce_ebootpbp" for a PS1 game
@@ -103,7 +103,7 @@ int ksceNpDrmEbootSigGenPsp(const char* eboot_pbp_path, const void* eboot_sha256
  *
  * @return 0 on success, < 0 on error.
 */
-int ksceNpDrmEbootSigGenPs1(const char* eboot_pbp_path, const void* eboot_sha256, void* eboot_signature, int sw_version);
+int ksceNpDrmEbootSigGenPs1(const char *eboot_pbp_path, const void *eboot_sha256, void *eboot_signature, int sw_version);
 
 #ifdef __cplusplus
 }

--- a/include/psp2kern/npdrm.h
+++ b/include/psp2kern/npdrm.h
@@ -85,7 +85,7 @@ int ksceNpDrmGetRifInfo(const void *license, SceSize license_size, int check_sig
  * Generate eboot.pbp signature "__sce_ebootpbp" for a PSP game
  *
  * @param[in]  eboot_pbp_path         - The pointer of the file path of the EBOOT.PBP file
- * @param[in]  eboot_sha256           - The pointer of SHA256 hash of first 0x1D900 bytes of EBOOT.PBP??
+ * @param[in]  eboot_sha256           - The pointer of SHA256 hash of first (data.psar offset + 0x1C0000) bytes into the EBOOT.PBP file
  * @param[out] eboot_signature        - The pointer of the output eboot signature data. size is 0x200
  * @param[in]  sw_version             - The minimum firmware version the signature can be used on. cannot be lower than current firmware
  *
@@ -97,7 +97,7 @@ int ksceNpDrmEbootSigGenPsp(const char *eboot_pbp_path, const void *eboot_sha256
  * Generate eboot.pbp signature "__sce_ebootpbp" for a PS1 game
  *
  * @param[in]  eboot_pbp_path         - The pointer of the file path of the EBOOT.PBP file
- * @param[in]  eboot_sha256           - The pointer of SHA256 hash of first 0x1D900 bytes of EBOOT.PBP??
+ * @param[in]  eboot_sha256           - The pointer of SHA256 hash of first (data.psar offset + 0x1C0000) bytes into the EBOOT.PBP file
  * @param[out] eboot_signature        - The pointer of the output eboot signature data. size is 0x200
  * @param[in]  sw_version             - The minimum firmware version the signature can be used on. cannot be lower than current firmware
  *

--- a/include/psp2kern/npdrm.h
+++ b/include/psp2kern/npdrm.h
@@ -82,7 +82,7 @@ int ksceNpDrmGetRifPspKey(const void *license, void *klicense, int *flags, SceUI
 int ksceNpDrmGetRifInfo(const void *license, SceSize license_size, int check_sign, char *content_id, SceUInt64 *account_id, int *license_version, int *license_flags, int *flags, int *sku_flags, SceInt64 *lic_start_time, SceInt64 *lic_exp_time, SceUInt64 *flags2);
 
 /**
- * Generate eboot.pbp signature "__sce_ebootpbp"  for a PSP game
+ * Generate eboot.pbp signature "__sce_ebootpbp" for a PSP game
  *
  * @param[in]  eboot_pbp_path         - The pointer of the file path of the EBOOT.PBP file
  * @param[in]  eboot_sha256           - The pointer of SHA256 hash of first 0x1D900 bytes of EBOOT.PBP??
@@ -94,7 +94,7 @@ int ksceNpDrmGetRifInfo(const void *license, SceSize license_size, int check_sig
 int ksceNpDrmEbootSigGenPsp(const char* eboot_pbp_path, const void* eboot_sha256, void* eboot_signature, int sw_version);
 
 /**
- * Generate eboot.pbp signature "__sce_ebootpbp"  for a PS1 game
+ * Generate eboot.pbp signature "__sce_ebootpbp" for a PS1 game
  *
  * @param[in]  eboot_pbp_path         - The pointer of the file path of the EBOOT.PBP file
  * @param[in]  eboot_sha256           - The pointer of SHA256 hash of first 0x1D900 bytes of EBOOT.PBP??


### PR DESCRIPTION
that eboot_sha256 parameter is very weird, you have to read the data.psar offset from the pbp header, then add 0x1C0000 to it
then sha256 that many bytes into the EBOOT.PBP .. npdrm.skprx actually enforces this is the case too. 

anyway i tried to write a description to explain that parameter, dunno how well i did

have written a little script that can generate valid input for this parameter https://pastebin.com/neu4ZLKi and tested it on two EBOOT.PBP files and seems to be working

its very weird-
i dont know why sony did this, maybe it was a way to patch some old psp mode exploit in the past?
