### PR TITLE
add SceNpDrmActivationData struct, and ksceNpDrmReadActData, and sceNpDrmCheckActData

### DIFF
--- a/include/psp2/npdrm.h
+++ b/include/psp2/npdrm.h
@@ -38,6 +38,21 @@ int _sceNpDrmGetRifName(char *rif_name, uint64_t aid);
 int _sceNpDrmGetFixedRifName(char *rif_name, uint64_t aid);
 
 /**
+ * Check you have npdrm activation data, and get information from it
+ *
+ * @param[out]  act_type        - The pointer of activation type output.
+ *
+ * @param[out]  version_flag    - The pointer of version flag output.
+ *
+ * @param[out]  account_id      - The pointer of activated account id output.
+ *
+ * @param[out]  act_exp_time    - The pointer of activation expire time output, [0] is start_date, [1] is end_date
+ *
+ * @return 0 on success, < 0 on error.
+*/
+int _sceNpDrmCheckActData(int *act_type, int *version_flag, SceUInt64 *account_id, SceUInt64 act_exp_time[2]);
+
+/**
  * Get rif name for install
  *
  * @param[out] rif_name - RIF name buffer (48 bytes)

--- a/include/psp2common/npdrm.h
+++ b/include/psp2common/npdrm.h
@@ -12,9 +12,24 @@
 extern "C" {
 #endif
 
+typedef struct SceNpDrmActivationData { // size is 0x1038
+  SceInt16 act_type; 
+  SceInt16 version_flag;
+  SceInt32 version;
+  SceUInt64 account_id;
+  SceUInt8 primary_key_table[0x80][0x10];
+  SceUInt8 unk1[0x40];
+  SceUInt8 openpsid[0x10];
+  SceUInt8 unk2[0x10];
+  SceUInt8 unk3[0x10];
+  SceUInt8 secondary_key_table[0x65][0x10];
+  SceUInt8 rsa_signature[0x100];
+  SceUInt8 unk_sigmature[0x40];
+  SceUInt8 ecdsa_signature[0x28]; // checked by pspemu, and SceNpDrm.
+} SceNpDrmActivationData;
 
 typedef struct SceNpDrmLicense { // size is 0x200
-  SceInt16 version;       // -1, 1
+  SceInt16 version;       // -1 VITA, 0 PSP, 1 PSP-VITA
   SceInt16 version_flags; // 0, 1
   SceInt16 license_type;  // 1
   SceInt16 license_flags; // 0x400:non-check ecdsa

--- a/include/psp2kern/npdrm.h
+++ b/include/psp2kern/npdrm.h
@@ -35,6 +35,28 @@ int ksceNpDrmGetRifName(char *name, SceUInt64 aid);
 int ksceNpDrmGetFixedRifName(char *name, SceUInt64 aid);
 
 /**
+ * Get current activation data
+ *
+ * @param[out] act_data       - The pointer of output activation data see:SceNpDrmActivationData. if ecdsa or rsa verify fail, will be all 0.
+ *
+ * @return 0 on success, < 0 on error.
+*/
+int ksceNpDrmReadActData(SceNpDrmActivationData *act_data);
+
+/**
+ * Check you have npdrm activation data, and get information from it
+ *
+ * @param[out]  act_type        - The pointer of activation type output.
+ * @param[out]  version_flag    - The pointer of version flag output.
+ * @param[out]  account_id      - The pointer of activated account id output.
+ * @param[out]  act_start_time  - The pointer of activation data start time output.
+ * @param[out]  act_exp_time    - The pointer of activation data expire time output
+ *
+ * @return 0 on success, < 0 on error.
+*/
+int ksceNpDrmCheckActData(int *act_type, int *version_flag, SceUInt64 *account_id, SceUInt64 *act_start_time, SceUInt64 *act_end_time);
+
+/**
  * Get license key info
  *
  * @param[in]  license        - The pointer of license data. see:SceNpDrmLicense


### PR DESCRIPTION
+ the "SceNpDrmActivationData" struct is based on a simular struct from within NoPspEmuDrm: https://github.com/KuromeSan/NoPspEmuDrm/blob/master/user/PspNpDrm.h#L115, which is licensed under the GPLv3, but given that _i wrote this_ you have my permission to include this and license under MIT 

+ the PspAct struct in NoPspEmuDrm is itself based on the Act struct within Chovy-Sign2 just re written as C code https://github.com/KuromeSan/chovy-sign/blob/master/PspCrypto/SceNpDrm.cs#L317 that one was done by SquallATF, who also have no problem with it being included in VitaSDK. 


if its still somehow a problem i guess just change the output type of ksceNpDrmReadActivationData to void* 🤷‍♀️