### PR TITLE
Move power shared define to psp2common

### DIFF
--- a/check_size/psp2all.c
+++ b/check_size/psp2all.c
@@ -28,8 +28,8 @@
 #include <psp2/display.h>
 #include <psp2kern/display.h>
 
-// #include <psp2/power.h>
-// #include <psp2kern/power.h>
+#include <psp2/power.h>
+#include <psp2kern/power.h>
 
 // #include <psp2/udcd.h>
 // #include <psp2kern/udcd.h>

--- a/include/psp2/power.h
+++ b/include/psp2/power.h
@@ -3,62 +3,15 @@
  * \usage{psp2/power.h,ScePower_stub}
  */
 
-
 #ifndef _PSP2_POWER_H_
 #define _PSP2_POWER_H_
 
+#include <psp2common/power.h>
 #include <psp2/types.h>
-
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef enum ScePowerErrorCode {
-	SCE_POWER_ERROR_INVALID_VALUE           = 0x802B0000,
-	SCE_POWER_ERROR_ALREADY_REGISTERED      = 0x802B0001,
-	SCE_POWER_ERROR_CALLBACK_NOT_REGISTERED = 0x802B0002,
-	SCE_POWER_ERROR_CANT_SUSPEND            = 0x802B0003,
-	SCE_POWER_ERROR_NO_BATTERY              = 0x802B0100,
-	SCE_POWER_ERROR_DETECTING               = 0x802B0101
-} ScePowerErrorCode;
-
-typedef enum ScePowerCallbackType {
-	/** indicates the unit is using battery as power source */
-	SCE_POWER_CB_BATTERY_MODE          = 0x00000000,
-	/** indicates the battery is in low state */
-	SCE_POWER_CB_LOW_BATTERY           = 0x00000100,
-	/** indicates the unit is using an AC outlet as power source */
-	SCE_POWER_CB_AC_POWER_MODE         = 0x00001000,
-	/** indicates the unit has been shutdown **/
-	SCE_POWER_CB_SHUTDOWN              = 0x00010000,
-	/** indicates the application resumed after being put in suspend from a LiveArea event **/
-	SCE_POWER_CB_RESUME_LIVEAREA       = 0x00200000,
-	/** indicates the unit entered suspend mode **/
-	SCE_POWER_CB_SUSPENDING            = 0x00400000,
-	/** indicates the unit resumed from suspend mode **/
-	SCE_POWER_CB_RESUMING              = 0x00800000,
-	/** indicates the system is taking a screenshot **/
-	SCE_POWER_CB_SCREENSHOT_TRIGGER    = 0x04000000,
-	/** indicates the system shown the Quick Menu screen **/
-	SCE_POWER_CB_QUICK_MENU_TRIGGER    = 0x10000000,
-	/** indicates the PS button was pushed **/
-	SCE_POWER_CB_PS_BUTTON_PRESS       = 0x20000000,
-	/** indicates the system shown the shutdown screen **/
-	SCE_POWER_CB_SHUTDOWN_MENU_TRIGGER = 0x40000000,
-	/** indicates the system shown the unlock screen **/
-	SCE_POWER_CB_UNLOCK_MENU_TRIGGER   = 0x80000000,
-} ScePowerCallbackType;
-
-/* GPU, WLAN/COM configuration setting */
-typedef enum ScePowerConfigurationMode {
-	SCE_POWER_CONFIGURATION_MODE_A   = 0x00000080U, /* GPU clock normal, WLAN/COM enabled */
-	SCE_POWER_CONFIGURATION_MODE_B   = 0x00000800U, /* GPU clock high, WLAN/COM disabled */
-	SCE_POWER_CONFIGURATION_MODE_C   = 0x00010880U, /* GPU clock high, WLAN/COM enabled (drains battery faster) */
-} ScePowerConfigurationMode;
-
-/** Callback function prototype */
-typedef void (*ScePowerCallback)(int notifyId, int notifyCount, int powerInfo, void* userData);
 
 /**
  * Registers a ScePower Callback

--- a/include/psp2common/power.h
+++ b/include/psp2common/power.h
@@ -1,0 +1,83 @@
+/**
+ * \kernelgroup{ScePower}
+ * \usage{psp2common/power.h}
+ */
+
+#ifndef _PSP2COMMON_POWER_H_
+#define _PSP2COMMON_POWER_H_
+
+#include <vitasdk/build_utils.h>
+#include <psp2common/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum ScePowerErrorCode : SceInt32 {
+	SCE_POWER_ERROR_INVALID_VALUE           = (SceInt32)0x802B0000,
+	SCE_POWER_ERROR_ALREADY_REGISTERED      = (SceInt32)0x802B0001,
+	SCE_POWER_ERROR_CALLBACK_NOT_REGISTERED = (SceInt32)0x802B0002,
+	SCE_POWER_ERROR_CANT_SUSPEND            = (SceInt32)0x802B0003,
+	SCE_POWER_ERROR_NO_BATTERY              = (SceInt32)0x802B0100,
+	SCE_POWER_ERROR_DETECTING               = (SceInt32)0x802B0101
+} ScePowerErrorCode;
+VITASDK_BUILD_ASSERT_EQ(4, ScePowerErrorCode);
+
+typedef enum ScePowerCallbackType : SceUInt32 {
+	SCE_POWER_CB_AFTER_SYSTEM_RESUME   = 0x00000080, /* TODO: confirm */
+	SCE_POWER_CB_BATTERY_ONLINE        = 0x00000100,
+	SCE_POWER_CB_THERMAL_SUSPEND       = 0x00000200, /* TODO: confirm */
+	SCE_POWER_CB_LOW_BATTERY_SUSPEND   = 0x00000400, /* TODO: confirm */
+	SCE_POWER_CB_LOW_BATTERY           = 0x00000800,
+	SCE_POWER_CB_POWER_ONLINE          = 0x00001000,
+	SCE_POWER_CB_SYSTEM_SUSPEND        = 0x00010000,
+	SCE_POWER_CB_SYSTEM_RESUMING       = 0x00020000,
+	SCE_POWER_CB_SYSTEM_RESUME         = 0x00040000,
+	SCE_POWER_CB_UNK_0x100000          = 0x00100000, /* Related to proc_event::display_switch */
+	SCE_POWER_CB_APP_RESUME            = 0x00200000,
+	SCE_POWER_CB_APP_SUSPEND           = 0x00400000,
+	SCE_POWER_CB_APP_RESUMING          = 0x00800000, /* TODO: confirm */
+	SCE_POWER_CB_BUTTON_PS_START_PRESS = 0x04000000,
+	SCE_POWER_CB_BUTTON_PS_POWER_PRESS = 0x08000000,
+	SCE_POWER_CB_BUTTON_PS_HOLD        = 0x10000000,
+	SCE_POWER_CB_BUTTON_PS_PRESS       = 0x20000000,
+	SCE_POWER_CB_BUTTON_POWER_HOLD     = 0x40000000,
+	SCE_POWER_CB_BUTTON_POWER_PRESS    = 0x80000000,
+	SCE_POWER_CB_VALID_MASK_KERNEL     = 0xFCF71F80,
+	SCE_POWER_CB_VALID_MASK_SYSTEM     = 0xFCF71F80,
+	SCE_POWER_CB_VALID_MASK_NON_SYSTEM = 0x00361180
+} ScePowerCallbackType;
+VITASDK_BUILD_ASSERT_EQ(4, ScePowerCallbackType);
+
+/* GPU, WLAN/COM configuration setting */
+typedef enum ScePowerConfigurationMode : SceInt32 {
+	SCE_POWER_CONFIGURATION_MODE_A   = 0x00000080U, /* GPU clock normal, WLAN/COM enabled */
+	SCE_POWER_CONFIGURATION_MODE_B   = 0x00000800U, /* GPU clock high, WLAN/COM disabled */
+	SCE_POWER_CONFIGURATION_MODE_C   = 0x00010880U, /* GPU clock high, WLAN/COM enabled (drains battery faster) */
+} ScePowerConfigurationMode;
+VITASDK_BUILD_ASSERT_EQ(4, ScePowerConfigurationMode);
+
+/* Callbacks */
+
+/** Callback function prototype */
+typedef void (*ScePowerCallback)(int notifyId, int notifyCount, int powerInfo, void* userData);
+
+
+/* For backwards compatibility */
+
+#ifdef _PSP2_POWER_H_
+#define SCE_POWER_CB_SUSPENDING (SCE_POWER_CB_APP_SUSPEND)
+#define SCE_POWER_CB_RESUMING   (SCE_POWER_CB_APP_RESUMING)
+#endif
+
+#ifdef _PSP2KERN_POWER_H_
+#define SCE_POWER_CB_SUSPENDING (SCE_POWER_CB_SYSTEM_SUSPEND)
+#define SCE_POWER_CB_RESUMING   (SCE_POWER_CB_SYSTEM_RESUMING)
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PSP2COMMON_POWER_H_ */

--- a/include/psp2kern/power.h
+++ b/include/psp2kern/power.h
@@ -6,39 +6,12 @@
 #ifndef _PSP2KERN_POWER_H_
 #define _PSP2KERN_POWER_H_
 
+#include <psp2common/power.h>
 #include <psp2kern/types.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef enum ScePowerCallbackType {
-	/** indicates the power button was pushed, putting the unit into suspend mode */
-	SCE_POWER_CB_POWER_SWITCH     = 0x80000000,
-	/** ? screen on after off ? **/
-	SCE_POWER_CB_UNK_1            = 0x00600000,
-	/** ? screen off ? **/
-	SCE_POWER_CB_UNK_2            = 0x00400000,
-	/** indicates the unit has finish resuming from suspend mode */
-	SCE_POWER_CB_RESUME_COMPLETE  = 0x00040000,
-	/** indicates the unit is resuming from suspend mode */
-	SCE_POWER_CB_RESUMING         = 0x00020000,
-	/** indicates the unit is suspending, seems to occur due to inactivity */
-	SCE_POWER_CB_SUSPENDING       = 0x00010000,
-	/** indicates the unit is plugged into an AC outlet */
-	SCE_POWER_CB_AC_POWER         = 0x00001000,
-	/** indicates the battery is in low state **/
-	SCE_POWER_CB_LOWBATTERY       = 0x00000100,
-	/** indicates there is a battery present in the unit **/
-	SCE_POWER_CB_BATTERY_EXIST    = 0x00000080
-} ScePowerCallbackType;
-
-/* Callbacks */
-
-/** Callback function prototype */
-typedef void (*ScePowerCallback)(int notifyId, int notifyCount, int powerInfo);
-
-/* Prototypes */
 
 /**
  * Registers a ScePower Callback


### PR DESCRIPTION
However, ScePowerCallbackType had the same definition name but different values for user and kernel, so it was replaced with the one I RE'd.

```C
// user
SCE_POWER_CB_RESUMING = 0x00800000

// kernel
SCE_POWER_CB_RESUMING = 0x00020000
```