### PR TITLE
Remove unnecessary include

### DIFF
--- a/include/psp2kern/kernel/sysmem.h
+++ b/include/psp2kern/kernel/sysmem.h
@@ -15,8 +15,6 @@
 #include <psp2kern/kernel/sysmem/data_transfers.h>
 #include <psp2kern/kernel/sysmem/mmu.h>
 #include <psp2kern/kernel/sysmem/memtype.h>
-#include <psp2kern/kernel/debug.h>
-#include <psp2kern/kernel/sysroot.h>
 #include <psp2common/kernel/sysmem.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
`__vitasdk_expires_kern_header_remove_no_depend_include` in vita.header_warn.cmake