### PR TITLE
last_built_toolchain.py: fetch 100 items instead of 30

### DIFF
--- a/.travis.d/last_built_toolchain.py
+++ b/.travis.d/last_built_toolchain.py
@@ -10,7 +10,7 @@ except ImportError:
 
 GITHUB_REPO = 'vitasdk/autobuilds'
 GITHUB_API = 'https://api.github.com'
-GITHUB_REL = GITHUB_API + '/repos/' + GITHUB_REPO + '/releases'
+GITHUB_REL = GITHUB_API + '/repos/' + GITHUB_REPO + '/releases?per_page=100'
 
 try:
     token = os.environ['TOKEN']

--- a/.travis.d/last_built_toolchain.py
+++ b/.travis.d/last_built_toolchain.py
@@ -17,8 +17,8 @@ try:
 except KeyError:
     token = None
 
-def fetch_last_release(branch='master', os='linux'):
-    req = urllib2.Request(GITHUB_REL)
+def fetch_last_release(branch='master', os='linux', page=1):
+    req = urllib2.Request(GITHUB_REL+'&page=' + str(page))
     if token:
         req.add_header('Authorization', 'Bearer ' + token);
     try:
@@ -41,7 +41,12 @@ def fetch_last_release(branch='master', os='linux'):
 if __name__ == '__main__':
     import sys
 
-    url = fetch_last_release(*sys.argv[1:])
+    for page in range(1,6):
+        url = fetch_last_release(*sys.argv[1:3], page=page)
+        if not url:
+            continue
+        break
+
     if not url:
         raise SystemExit(1)
     print(url)


### PR DESCRIPTION
currently last linux tag is beyond default 30 items limit, so raise it to max (100)
~~"proper" fix would be to iterate through pages until we get required tag (but that could trigger api rate limit)~~
added iteration through 5 first pages