### PR TITLE
Update Sysmem functions with names from the Wiki

### DIFF
--- a/db/360/SceSysmem.yml
+++ b/db/360/SceSysmem.yml
@@ -417,106 +417,106 @@ modules:
         nid: 0x6F25E18A
         functions:
           ksceGUIDClose: 0x047D32F2
+          ksceGUIDCreate: 0x89A44858
+          ksceGUIDGetClass: 0xC74B0152
+          ksceGUIDGetName: 0xA78755EB
+          ksceGUIDGetObject: 0x0FC24464
+          ksceGUIDKernelCreate: 0x56A13E90
+          ksceGUIDName: 0xE655852F
+          ksceGUIDOpenByName: 0xD76E7452
           ksceGUIDReferObject: 0x0F5C84B7
           ksceGUIDReferObjectWithClass: 0x00ED6C14
           ksceGUIDReferObjectWithClassLevel: 0x77066FD1
+          ksceGUIDReferObjectWithLevel: 0xF6DB54BA
+          ksceGUIDReferObjectWithSubclass: 0x72A98D17
           ksceGUIDReleaseObject: 0x149885C4
-          ksceKernelAddressSpaceVAtoPABySW: 0x65419BD3
+          ksceGUIDSetName: 0x4CFA4100
           ksceKernelAllocHeapMemory: 0x7B4CB60A
-          ksceKernelAllocHeapMemoryFromGlobalHeap: 0x7750CEA7
-          ksceKernelAllocHeapMemoryFromGlobalHeapWithOpt: 0x0B4ED16A
-          ksceKernelAllocHeapMemoryWithOpt1: 0xB415B5A8
+          ksceKernelAllocHeapMemoryWithOpt: 0xB415B5A8
           ksceKernelAllocHeapMemoryWithOption: 0x49D4DD9B
           ksceKernelAllocMemBlock: 0xC94850C9
           ksceKernelAllocMemBlockWithInfo: 0xD44F464D
-          ksceKernelCreateClass: 0x61317102
+          ksceKernelAllocUncacheHeapMemory: 0x7750CEA7
+          ksceKernelAllocUncacheHeapMemoryWithOption: 0x0B4ED16A
+          ksceKernelCopyFromToUser: 0x1BD44DD5
+          ksceKernelCopyFromToUserProc: 0x8E086C33
+          ksceKernelCopyFromUser: 0xBC996A7A
+          ksceKernelCopyFromUserProc: 0x605275F8
+          ksceKernelCopyToUser: 0x6D88EF8A
+          ksceKernelCopyToUserProc: 0x6B825479
+          ksceKernelCountFillValue64FromUser: 0xBB3B02C2
+          ksceKernelCountFillValue64FromUserProc: 0xE83855FD
+          ksceKernelCountFillValueFromUser: 0xBDA6E42B
+          ksceKernelCountFillValueFromUserProc: 0x8334454F
           ksceKernelCreateHeap: 0x9328E0E8
-          ksceKernelCreateUidObj2: 0x56A13E90
-          ksceKernelCreateUidObjForUid: 0x89A44858
-          ksceKernelCreateUserUidForClass: 0xCED1547B
-          ksceKernelCreateUserUidForName: 0x513B9DDD
-          ksceKernelCreateUserUidForNameWithClass: 0x8DA0BCA5
+          ksceKernelDecRefCountMemBlock: 0xF50BDC0C
           ksceKernelDeleteHeap: 0xD6437637
-          ksceKernelFindMemBlock: 0x9C78064C
           ksceKernelFindMemBlockByAddr: 0x8A1742F6
-          ksceKernelFindMemBlockByAddrForDefaultSize: 0xF3BBE2E1
-          ksceKernelFindMemBlockByAddrForPid: 0x857F1D5A
-          ksceKernelFindMemBlockForPid: 0x9F6E45E3
-          ksceKernelFirstDifferentBlock32User: 0xBDA6E42B
-          ksceKernelFirstDifferentBlock64User: 0xBB3B02C2
-          ksceKernelFirstDifferentBlock64UserForPid: 0xE83855FD
-          ksceKernelFirstDifferentIntUserForPid: 0x8334454F
+          ksceKernelFindProcMemBlockByAddr: 0x857F1D5A
           ksceKernelFreeHeapMemory: 0x3EBCE343
-          ksceKernelFreeHeapMemoryFromGlobalHeap: 0xFB817A59
           ksceKernelFreeMemBlock: 0x009E1C61
-          ksceKernelGUIDGetObject: 0x0FC24464
-          ksceKernelGetClassForPidForUid: 0xE9728A12
-          ksceKernelGetClassForUid: 0xC74B0152
+          ksceKernelFreeUncacheHeapMemory: 0xFB817A59
           ksceKernelGetMemBlockAllocMapSize: 0x78337B62
           ksceKernelGetMemBlockBase: 0xA841EDDA
+          ksceKernelGetMemBlockInfo: 0xA73CFFEF
           ksceKernelGetMemBlockMappedBase: 0x0B1FD5C3
+          ksceKernelGetMemBlockMemtypeByAddr: 0xF3BBE2E1
           ksceKernelGetMemBlockPARange: 0x98C15666
-          ksceKernelGetMemBlockPaddrListForUid: 0x19A51AC7
+          ksceKernelGetMemBlockPAVector: 0x19A51AC7
           ksceKernelGetMemBlockVBase: 0xB81CF0A3
-          ksceKernelGetNameForPidByUid: 0x09896EB7
-          ksceKernelGetNameForUid: 0xA78755EB
-          ksceKernelGetNameForUid2: 0xE655852F
-          ksceKernelGetObjectForPidForUid: 0xFE6D7FAE
-          ksceKernelGetObjectForUidForAttr: 0xF6DB54BA
-          ksceKernelGetObjectForUidForClassTree: 0x72A98D17
-          ksceKernelGetPaddrListForLargePage: 0x08A8A7E8
-          ksceKernelGetPaddrListForSmallPage: 0x16844CE6
-          ksceKernelGetPaddrPair: 0xAE36C775
-          ksceKernelGetPaddrPairForLargePage: 0x32257A24
-          ksceKernelGetPaddrPairForSmallPage: 0xB3575090
           ksceKernelGetPhysicalMemoryType: 0x0AAA4FDD
-          ksceKernelGetUidClass: 0x85336A1C
-          ksceKernelIsPaddrWithinSameSectionForUid: 0xF4AD89D8
-          ksceKernelKernelUidForUserUidForClass: 0x184172B1
-          ksceKernelMapBlockUserVisible: 0x58D21746
-          ksceKernelMapBlockUserVisibleWithFlag: 0x04059C4B
-          ksceKernelMapUserBlock: 0x7D4F8B5F
-          ksceKernelMemBlockDecRefCounterAndReleaseUid: 0xF50BDC0C
+          ksceKernelGetUIDClass: 0x85336A1C
+          ksceKernelIncRefCountMemBlock: 0xEAF3849B
+          ksceKernelIsAccessibleRange: 0x9C78064C
+          ksceKernelIsAccessibleRangeProc: 0x9F6E45E3
+          ksceKernelIsEqualAccessibleRangeProcBySW: 0xF4AD89D8
+          ksceKernelLockRange: 0x59A4402F
+          ksceKernelLockRangeProc: 0x659586BF
+          ksceKernelLockRangeWithMode: 0xBC0A1D60
+          ksceKernelMapMemBlock: 0x58D21746
+          ksceKernelMapMemBlockWithFlag: 0x04059C4B
           ksceKernelMemBlockGetInfoEx: 0x24A99FFF
-          ksceKernelMemBlockGetInfoExForVisibilityLevel: 0xA73CFFEF
-          ksceKernelMemBlockIncRefCounterAndReleaseUid: 0xEAF3849B
-          ksceKernelMemBlockRelease: 0x00575B00
           ksceKernelMemBlockType2Memtype: 0x20C811FA
           ksceKernelMemBlockTypeGetPrivileges: 0x6A0792A3
-          ksceKernelMemRangeRelease: 0x75C70DE0
-          ksceKernelMemRangeReleaseForPid: 0xA8525B06
-          ksceKernelMemRangeReleaseWithPerm: 0x22CBE925
-          ksceKernelMemRangeRetain: 0x59A4402F
-          ksceKernelMemRangeRetainForPid: 0x659586BF
-          ksceKernelMemRangeRetainWithPerm: 0xBC0A1D60
-          ksceKernelMemcpyFromUser: 0xBC996A7A
-          ksceKernelMemcpyToUser: 0x6D88EF8A
-          ksceKernelOpenUidForName: 0xD76E7452
-          ksceKernelProcMemcpyFromUser: 0x605275F8
-          ksceKernelProcMemcpyToUser: 0x6B825479
           ksceKernelProcModeVAtoPA: 0x61A67D32
-          ksceKernelProcStrncpyFromUser: 0x75AAF178
-          ksceKernelProcStrncpyToUser: 0xFED82F2D
-          ksceKernelProcStrnlenUser: 0x9929EB07
           ksceKernelProcUserMap: 0x0091D74D
-          ksceKernelProcUserMemcpy: 0x8E086C33
           ksceKernelProcessGetContext: 0x2ECF7944
           ksceKernelProcessSwitchContext: 0x2D711589
-          ksceKernelRemapBlock: 0xDFE2C8CB
-          ksceKernelSetNameForPidForUid: 0x12624884
-          ksceKernelSetObjectForUid: 0x4CFA4100
+          ksceKernelRemapMemBlock: 0xDFE2C8CB
           ksceKernelStrncpyFromUser: 0xDB3EC244
+          ksceKernelStrncpyFromUserProc: 0x75AAF178
           ksceKernelStrncpyToUser: 0x80BD6FEB
-          ksceKernelStrnlenUser: 0xB429D419
+          ksceKernelStrncpyToUserProc: 0xFED82F2D
+          ksceKernelStrnlenFromUser: 0xB429D419
+          ksceKernelStrnlenFromUserProc: 0x9929EB07
           ksceKernelSwitchVmaForPid: 0x6F2ACDAE
+          ksceKernelUnlockRange: 0x75C70DE0
+          ksceKernelUnlockRangeProc: 0xA8525B06
+          ksceKernelUnlockRangeWithMode: 0x22CBE925
           ksceKernelUnmapMemBlock: 0xFFCD9B60
           ksceKernelUserMap: 0x278BC201
-          ksceKernelUserMemcpy: 0x1BD44DD5
+          ksceKernelUserMapWithFlags: 0x7D4F8B5F
+          ksceKernelUserUnmap: 0x00575B00
+          ksceKernelVARangeToPARange: 0xAE36C775
+          ksceKernelVARangeToPARangeByHW: 0xB3575090
+          ksceKernelVARangeToPARangeBySW: 0x32257A24
           ksceKernelVARangeToPAVector: 0xE68BEEBD
+          ksceKernelVARangeToPAVectorByHW: 0x16844CE6
+          ksceKernelVARangeToPAVectorBySW: 0x08A8A7E8
           ksceKernelVAtoPA: 0x8D160E65
+          ksceKernelVAtoPABySW: 0x65419BD3
           kscePUIDClose: 0x84A4AF5E
+          kscePUIDGetClass: 0xE9728A12
+          kscePUIDGetName: 0x09896EB7
+          kscePUIDGetObject: 0xFE6D7FAE
           kscePUIDOpenByGUID: 0xBF209859
+          kscePUIDOpenByGUIDWithFlags: 0xCED1547B
+          kscePUIDOpenByName: 0x513B9DDD
+          kscePUIDOpenByNameWithClass: 0x8DA0BCA5
+          kscePUIDSetName: 0x12624884
           kscePUIDtoGUID: 0x45D22597
+          kscePUIDtoGUIDWithClass: 0x184172B1
+          ksceUIDClassInitClass: 0x61317102
       SceSysmemForKernel:
         kernel: true
         nid: 0x63A519E5
@@ -531,7 +531,10 @@ modules:
           ksceKernelAddressSpaceUnmap: 0xCE72839E
           ksceKernelAddressSpaceVAtoPA: 0xF2179820
           ksceKernelAlloc: 0xC0A4D2F3
-          ksceKernelAllocSystemCallTable: 0x5FFE4B79
+          ksceKernelAllocPartitionMemBlock: 0x5FFE4B79
+          ksceKernelCopyToUserDomain: 0xA6F95838
+          ksceKernelCopyToUserProcTextDomain: 0x30931572
+          ksceKernelCopyToUserTextDomain: 0x67BAD5B4
           ksceKernelCreateAddressSpace: 0x4A3737F0
           ksceKernelDeleteAddressSpace: 0xF2D7FE3A
           ksceKernelFindClassByName: 0x62989905
@@ -541,13 +544,10 @@ modules:
           ksceKernelGetHeapInfo: 0x91733EF4
           ksceKernelGetHeapInfoByPtr: 0x68451777
           ksceKernelGetMemBlockType: 0x289BE3EC
-          ksceKernelGetUidDLinkClass: 0xC105604E
-          ksceKernelGetUidHeapClass: 0x4CCA935D
-          ksceKernelGetUidMemBlockClass: 0xAF729575
-          ksceKernelMemcpyToUserRo: 0xA6F95838
-          ksceKernelMemcpyToUserRx: 0x67BAD5B4
+          ksceKernelGetUIDDLinkClass: 0xC105604E
+          ksceKernelGetUIDHeapClass: 0x4CCA935D
+          ksceKernelGetUIDMemBlockClass: 0xAF729575
           ksceKernelNameHeapGetInfo: 0xE443253B
-          ksceKernelProcMemcpyToUserRx: 0x30931572
           ksceKernelUIDEntryHeapGetInfo: 0x686AA15C
       SceSysrootForDriver:
         kernel: true

--- a/db/363/SceSysmem.yml
+++ b/db/363/SceSysmem.yml
@@ -9,9 +9,9 @@ modules:
         nid: 0x02451F0F
         functions:
           ksceGUIDKernelCreateWithOpt: 0xFB6390CE
+          ksceKernelCopyToUserProcTextDomain: 0x2995558D
           ksceKernelFindClassByName: 0x7D87F706
           ksceKernelGetMemBlockType: 0xD44FE44B
-          ksceKernelProcMemcpyToUserRx: 0x2995558D
       SceUartForKernel:
         kernel: true
         nid: 0x1CCD9BA3

--- a/include/psp2kern/kernel/sysmem.h
+++ b/include/psp2kern/kernel/sysmem.h
@@ -110,7 +110,7 @@ int ksceKernelGetMemBlockType(SceUID uid, unsigned int *type);
 SceUID ksceKernelFindMemBlockByAddr(const void *addr, SceSize size);
 
 /**
- * Find the SceUID of a memory block for a PID
+ * Find the SceUID of a memory block in a process
  *
  * @param[in] pid - PID of the process
  * @param[in] addr - Base address of the memory block
@@ -118,7 +118,7 @@ SceUID ksceKernelFindMemBlockByAddr(const void *addr, SceSize size);
  *
  * @return SceUID of the memory block on success, < 0 on error.
 */
-SceUID ksceKernelFindMemBlockByAddrForPid(SceUID pid, const void *addr, SceSize size);
+SceUID ksceKernelFindProcMemBlockByAddr(SceUID pid, const void *addr, SceSize size);
 
 /**
  * Get the AllocMapSize of a MemBlock
@@ -131,6 +131,25 @@ SceUID ksceKernelFindMemBlockByAddrForPid(SceUID pid, const void *addr, SceSize 
 int ksceKernelGetMemBlockAllocMapSize(SceUID memid, SceSize *alloc_map_size);
 
 /**
+ * Map a memblock
+ *
+ * @param[in] uid - GUID of the memblock to map.
+ *
+ * @return SCE_OK on success, < 0 on error.
+ */
+int ksceKernelMapMemBlock(SceUID uid);
+
+/**
+ * Map a memblock.
+ *
+ * @param[in] uid  - GUID of the memblock to map.
+ * @param[in] flag - Set to 1 to prevent DCache invalidation before mapping.
+ *
+ * @return SCE_OK on success, < 0 on error.
+ */
+int ksceKernelMapMemBlockWithFlag(SceUID uid, int flag);
+
+/**
  * Changes the block type
  *
  * @param[in] uid - SceUID of the memory block to change
@@ -138,19 +157,22 @@ int ksceKernelGetMemBlockAllocMapSize(SceUID memid, SceSize *alloc_map_size);
  *
  * @return 0 on success, < 0 on error.
  */
-int ksceKernelRemapBlock(SceUID uid, SceKernelMemBlockType type);
+int ksceKernelRemapMemBlock(SceUID uid, SceKernelMemBlockType type);
 
-int ksceKernelMapBlockUserVisible(SceUID uid);
-
-SceUID ksceKernelMapUserBlock(const char *name, int permission, int type,
-			   const void *user_buf, SceSize size, void **kernel_page,
-			   SceSize *kernel_size, unsigned int *kernel_offset);
+/**
+ * Unmap a memblock.
+ *
+ * @param[in] uid  - GUID of the memblock to unmap.
+ *
+ * @return SCE_OK on success, < 0 on error.
+ */
+int ksceKernelUnmapMemBlock(SceUID uid);
 
 /**
  * The mapping user address space to kernel
  *
  * @param[in]  name          - The mapping name.
- * @param[in]  permission    - The access permission. 1 for Read.
+ * @param[in]  permission    - The access permission. 1 for Read, 2 or 3 for read/write.
  * @param[in]  user_buf      - The target address of user space.
  * @param[in]  size          - The mapping size.
  * @param[out] kernel_page   - The mapped kernel address space.
@@ -164,14 +186,12 @@ SceUID ksceKernelMapUserBlock(const char *name, int permission, int type,
  */
 SceUID ksceKernelUserMap(const char *name, int permission, const void *user_buf, SceSize size, void **kernel_page, SceSize *kernel_size, SceUInt32 *kernel_offset);
 
-#define ksceKernelMapUserBlockDefaultType(name, permission, user_buf, size, kernel_page, kernel_size, kernel_offset) ksceKernelUserMap(name, permission, user_buf, size, kernel_page, kernel_size, kernel_offset)
-
 /**
  * The mapping user address space to kernel with process
  *
  * @param[in]  pid           - The target process id.
  * @param[in]  name          - The mapping name.
- * @param[in]  permission    - The access permission. 1 for Read.
+ * @param[in]  permission    - The access permission. 1 for Read, 2 or 3 for read/write.
  * @param[in]  user_buf      - The target address of user space.
  * @param[in]  size          - The mapping size.
  * @param[out] kernel_page   - The mapped kernel address space.
@@ -185,10 +205,27 @@ SceUID ksceKernelUserMap(const char *name, int permission, const void *user_buf,
  */
 SceUID ksceKernelProcUserMap(SceUID pid, const char *name, int permission, const void *user_buf, SceSize size, void **kernel_page, SceSize *kernel_size, SceUInt32 *kernel_offset);
 
-#define ksceKernelMapUserBlockDefaultTypeForPid(pid, name, permission, user_buf, size, kernel_page, kernel_size, kernel_offset) ksceKernelProcUserMap(pid, name, permission, user_buf, size, kernel_page, kernel_size, kernel_offset)
+/**
+ * The mapping user address space to kernel with flags
+ *
+ * @param[in]  name          - The mapping name.
+ * @param[in]  permission    - The access permission. 1 for Read, 2 or 3 for read/write.
+ * @param[in]  flags         - 0x11 to map into TmpFsGame instead of Tmp
+ * @param[in]  user_buf      - The target address of user space.
+ * @param[in]  size          - The mapping size.
+ * @param[out] kernel_page   - The mapped kernel address space.
+ * @param[out] kernel_size   - The mapped size.
+ * @param[out] kernel_offset - The output of address align value.
+ *                             For example, if user_buf is 0x81000123, kernel_offset to 0x123.
+ *
+ * @return uid on success, < 0 on error.
+ *
+ * note - If no longer use the mapped address, need to release it with ksceKernelMemBlockRelease
+ */
+SceUID ksceKernelUserMapWithFlags(const char *name, int permission, int flags, const void *user_buf, SceSize size, void **kernel_page, SceSize *kernel_size, unsigned int *kernel_offset);
 
 /**
- * Releases a memblock referenced by the UID.
+ * Frees a memblock mapped with ksceKernelUserMap
  *
  * This decreases the internal reference count.
  *
@@ -196,10 +233,10 @@ SceUID ksceKernelProcUserMap(SceUID pid, const char *name, int permission, const
  *
  * @return 0 on success, < 0 on error.
  */
-int ksceKernelMemBlockRelease(SceUID uid);
+int ksceKernelUserUnmap(SceUID uid);
 
 /**
- * Retains a memory range
+ * Locks a memory range
  *
  * This increases the internal reference count of the memblocks belonging to the range.
  *
@@ -210,10 +247,10 @@ int ksceKernelMemBlockRelease(SceUID uid);
  *
  * @return 0 on success, < 0 on error.
  */
-int ksceKernelMemRangeRetain(void *addr, SceSize size);
+int ksceKernelLockRange(void *addr, SceSize size);
 
 /**
- * Retains a memory range for a process (pid)
+ * Locks a memory range for a process (pid)
  *
  * This increases the internal reference count of the memblocks belonging to the range.
  *
@@ -225,10 +262,10 @@ int ksceKernelMemRangeRetain(void *addr, SceSize size);
  *
  * @return 0 on success, < 0 on error.
  */
-int ksceKernelMemRangeRetainForPid(SceUID pid, void *addr, SceSize size);
+int ksceKernelLockRangeProc(SceUID pid, void *addr, SceSize size);
 
 /**
- * Retains a memory range checking for a given permission
+ * Locks a memory range, checking for a given permission
  *
  * This increases the internal reference count of the memblocks belonging to the range.
  * If the memory blocks belonging to the range don't have the required memory access permission,
@@ -240,10 +277,10 @@ int ksceKernelMemRangeRetainForPid(SceUID pid, void *addr, SceSize size);
  *
  * @return 0 on success, < 0 on error.
  */
-int ksceKernelMemRangeRetainWithPerm(SceKernelMemoryRefPerm perm, void *addr, SceSize size);
+int ksceKernelLockRangeWithMode(SceKernelMemoryRefPerm perm, void *addr, SceSize size);
 
 /**
- * Releases a memory range
+ * Unlocks a memory range
  *
  * This decreases the internal reference count of the memblocks belonging to the range.
  *
@@ -254,10 +291,10 @@ int ksceKernelMemRangeRetainWithPerm(SceKernelMemoryRefPerm perm, void *addr, Sc
  *
  * @return 0 on success, < 0 on error.
  */
-int ksceKernelMemRangeRelease(void *addr, SceSize size);
+int ksceKernelUnlockRange(void *addr, SceSize size);
 
 /**
- * Releases a memory range for a process (pid)
+ * Unlocks a memory range for a process (pid)
  *
  * This decreases the internal reference count of the memblocks belonging to the range.
  *
@@ -269,10 +306,10 @@ int ksceKernelMemRangeRelease(void *addr, SceSize size);
  *
  * @return 0 on success, < 0 on error.
  */
-int ksceKernelMemRangeReleaseForPid(SceUID pid, void *addr, SceSize size);
+int ksceKernelUnlockRangeProc(SceUID pid, void *addr, SceSize size);
 
 /**
- * Releases a memory range checking for a given permission
+ * Unlocks a memory range checking for a given permission
  *
  * This decreases the internal reference count of the memblocks belonging to the range.
  * If the memory blocks belonging to the range don't have the required memory access permission,
@@ -284,7 +321,26 @@ int ksceKernelMemRangeReleaseForPid(SceUID pid, void *addr, SceSize size);
  *
  * @return 0 on success, < 0 on error.
  */
-int ksceKernelMemRangeReleaseWithPerm(SceKernelMemoryRefPerm perm, void *addr, SceSize size);
+int ksceKernelUnlockRangeWithMode(SceKernelMemoryRefPerm perm, void *addr, SceSize size);
+
+/* Macros for backwards compatibility */
+#define ksceKernelFindMemBlockByAddrForPid(pid, addr, size) ksceKernelFindProcMemBlockByAddr(pid, addr, size)
+
+#define ksceKernelMapBlockUserVisible(uid) ksceKernelMapMemBlock(uid)
+#define ksceKernelRemapBlock(uid, type) ksceKernelRemapMemBlock(uid, type)
+
+#define ksceKernelMapUserBlock(name, permission, flags, user_buf, size, kernel_page, kernel_size, kernel_offset) ksceKernelUserMapWithFlags(name, permission, flags, user_buf, size, kernel_page, kernel_size, kernel_offset)
+#define ksceKernelMapUserBlockDefaultType(name, permission, user_buf, size, kernel_page, kernel_size, kernel_offset) ksceKernelUserMap(name, permission, user_buf, size, kernel_page, kernel_size, kernel_offset)
+#define ksceKernelMapUserBlockDefaultTypeForPid(pid, name, permission, user_buf, size, kernel_page, kernel_size, kernel_offset) ksceKernelProcUserMap(pid, name, permission, user_buf, size, kernel_page, kernel_size, kernel_offset)
+#define ksceKernelMemBlockRelease(uid) ksceKernelUserUnmap(uid)
+
+#define ksceKernelMemRangeRetain(addr, size) ksceKernelLockRange(addr, size)
+#define ksceKernelMemRangeRetainForPid(pid, addr, size) ksceKernelLockRangeProc(pid, addr, size)
+#define ksceKernelMemRangeRetainWithPerm(perm, addr, size) ksceKernelLockRangeWithMode(perm, addr, size)
+
+#define ksceKernelMemRangeRelease(addr, size) ksceKernelUnlockRange(addr, size)
+#define ksceKernelMemRangeReleaseForPid(pid, addr, size) ksceKernelUnlockRangeProc(pid, addr, size)
+#define ksceKernelMemRangeReleaseWithPerm(perm, addr, size) ksceKernelUnlockRangeWithMode(perm, addr, size)
 
 #ifdef __cplusplus
 }

--- a/include/psp2kern/kernel/sysmem/address_space.h
+++ b/include/psp2kern/kernel/sysmem/address_space.h
@@ -25,6 +25,16 @@ extern "C" {
 int ksceKernelVAtoPA(const void *va, uintptr_t *pa);
 
 /**
+ * Get the physical address range of a given virtual address range
+ *
+ * @param[in]  va_range  - The virtual address range
+ * @param[out] pa_range - The vector of physical addresses
+ *
+ * @return 0 on success, < 0 on error.
+ */
+int ksceKernelVARangeToPARange(const SceKernelVARange *va_range, SceKernelPARange *pa_range);
+
+/**
  * Get the physical address list of a given virtual address range
  *
  * @param[in]  va_range  - The virtual address range

--- a/include/psp2kern/kernel/sysmem/data_transfers.h
+++ b/include/psp2kern/kernel/sysmem/data_transfers.h
@@ -36,7 +36,7 @@ extern "C" {
  *       DACR          - 0x55555555
  *       Setting TTBR1 - No (use current TTBR1)
  */
-int ksceKernelMemcpyFromUser(void *dst, const void *src, SceSize len);
+int ksceKernelCopyFromUser(void *dst, const void *src, SceSize len);
 
 /**
  * Memcpy from user memory with process
@@ -51,7 +51,7 @@ int ksceKernelMemcpyFromUser(void *dst, const void *src, SceSize len);
  * @note - Invoke ksceKernelMemcpyFromUser with disable interrupts.
  *         Setting TTBR1 - Yes
  */
-int ksceKernelProcMemcpyFromUser(SceUID pid, void *dst, const void *src, SceSize len);
+int ksceKernelCopyFromUserProc(SceUID pid, void *dst, const void *src, SceSize len);
 
 /**
  * Memcpy to user memory
@@ -66,7 +66,7 @@ int ksceKernelProcMemcpyFromUser(SceUID pid, void *dst, const void *src, SceSize
  *       DACR          - 0x55555555
  *       Setting TTBR1 - No (use current TTBR1)
  */
-int ksceKernelMemcpyToUser(void *dst, const void *src, SceSize len);
+int ksceKernelCopyToUser(void *dst, const void *src, SceSize len);
 
 /**
  * Memcpy from user memory with process
@@ -81,7 +81,7 @@ int ksceKernelMemcpyToUser(void *dst, const void *src, SceSize len);
  * @note - Invoke ksceKernelMemcpyToUser with disable interrupts.
  *         Setting TTBR1 - Yes
  */
-int ksceKernelProcMemcpyToUser(SceUID pid, void *dst, const void *src, SceSize len);
+int ksceKernelCopyToUserProc(SceUID pid, void *dst, const void *src, SceSize len);
 
 /**
  * Memcpy to user RO memory
@@ -96,7 +96,7 @@ int ksceKernelProcMemcpyToUser(SceUID pid, void *dst, const void *src, SceSize l
  *       DACR          - 0x15450FC3
  *       Setting TTBR1 - No (use current TTBR1)
  */
-int ksceKernelMemcpyToUserRo(void *dst, const void *src, SceSize len);
+int ksceKernelCopyToUserDomain(void *dst, const void *src, SceSize len);
 
 /**
  * Memcpy to user RO memory with DcacheAndL2WritebackRange
@@ -111,7 +111,7 @@ int ksceKernelMemcpyToUserRo(void *dst, const void *src, SceSize len);
  *       DACR          - 0x15450FC3
  *       Setting TTBR1 - No (use current TTBR1)
  */
-int ksceKernelMemcpyToUserRx(void *dst, const void *src, SceSize len);
+int ksceKernelCopyToUserTextDomain(void *dst, const void *src, SceSize len);
 
 /**
  * Memcpy to user RX memory with process
@@ -123,10 +123,10 @@ int ksceKernelMemcpyToUserRx(void *dst, const void *src, SceSize len);
  *
  * @return 0 on success, < 0 on error.
  *
- * @note - Invoke ksceKernelMemcpyToUserRx with disable interrupts.
+ * @note - Invokes ksceKernelCopyToUserTextDomain with disable interrupts. Cleans the cache.
  *         Setting TTBR1 - Yes
  */
-int ksceKernelProcMemcpyToUserRx(SceUID pid, void *dst, const void *src, SceSize len);
+int ksceKernelCopyToUserProcTextDomain(SceUID pid, void *dst, const void *src, SceSize len);
 
 /**
  * Strncpy from user memory
@@ -157,7 +157,7 @@ SceSSize ksceKernelStrncpyFromUser(char *dst, const char *src, SceSize len);
  *         DACR          - Current process DACR
  *         Setting TTBR1 - Yes
  */
-SceSSize ksceKernelProcStrncpyFromUser(SceUID pid, char *dst, const char *src, SceSize len);
+SceSSize ksceKernelStrncpyFromUserProc(SceUID pid, char *dst, const char *src, SceSize len);
 
 /**
  * Strncpy to user memory
@@ -188,7 +188,7 @@ SceSSize ksceKernelStrncpyToUser(char *dst, const char *src, SceSize len);
  *         DACR          - Current process DACR
  *         Setting TTBR1 - Yes
  */
-SceSSize ksceKernelProcStrncpyToUser(SceUID pid, char *dst, const char *src, SceSize len);
+SceSSize ksceKernelStrncpyToUserProc(SceUID pid, char *dst, const char *src, SceSize len);
 
 /**
  * Strnlen user memory
@@ -202,7 +202,7 @@ SceSSize ksceKernelProcStrncpyToUser(SceUID pid, char *dst, const char *src, Sce
  *       DACR          - 0x55555555
  *       Setting TTBR1 - No (use current TTBR1)
  */
-SceSize ksceKernelStrnlenUser(const char *s, SceSize n);
+SceSize ksceKernelStrnlenFromUser(const char *s, SceSize n);
 
 /**
  * Strnlen user memory with process
@@ -217,7 +217,7 @@ SceSize ksceKernelStrnlenUser(const char *s, SceSize n);
  *         DACR          - Current process DACR
  *         Setting TTBR1 - Yes
  */
-SceSSize ksceKernelProcStrnlenUser(SceUID pid, const char *s, SceSize n);
+SceSSize ksceKernelStrnlenFromUserProc(SceUID pid, const char *s, SceSize n);
 
 /**
  * Memcpy user memory to user memory
@@ -232,7 +232,7 @@ SceSSize ksceKernelProcStrnlenUser(SceUID pid, const char *s, SceSize n);
  *       DACR          - 0x55555555
  *       Setting TTBR1 - No (use current TTBR1)
  */
-int ksceKernelUserMemcpy(void *dst, const void *src, SceSize len);
+int ksceKernelCopyFromToUser(void *dst, const void *src, SceSize len);
 
 /**
  * Memcpy user memory to user memory with process
@@ -248,21 +248,33 @@ int ksceKernelUserMemcpy(void *dst, const void *src, SceSize len);
  *         DACR          - Current process DACR
  *         Setting TTBR1 - Yes
  */
-int ksceKernelProcUserMemcpy(SceUID pid, void *dst, const void *src, SceSize len);
+int ksceKernelCopyFromToUserProc(SceUID pid, void *dst, const void *src, SceSize len);
 
 
 /* Macros for backwards compatibility */
-#define ksceKernelMemcpyUserToKernel(__dst__, __src__, __len__)                  ksceKernelMemcpyFromUser((__dst__), (__src__), (__len__))
-#define ksceKernelMemcpyUserToKernelForPid(__pid__, __dst__, __src__, __len__)   ksceKernelProcMemcpyFromUser((__pid__), (__dst__), (__src__), (__len__))
-#define ksceKernelMemcpyKernelToUser(__dst__, __src__, __len__)                  ksceKernelMemcpyToUser((__dst__), (__src__), (__len__))
-#define ksceKernelMemcpyToUserRo(__dst__, __src__, __len__)                      ksceKernelMemcpyToUserRo((__dst__), (__src__), (__len__))
-#define ksceKernelMemcpyToUserRx(__dst__, __src__, __len__)                      ksceKernelMemcpyToUserRx((__dst__), (__src__), (__len__))
-#define ksceKernelRxMemcpyKernelToUserForPid(__pid__, __dst__, __src__, __len__) ksceKernelProcMemcpyToUserRx((__pid__), (__dst__), (__src__), (__len__))
+#define ksceKernelMemcpyUserToKernel(__dst__, __src__, __len__)                  ksceKernelCopyFromUser((__dst__), (__src__), (__len__))
+#define ksceKernelMemcpyUserToKernelForPid(__pid__, __dst__, __src__, __len__)   ksceKernelCopyFromUserProc((__pid__), (__dst__), (__src__), (__len__))
+#define ksceKernelMemcpyKernelToUser(__dst__, __src__, __len__)                  ksceKernelCopyToUser((__dst__), (__src__), (__len__))
+#define ksceKernelMemcpyToUserRo(__dst__, __src__, __len__)                      ksceKernelCopyToUserDomain((__dst__), (__src__), (__len__))
+#define ksceKernelMemcpyToUserRx(__dst__, __src__, __len__)                      ksceKernelCopyToUserTextDomain((__dst__), (__src__), (__len__))
+#define ksceKernelRxMemcpyKernelToUserForPid(__pid__, __dst__, __src__, __len__) ksceKernelCopyToUserProcTextDomain((__pid__), (__dst__), (__src__), (__len__))
+
+#define ksceKernelMemcpyFromUser(__dst__, __src__, __len__)              ksceKernelCopyFromUser(__dst__, __src__, __len__)
+#define ksceKernelProcMemcpyFromUser(__pid__, __dst__, __src__, __len__) ksceKernelCopyFromUserProc(__pid__, __dst__, __src__, __len__)
+#define ksceKernelMemcpyToUser(__dst__, __src__, __len__)                ksceKernelCopyToUser(__dst__, __src__, __len__)
+#define ksceKernelProcMemcpyToUser(__pid__, __dst__, __src__, __len__)   ksceKernelCopyToUserProc(__pid__, __dst__, __src__, __len__)
+#define ksceKernelUserMemcpy(__dst__, __src__, __len__)                  ksceKernelCopyFromToUser(__dst__, __src__, __len__)
+#define ksceKernelProcUserMemcpy(__pid__, __dst__, __src__, __len__)     ksceKernelCopyFromToUserProc(__pid__, __dst__, __src__, __len__)
+#define ksceKernelProcMemcpyToUserRx(__pid__, __dst__, __src__, __len__) ksceKernelCopyToUserProcTextDomain(__pid__, __dst__, __src__, __len__)
 
 #define ksceKernelStrncpyUserToKernel(__dst__, __src__, __len__)        ksceKernelStrncpyFromUser((__dst__), (__src__), (__len__))
-#define ksceKernelStrncpyUserForPid(__pid__, __dst__, __src__, __len__) ksceKernelProcStrncpyFromUser((__pid__), (__dst__), (__src__), (__len__))
+#define ksceKernelStrncpyUserForPid(__pid__, __dst__, __src__, __len__) ksceKernelStrncpyFromUserProc((__pid__), (__dst__), (__src__), (__len__))
 #define ksceKernelStrncpyKernelToUser(__dst__, __src__, __len__)        ksceKernelStrncpyToUser((__dst__), (__src__), (__len__))
 
+#define ksceKernelProcStrncpyFromUser(__pid__, __dst__, __src__, __len__) ksceKernelStrncpyFromUserProc((__pid__), (__dst__), (__src__), (__len__))
+#define ksceKernelProcStrncpyToUser(__pid__, __dst__, __src__, __len__)   ksceKernelStrncpyToUserProc((__pid__), (__dst__), (__src__), (__len__))
+#define ksceKernelStrnlenUser(__s__, __n__)                               ksceKernelStrnlenFromUser(__s__, __n__)
+#define ksceKernelProcStrnlenUser(__pid__, __s__, __n__)                  ksceKernelStrnlenFromUserProc(__pid__, __s__, __n__)
 
 #ifdef __cplusplus
 }

--- a/include/psp2kern/kernel/sysmem/uid_class.h
+++ b/include/psp2kern/kernel/sysmem/uid_class.h
@@ -43,14 +43,22 @@ typedef struct SceObjectBase { // size is 0x8-bytes
 } SceObjectBase;
 VITASDK_BUILD_ASSERT_EQ(8, SceObjectBase);
 
-SceClass *ksceKernelGetUidClass(void);
-SceClass *ksceKernelGetUidDLinkClass(void);
-SceClass *ksceKernelGetUidHeapClass(void);
-SceClass *ksceKernelGetUidMemBlockClass(void);
+SceClass *ksceKernelGetUIDClass(void);
+SceClass *ksceKernelGetUIDDLinkClass(void);
+SceClass *ksceKernelGetUIDHeapClass(void);
+SceClass *ksceKernelGetUIDMemBlockClass(void);
 
-int ksceKernelCreateClass(SceClass *cls, const char *name, void *uidclass, SceSize itemsize, SceClassCallback create, SceClassCallback destroy);
+int ksceUIDClassInitClass(SceClass *cls, const char *name, void *uidclass, SceSize itemsize, SceClassCallback create, SceClassCallback destroy);
 
 int ksceKernelFindClassByName(const char *name, SceClass **cls);
+
+/* Macros for backwards compatibility */
+#define ksceKernelCreateClass(cls, name, uidclass, itemsize, create, destroy) ksceUIDClassInitClass(cls, name, uidclass, itemsize, create, destroy)
+
+#define ksceKernelGetUidClass()         ksceKernelGetUIDClass()
+#define ksceKernelGetUidDLinkClass()    ksceKernelGetUIDDLinkClass()
+#define ksceKernelGetUidHeapClass()     ksceKernelGetUIDHeapClass()
+#define ksceKernelGetUidMemBlockClass() ksceKernelGetUIDMemBlockClass()
 
 #ifdef __cplusplus
 }

--- a/include/psp2kern/types.h
+++ b/include/psp2kern/types.h
@@ -137,7 +137,7 @@ typedef struct SceKernelPAVector { // size is 0x14
 		struct { // do not use.
 			uint32_t list_size;             //!< Size in elements of the list array
 			uint32_t ret_length;            //!< Total physical size of the memory pairs
-			uint32_t ret_count;             //!< Number of elements of list filled by ksceKernelGetPaddrList
+			uint32_t ret_count;             //!< Number of elements of list filled by ksceKernelVARangeToPAVector
 			SceKernelAddrPair *list;        //!< Array of physical addresses and their lengths pairs
 		};
 	};


### PR DESCRIPTION
- Update MemRange functions with names from Wiki

- Update UserMap functions with names from Wiki

- Update MapMemBlock functions with names from Wiki

- Update GetPaddr functions with names from the Wiki

- Update FirstDifferent functions with names from the Wiki

- Update FindMemBlock functions with names from the Wiki

- Update UID functions with names from the Wiki

- Update CopyFromToUser functions with names from the Wiki

- Added ksceKernelVARangeToPARange, ksceKernelMapMemBlockWithFlag and ksceKernelUnmapMemBlock prototypes.