### PR TITLE
add SceSdifCmd56 nids

### DIFF
--- a/db/360/SceSdif.yml
+++ b/db/360/SceSdif.yml
@@ -17,7 +17,9 @@ modules:
           ksceSdifGetSdContextPartValidateSdio: 0x6A8235FC
           ksceSdifInitializeMmcDevice: 0x22C82E79
           ksceSdifInitializeSdDevice: 0xC1271539
+          ksceSdifReadCmd56: 0x134E06C4
           ksceSdifReadSectorMmc: 0x6F8D529B
           ksceSdifReadSectorSd: 0xB9593652
+          ksceSdifWriteCmd56: 0xB0996641
           ksceSdifWriteSectorMmc: 0x175543D2
           ksceSdifWriteSectorSd: 0xE0781171


### PR DESCRIPTION
used to  communicate with MMC device over GENERAL_CMD, (used on vita for gamecart authentication)