### PR TITLE
Update check.yml to use upload-artifact@v4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -87,7 +87,7 @@ jobs:
         make -j$(nproc)
     - name: Upload artifacts
       if: ${{ success() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: vitasdk-db-stubs
         path: vitasdk-db-stubs.tar.bz2


### PR DESCRIPTION
check-headers action is failing with the reason 

"Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/"

(see: https://github.com/vitasdk/vita-headers/actions/runs/13060016266/job/36440444315?pr=844)

so this is bumping the version to v4, 

https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md none of these cases apply here, so i think this should just work,