### PR TITLE
Fixed sdif stuff

### DIFF
--- a/docs/definitions.dox
+++ b/docs/definitions.dox
@@ -189,7 +189,7 @@
  *     \defgroup SceMsif Memory stick interface Library
  *      Read/Write the memory stick sector data
  *
- *     \defgroup SceSdif Secure Digital interface Library
+ *     \defgroup SceSdif SD Interface Library
  *      Read/Write eMMC, BT, WIFI and GameCart.
  * \}
  *

--- a/include/psp2kern/kernel/sdif.h
+++ b/include/psp2kern/kernel/sdif.h
@@ -1,10 +1,10 @@
 /**
  * \kernelgroup{SceSdif}
- * \usage{psp2kern/lowio/sdif.h,SceSdifForDriver}
+ * \usage{psp2kern/kernel/sdif.h,SceSdifForDriver}
  */
 
-#ifndef _PSP2KERN_LOWIO_SDIF_H_
-#define _PSP2KERN_LOWIO_SDIF_H_
+#ifndef _PSP2KERN_KERNEL_SDIF_H_
+#define _PSP2KERN_KERNEL_SDIF_H_
 
 #include <psp2kern/types.h>
 
@@ -37,4 +37,4 @@ int ksceSdifReadCmd56(SceSdifDeviceContext* dev_ctx, void* buf, SceSize size);
 }
 #endif
 
-#endif /* _PSP2KERN_LOWIO_SDIF_H_ */
+#endif /* _PSP2KERN_KERNEL_SDIF_H_ */

--- a/include/vitasdkkern.h
+++ b/include/vitasdkkern.h
@@ -49,6 +49,7 @@
 #include <psp2kern/kernel/proc_event.h>
 #include <psp2kern/kernel/processmgr.h>
 #include <psp2kern/kernel/rtc.h>
+#include <psp2kern/kernel/sdif.h>
 #include <psp2kern/kernel/sm_comm.h>
 #include <psp2kern/kernel/ssmgr.h>
 #include <psp2kern/kernel/suspend.h>
@@ -73,6 +74,5 @@
 #include <psp2kern/lowio/i2c.h>
 #include <psp2kern/lowio/iftu.h>
 #include <psp2kern/lowio/pervasive.h>
-#include <psp2kern/lowio/sdif.h>
 
 #endif /* _VITASDKKERN_H_ */


### PR DESCRIPTION
Fixing changes of https://github.com/vitasdk/vita-headers/pull/848.

SceLowio module never export SceSdif library.