### PR TITLE
db: remove duplicate entries

### DIFF
--- a/db/360/SceLibMonoBridge.yml
+++ b/db/360/SceLibMonoBridge.yml
@@ -184,7 +184,6 @@ modules:
           monoeg_try_realloc: 0xB1006CCC
           pss_alloc_mem: 0x1A2E441F
           pss_alloc_raw: 0x599AEA5E
-          pss_app_exit_liveboard: 0x58ABAD62
           pss_code_mem_alloc: 0xF466ABEC
           pss_code_mem_flush_icache: 0x110F567B
           pss_code_mem_free: 0xB468C313
@@ -200,7 +199,6 @@ modules:
           pss_delay_thread: 0x018524DD
           pss_delete_semaphore: 0x6148DE4D
           pss_disable_ftz: 0x2E9C2A4B
-          pss_errno_loc: 0x58ABAD62
           pss_free_mem: 0x1C59A84B
           pss_free_prng_provider: 0xBBCF4B04
           pss_free_raw: 0xB9EFB986

--- a/db/360/SceLibMtp.yml
+++ b/db/360/SceLibMtp.yml
@@ -20,7 +20,6 @@ modules:
           sceMtpBeginGetObjectMetadata: 0xBD82BC51
           sceMtpBeginGetObjectStatus2: 0x2747749A
           sceMtpBeginGetObjectThumbnail: 0xEA291CFC
-          sceMtpBeginGetSystemSetting: 0xE3727775
           sceMtpBeginGetTotalObjectSize: 0x46CCEAEC
           sceMtpBeginHandover: 0xCFCED21A
           sceMtpBeginHttpGetDataWithUrl: 0x6B7800B7

--- a/db/360/ScePaf.yml
+++ b/db/360/ScePaf.yml
@@ -29,7 +29,7 @@ modules:
           scePafResourceGetAttributeFloat: 0xBE772869
           scePafResourceGetAttributeFloatArray: 0x7B360965
           scePafResourceGetAttributeIdInt: 0xABFA169F
-          scePafResourceGetAttributeIdIntLpb: 0xABFA169F
+          scePafResourceGetAttributeIdIntLpb: 0x74FB882A
           scePafResourceGetAttributeIdStr: 0xBD3A6015
           scePafResourceGetAttributeIdStrLpb: 0x445BCAAB
           scePafResourceGetAttributeInteger: 0xE59C9265


### PR DESCRIPTION
There are duplicate entries in the following files:
- db/360/SceLibMonoBridge.yml
	* pss_errno_loc
	* pss_app_exit_liveboard
	* (both removed as unknown which one is correct)

- db/360/SceLibMtp.yml
	* sceMtpBeginHttpGetPropertyWithUrl
	* sceMtpBeginGetSystemSetting
	* (wrong name determined thanks to NID calculation)

- db/360/ScePaf.yml
	* scePafResourceGetAttributeIdInt
	* scePafResourceGetAttributeIdIntLpb
	* (changed NID of scePafResourceGetAttributeIdIntLpb to match NID of function calling scePafResourceGetIdIntLpb)

cc @LiEnby to fix file `#1`
cc @Princess-of-Sleeping to check `#3`