### PR TITLE
Update minimum cmake to 3.16

### DIFF
--- a/check_size/CMakeLists.txt
+++ b/check_size/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   if(DEFINED ENV{VITASDK})

--- a/check_size/check_360/CMakeLists.txt
+++ b/check_size/check_360/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   if(DEFINED ENV{VITASDK})

--- a/check_size/check_363/CMakeLists.txt
+++ b/check_size/check_363/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   if(DEFINED ENV{VITASDK})


### PR DESCRIPTION
Make cmake version consistent and bump it to 3.16 (comes with ubuntu 20.04).
Compatibility with cmake < 3.5 was removed in cmake 4