### PR TITLE
Fix incorrect value of SCE_GXM_PARAMETER_CATEGORY_UNIFORM_BUFFER.

### DIFF
--- a/include/psp2/gxm.h
+++ b/include/psp2/gxm.h
@@ -1310,7 +1310,7 @@ typedef enum SceGxmParameterCategory {
 	SCE_GXM_PARAMETER_CATEGORY_ATTRIBUTE,          //!< Vertex attribute input
 	SCE_GXM_PARAMETER_CATEGORY_UNIFORM,            //!< Uniform
 	SCE_GXM_PARAMETER_CATEGORY_SAMPLER,            //!< Sampler
-	SCE_GXM_PARAMETER_CATEGORY_UNIFORM_BUFFER      //!< Uniform buffer
+	SCE_GXM_PARAMETER_CATEGORY_UNIFORM_BUFFER = 4  //!< Uniform buffer
 } SceGxmParameterCategory;
 
 typedef enum SceGxmParameterType {


### PR DESCRIPTION
This was erroneously changed with latest merged PR that touched gxm header.