### PR TITLE
add ksceKernelReallocHeapMemory

### DIFF
--- a/db/360/SceSysmem.yml
+++ b/db/360/SceSysmem.yml
@@ -548,6 +548,7 @@ modules:
           ksceKernelGetUIDHeapClass: 0x4CCA935D
           ksceKernelGetUIDMemBlockClass: 0xAF729575
           ksceKernelNameHeapGetInfo: 0xE443253B
+          ksceKernelReallocHeapMemory: 0xFDC0EA11
           ksceKernelUIDEntryHeapGetInfo: 0x686AA15C
       SceSysrootForDriver:
         kernel: true

--- a/db/363/SceSysmem.yml
+++ b/db/363/SceSysmem.yml
@@ -35,6 +35,7 @@ modules:
           ksceKernelGetUIDHeapClass: 0x7C878E94
           ksceKernelGetUIDMemBlockClass: 0x86681B64
           ksceKernelNameHeapGetInfo: 0x01194C2E
+          ksceKernelReallocHeapMemory: 0x8EE8B917
           ksceKernelUIDEntryHeapGetInfo: 0xCCD47B97
       SceUartForKernel:
         kernel: true

--- a/include/psp2kern/kernel/sysmem/heap.h
+++ b/include/psp2kern/kernel/sysmem/heap.h
@@ -65,7 +65,7 @@ SceUID ksceKernelCreateHeap(const char *name, SceSize size, SceKernelHeapCreateO
 int ksceKernelDeleteHeap(SceUID uid);
 
 /**
- * Allocation the specified length of memory from heap
+ * Allocate the specified length of memory from heap
  *
  * @param[in] uid  - The heapid
  * @param[in] size - The alloc size
@@ -75,7 +75,7 @@ int ksceKernelDeleteHeap(SceUID uid);
 void *ksceKernelAllocHeapMemory(SceUID uid, SceSize size);
 
 /**
- * Allocation the specified length of memory from heap with option
+ * Allocate the specified length of memory from heap with option
  *
  * @param[in] uid  - The heapid
  * @param[in] size - The alloc size
@@ -84,6 +84,17 @@ void *ksceKernelAllocHeapMemory(SceUID uid, SceSize size);
  * @return The pointer of allocated memory on success, NULL on error.
  */
 void *ksceKernelAllocHeapMemoryWithOption(SceUID heapid, SceSize len, SceAllocOpt *opt);
+
+/**
+ * Reallocate the specified pointer to the new length
+ *
+ * @param[in] uid - The heapid
+ * @param[in] ptr - The pointer of allocated memory or NULL
+ * @param[in] len - The new alloc size
+ *
+ * @return The pointer of allocated memory on success, NULL on error.
+ */
+void *ksceKernelReallocHeapMemory(SceUID heapid, void *ptr, SceSize len);
 
 /**
  * Free allocated memory


### PR DESCRIPTION
adds ksceKernelReallocHeapMemory to nids and the header