### PR TITLE
Bump action versions and setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,8 +15,8 @@ jobs:
   check-headers:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
+    - uses: actions/checkout@v7
       with:
         repository: vitasdk/vdpm
         path: vdpm
@@ -65,7 +65,7 @@ jobs:
         cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake
         cmake --build build
       working-directory: check_nid_compat
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         repository: vitasdk/samples
         path: samples
@@ -76,7 +76,7 @@ jobs:
       working-directory: samples
     - name: Upload artifacts
       if: ${{ success() }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: vitasdk-db-stubs
         path: vitasdk-db-stubs.tar.bz2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Install dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
- Fix a warning found in https://github.com/vitasdk/vita-headers/actions/runs/24939090049 by updating `actions/checkout` in `.github/workflows/deploy.yml`
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```
- Update outdated actions
- Setup dependabot which will open PR automatically when actions need to be update