### PR TITLE
Install SDL3 to fix build with the latest samples

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,7 @@ jobs:
         bash vdpm/bootstrap-vitasdk.sh
         echo "$VITASDK/bin" >> "$GITHUB_PATH"
     - name: Install packages
-      run: vdpm SDL2 curl openssl soloud taihen zlib zstd
+      run: vdpm SDL2 SDL3 curl openssl soloud taihen zlib zstd
     - name: Check
       run: |
         set -e


### PR DESCRIPTION
https://github.com/vitasdk/samples/pull/98 added a new sample with SDL3 as dependency so it is now required to add SDL3 to compile all samples